### PR TITLE
Fix panic in ipc writer if arrow table is empty

### DIFF
--- a/cmd/dev-server/config.go
+++ b/cmd/dev-server/config.go
@@ -64,6 +64,7 @@ func loadConfig() Config {
 			MaxOpenConns: viper.GetInt("DB_MAX_OPEN_CONNS"),
 			MaxIdleConns: viper.GetInt("DB_MAX_IDLE_CONNS"),
 			Settings: db.Settings{
+				HomeDirectory:        viper.GetString("DB_HOME_DIRECTORY"),
 				AllowedDirectories:   viper.GetStringSlice("DB_ALLOWED_DIRECTORIES"),
 				AllowedPaths:         viper.GetStringSlice("DB_ALLOWED_PATHS"),
 				EnableLogging:        viper.GetBool("DB_ENABLE_LOGGING"),

--- a/hugr-ipc.md
+++ b/hugr-ipc.md
@@ -40,6 +40,7 @@ Each part in the response has its own MIME headers and content. The parts includ
    - `X-Hugr-Path`: The path of the data in the query.
    - `X-Hugr-Format`: `table` (for Arrow tables) or `object` (for JSON objects).
    - `X-Hugr-Chunk`: (Optional) The chunk number for streaming data.
+   - `X-Hugr-Empty`: `true` if the table part is empty.
 
 2. **Extensions Part**:
    - `Content-Type`: `application/json`

--- a/pkg/db/settings.go
+++ b/pkg/db/settings.go
@@ -13,6 +13,7 @@ type Settings struct {
 	MaxTempDirectorySize int      `json:"max_temp_directory_size"`
 	TempDirectory        string   `json:"temp_directory"`
 	WorkerThreads        int      `json:"worker_threads"`
+	HomeDirectory        string   `json:"home_directory"`
 	// POSTGRESQL
 	PGConnectionLimit int `json:"pg_connection_limit"`
 	PGPagesPerTask    int `json:"pg_pages_per_task"`
@@ -53,6 +54,10 @@ func (s Settings) applySQL() string {
 	}
 	if s.PGPagesPerTask != 0 {
 		sql = append(sql, fmt.Sprintf("SET pg_pages_per_task = %d;", s.PGPagesPerTask))
+	}
+	if s.HomeDirectory != "" {
+		sql = append(sql, fmt.Sprintf("SET home_directory = '%s';", s.HomeDirectory))
+		sql = append(sql, fmt.Sprintf("SET secret_directory = '%s/.stored_secrets';", s.HomeDirectory))
 	}
 	sql = append(sql, "PRAGMA enable_checkpoint_on_shutdown; PRAGMA force_checkpoint;")
 


### PR DESCRIPTION
- The new db settings - HomeDirectory, that defines where the persistence data of duckdb will be stored. This is very important in containers environments to make secrets persist after containers recreating 
- The panic when empty arrow table though IPC is written was fixed