### PR TITLE
Add universal data source self describe and meta runtime service

### DIFF
--- a/client.go
+++ b/client.go
@@ -267,7 +267,7 @@ func (c *Client) DescribeDataSource(ctx context.Context, name string, self bool)
 	res, err := c.Query(ctx, `query($name: String!, $self: Boolean=false){
 		function {
 			core{
-				describe_data_source(name: $name, self: $self)
+				describe_data_source_schema(name: $name, self: $self)
 			}
 		}
 	}`, map[string]any{
@@ -282,7 +282,7 @@ func (c *Client) DescribeDataSource(ctx context.Context, name string, self bool)
 		return "", res.Err()
 	}
 	var desc string
-	err = res.ScanData("function.core.describe_data_source", &desc)
+	err = res.ScanData("function.core.describe_data_source_schema", &desc)
 	if err != nil {
 		return "", err
 	}

--- a/client.go
+++ b/client.go
@@ -262,6 +262,36 @@ func (c *Client) DataSourceStatus(ctx context.Context, name string) (string, err
 	return status, err
 }
 
+// DescribeDataSource returns the description of the data source.
+func (c *Client) DescribeDataSource(ctx context.Context, name string, self bool) (string, error) {
+	res, err := c.Query(ctx, `query($name: String!, $self: Boolean=false){
+		function {
+			core{
+				describe_data_source(name: $name, self: $self)
+			}
+		}
+	}`, map[string]any{
+		"name": name,
+		"self": self,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer res.Close()
+	if res.Err() != nil {
+		return "", res.Err()
+	}
+	var desc string
+	err = res.ScanData("function.core.describe_data_source", &desc)
+	if err != nil {
+		return "", err
+	}
+	if desc == "" {
+		return "", errors.New("data source not found")
+	}
+	return desc, nil
+}
+
 func (c *Client) Query(ctx context.Context, query string, vars map[string]any) (*types.Response, error) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(map[string]any{

--- a/data_sources.go
+++ b/data_sources.go
@@ -98,3 +98,8 @@ func (s *Service) DataSourceStatus(ctx context.Context, name string) (string, er
 	}
 	return "detached", nil
 }
+
+// DescribeDataSource returns the formatted schema definition of a data source by its name.
+func (s *Service) DescribeDataSource(ctx context.Context, name string, self bool) (string, error) {
+	return s.ds.DescribeDataSource(ctx, name, self)
+}

--- a/engine.go
+++ b/engine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hugr-lab/query-engine/pkg/data-sources/sources"
 	coredb "github.com/hugr-lab/query-engine/pkg/data-sources/sources/runtime/core-db"
 	dssource "github.com/hugr-lab/query-engine/pkg/data-sources/sources/runtime/data-sources"
+	metainfo "github.com/hugr-lab/query-engine/pkg/data-sources/sources/runtime/meta-info"
 	"github.com/hugr-lab/query-engine/pkg/data-sources/sources/runtime/storage"
 	"github.com/hugr-lab/query-engine/pkg/db"
 	permissions "github.com/hugr-lab/query-engine/pkg/perm"
@@ -129,6 +130,10 @@ func (s *Service) Init(ctx context.Context) (err error) {
 	err = s.ds.AttachRuntimeSource(ctx, dssource.New(s))
 	if err != nil {
 		return fmt.Errorf("attach s3 source: %w", err)
+	}
+	err = s.ds.AttachRuntimeSource(ctx, metainfo.New())
+	if err != nil {
+		return fmt.Errorf("attach meta info source: %w", err)
 	}
 
 	s.planner = planner.New(s.catalog)

--- a/pkg/catalogs/sources/db_info.go
+++ b/pkg/catalogs/sources/db_info.go
@@ -1,0 +1,541 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hugr-lab/query-engine/pkg/compiler"
+	"github.com/hugr-lab/query-engine/pkg/types"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func DescribeDataSource(ctx context.Context, qe types.Querier, name string) (*DBInfo, error) {
+	res, err := qe.Query(ctx, `query dbMeta($name: String!) {
+		core {
+			meta {
+				databases_by_name(name: $name) {
+					name
+					description: comment
+					type
+					schemas(filter:{
+						_or:[
+							{internal: {eq: false}}
+							{name: {eq: "public"}}
+							{name: {eq: "main"}}
+						]
+						_not: {
+            				_or:[
+								{name: {like: "_timescaledb%"}}
+								{name: {eq: "timescaledb_experimental"}}
+								{name: {eq: "timescaledb_information"}}
+							]
+						}
+					}){
+						name
+						description: comment
+						tables(filter:{internal: {eq: false}}){
+							name
+							description: comment
+							schema_name: schema_name
+							columns(filter: {internal: {eq: false}}){
+								name
+								description: comment
+								data_type
+								default
+								is_nullable
+							}
+							constraints(filter:{
+								database_name: {eq: $name}
+							}){
+								name
+								type
+								references_schema_name: schema_name
+								references_table_name
+								columns
+								references_columns
+							}
+						}
+						views(filter:{internal: {eq: false}}){
+							name
+							description: comment
+							schema_name: schema_name
+							columns(filter: {internal: {eq: false}}){
+								name
+								description: comment
+								data_type
+								default
+								is_nullable
+							}
+						}
+					}
+				}
+			}
+		}
+	}`, map[string]any{
+		"name": name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query data source %s: %w", name, err)
+	}
+	defer res.Close()
+	var dbInfo DBInfo
+	err = res.ScanData("core.meta.databases_by_name", &dbInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan data source %s: %w", name, err)
+	}
+	if dbInfo.Name == "" {
+		return nil, fmt.Errorf("data source %s not found", name)
+	}
+
+	return &dbInfo, nil
+}
+
+// create catalog source by provided database definition
+type DBInfo struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Type        string         `json:"type"` // e.g., "mysql", "postgres", "duckdb", "memory", etc.
+	SchemaInfo  []DBSchemaInfo `json:"schemas"`
+}
+
+type DBSchemaInfo struct {
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Tables      []DBTableInfo `json:"tables"`
+	Views       []DBViewInfo  `json:"views"`
+}
+
+type DBTableInfo struct {
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	SchemaName  string             `json:"schema_name"`
+	Columns     []DBColumnInfo     `json:"columns"`
+	Constraints []DBConstraintInfo `json:"constraints"`
+}
+
+type DBViewInfo struct {
+	Name        string         `json:"name"`
+	SchemaName  string         `json:"schema_name"`
+	Description string         `json:"description"`
+	Columns     []DBColumnInfo `json:"columns"`
+}
+
+type DBColumnInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	DataType    string `json:"data_type"`
+	IsNullable  bool   `json:"is_nullable"`
+	Default     string `json:"default,omitempty"`
+}
+
+type DBConstraintInfo struct {
+	Name              string   `json:"name"`
+	Type              string   `json:"type"`                         // e.g., PRIMARY KEY, FOREIGN KEY, UNIQUE
+	Columns           []string `json:"columns"`                      // list of column names involved in the constraint
+	ReferencedSchema  string   `json:"referenced_schema,omitempty"`  // for foreign keys, the schema of the referenced table
+	ReferencedTable   string   `json:"referenced_table,omitempty"`   // for foreign keys
+	ReferencedColumns []string `json:"referenced_columns,omitempty"` // columns in the referenced table
+}
+
+func (s *DBInfo) SchemaDocument(ctx context.Context) (*ast.SchemaDocument, error) {
+	doc := &ast.SchemaDocument{}
+
+	for _, schema := range s.SchemaInfo {
+		defs, err := schema.Definitions()
+		if err != nil {
+			return nil, err
+		}
+		for _, def := range defs {
+			doc.Definitions = append(doc.Definitions, def)
+		}
+	}
+
+	return doc, nil
+}
+
+func (s *DBSchemaInfo) Definitions() (ast.DefinitionList, error) {
+	var defs ast.DefinitionList
+
+	for _, table := range s.Tables {
+		def, err := table.Definition()
+		if err != nil {
+			return nil, err
+		}
+		if def == nil {
+			continue
+		}
+		defs = append(defs, def)
+	}
+
+	for _, view := range s.Views {
+		def, err := view.Definition()
+		if err != nil {
+			return nil, err
+		}
+		if def == nil {
+			continue
+		}
+		defs = append(defs, def)
+	}
+
+	return defs, nil
+}
+
+func (t *DBTableInfo) Definition() (*ast.Definition, error) {
+	if len(t.Columns) == 0 {
+		return nil, nil // No columns, no definition
+	}
+	name := dataObjectName(t.SchemaName, t.Name)
+
+	def := &ast.Definition{
+		Name:        identGraphQL(name),
+		Kind:        ast.Object,
+		Description: t.Description,
+		Position:    compiler.CompiledPosName("self-described"),
+	}
+
+	// table directive
+	def.Directives = append(def.Directives, &ast.Directive{
+		Name: "table",
+		Arguments: ast.ArgumentList{
+			&ast.Argument{
+				Name:     "name",
+				Value:    &ast.Value{Raw: name, Kind: ast.StringValue, Position: compiler.CompiledPosName("self-described-table-source")},
+				Position: compiler.CompiledPosName("self-described-table"),
+			},
+		},
+		Position: compiler.CompiledPosName("self-described-table"),
+	})
+
+	if name != t.Name {
+		// add module directive if the name is qualified
+		def.Directives = append(def.Directives, &ast.Directive{
+			Name: "module",
+			Arguments: ast.ArgumentList{
+				&ast.Argument{
+					Name:     "name",
+					Value:    &ast.Value{Raw: identGraphQL(t.SchemaName), Kind: ast.StringValue, Position: compiler.CompiledPosName("self-described-module")},
+					Position: compiler.CompiledPosName("self-described-module"),
+				},
+			},
+			Position: compiler.CompiledPosName("self-described-module"),
+		})
+	}
+
+	for _, col := range t.Columns {
+		colDef, err := col.Definition()
+		if err != nil {
+			return nil, err
+		}
+		if colDef != nil {
+			def.Fields = append(def.Fields, colDef)
+		}
+	}
+
+	if len(def.Fields) == 0 {
+		return nil, nil // No fields, no definition
+	}
+	for _, constraint := range t.Constraints {
+		switch strings.ToUpper(constraint.Type) {
+		case "PRIMARY KEY":
+			// add primary key directive to the field
+			var pkf ast.FieldList
+			for _, colName := range constraint.Columns {
+				fieldDef := def.Fields.ForName(identGraphQL(colName))
+				if fieldDef == nil {
+					pkf = nil // Reset if any field is not found
+					continue  // Skip if the field is not found
+				}
+				pkf = append(pkf, fieldDef)
+			}
+			for _, field := range pkf {
+				field.Directives = append(field.Directives, &ast.Directive{
+					Name:     "pk",
+					Position: compiler.CompiledPosName("self-described-primary-key"),
+				})
+			}
+		case "FOREIGN KEY":
+			// add foreign key directive to the type
+			if len(constraint.ReferencedColumns) == 0 ||
+				len(constraint.Columns) != len(constraint.ReferencedColumns) {
+				continue
+			}
+			// make columns list
+			columns := make(ast.ChildValueList, len(constraint.Columns))
+			for i, col := range constraint.Columns {
+				columns[i] = &ast.ChildValue{
+					Name:     identGraphQL(col),
+					Value:    &ast.Value{Raw: identGraphQL(col), Kind: ast.StringValue, Position: compiler.CompiledPosName("self-described-foreign-key")},
+					Position: compiler.CompiledPosName("self-described-foreign-key"),
+				}
+			}
+			// make references columns list
+			references := make(ast.ChildValueList, len(constraint.ReferencedColumns))
+			for i, col := range constraint.ReferencedColumns {
+				references[i] = &ast.ChildValue{
+					Name:     identGraphQL(col),
+					Value:    &ast.Value{Raw: identGraphQL(constraint.Columns[i]), Kind: ast.StringValue, Position: compiler.CompiledPosName("self-described-foreign-key")},
+					Position: compiler.CompiledPosName("self-described-foreign-key"),
+				}
+			}
+			ref := &ast.Directive{
+				Name: "references",
+				Arguments: ast.ArgumentList{
+					&ast.Argument{
+						Name: "name",
+						Value: &ast.Value{
+							Raw:      t.Name + "_" + constraint.Name + "_fk",
+							Kind:     ast.StringValue,
+							Position: compiler.CompiledPosName("self-described-foreign-key"),
+						},
+						Position: compiler.CompiledPosName("self-described-foreign-key"),
+					},
+					&ast.Argument{
+						Name: "references_name",
+						Value: &ast.Value{
+							Raw:      dataObjectName(constraint.ReferencedSchema, constraint.ReferencedTable),
+							Kind:     ast.StringValue,
+							Position: compiler.CompiledPosName("self-described-foreign-key"),
+						},
+						Position: compiler.CompiledPosName("self-described-foreign-key"),
+					},
+					&ast.Argument{
+						Name: "source_fields",
+						Value: &ast.Value{
+							Kind:     ast.ListValue,
+							Children: columns,
+							Position: compiler.CompiledPosName("self-described-foreign-key"),
+						},
+					},
+					&ast.Argument{
+						Name: "references_fields",
+						Value: &ast.Value{
+							Kind:     ast.ListValue,
+							Children: references,
+							Position: compiler.CompiledPosName("self-described-foreign-key"),
+						},
+					},
+					&ast.Argument{
+						Name: "query",
+						Value: &ast.Value{
+							Raw:      identGraphQL("ref_" + constraint.ReferencedTable),
+							Kind:     ast.StringValue,
+							Position: compiler.CompiledPosName("self-described-foreign-key"),
+						},
+					},
+					&ast.Argument{
+						Name: "references_query",
+						Value: &ast.Value{
+							Raw:      identGraphQL("ref_" + t.Name),
+							Kind:     ast.StringValue,
+							Position: compiler.CompiledPosName("self-described-foreign-key"),
+						},
+					},
+				},
+				Position: compiler.CompiledPosName("self-described-foreign-key"),
+			}
+
+			def.Directives = append(def.Directives, ref)
+		}
+	}
+
+	return def, nil
+}
+
+func (v *DBViewInfo) Definition() (*ast.Definition, error) {
+	if len(v.Columns) == 0 {
+		return nil, nil // No columns, no definition
+	}
+	name := dataObjectName(v.SchemaName, v.Name)
+
+	def := &ast.Definition{
+		Name:        identGraphQL(name),
+		Kind:        ast.Object,
+		Description: v.Description,
+		Position:    compiler.CompiledPosName("self-described"),
+	}
+
+	// view directive
+	def.Directives = append(def.Directives, &ast.Directive{
+		Name: "view",
+		Arguments: ast.ArgumentList{
+			&ast.Argument{
+				Name:     "name",
+				Value:    &ast.Value{Raw: name, Kind: ast.StringValue, Position: compiler.CompiledPosName("self-described-view")},
+				Position: compiler.CompiledPosName("self-described-view"),
+			},
+		},
+		Position: compiler.CompiledPosName("self-described-view"),
+	})
+	if name != v.Name {
+		// add module directive if the name is qualified
+		def.Directives = append(def.Directives, &ast.Directive{
+			Name: "module",
+			Arguments: ast.ArgumentList{
+				&ast.Argument{
+					Name:     "name",
+					Value:    &ast.Value{Raw: identGraphQL(v.SchemaName), Kind: ast.StringValue, Position: compiler.CompiledPosName("self-described-module")},
+					Position: compiler.CompiledPosName("self-described-module"),
+				},
+			},
+			Position: compiler.CompiledPosName("self-described-module"),
+		})
+	}
+	for _, col := range v.Columns {
+		colDef, err := col.Definition()
+		if err != nil {
+			return nil, err
+		}
+		if colDef != nil {
+			def.Fields = append(def.Fields, colDef)
+		}
+	}
+	if len(def.Fields) == 0 {
+		return nil, nil // No fields, no definition
+	}
+
+	return def, nil
+}
+
+func (c *DBColumnInfo) Definition() (*ast.FieldDefinition, error) {
+	fieldDef := &ast.FieldDefinition{
+		Name:        c.Name,
+		Description: c.Description,
+		Type:        graphQLType(c.DataType),
+		Position:    compiler.CompiledPosName("self-described"),
+	}
+	if fieldDef.Type == nil {
+		return nil, nil // If the type is not recognized, return nil
+	}
+
+	// check if the field name is qualified
+	name := identGraphQL(c.Name)
+	if name != c.Name {
+		fieldDef.Name = name // Use the sanitized name
+		fieldDef.Directives = append(fieldDef.Directives, &ast.Directive{
+			Name: "field_source",
+			Arguments: ast.ArgumentList{
+				&ast.Argument{
+					Name:     "source",
+					Value:    &ast.Value{Raw: c.Name, Kind: ast.StringValue, Position: compiler.CompiledPosName("self-described-field-source")},
+					Position: compiler.CompiledPosName("self-described-field-source"),
+				},
+			},
+			Position: compiler.CompiledPosName("self-described-field-source"),
+		})
+	}
+
+	if !c.IsNullable {
+		fieldDef.Type.NonNull = true // Mark as non-nullable if applicable
+	}
+
+	// add default value if provided
+	if strings.HasPrefix(c.Default, "nextval('") && strings.HasSuffix(c.Default, "')") {
+		seqName := strings.TrimPrefix(strings.TrimSuffix(c.Default, "'"), "nextval(")
+		fieldDef.Directives = append(fieldDef.Directives, &ast.Directive{
+			Name: "default",
+			Arguments: ast.ArgumentList{
+				&ast.Argument{
+					Name:     "sequence",
+					Value:    &ast.Value{Raw: seqName, Kind: ast.StringValue, Position: compiler.CompiledPosName("default-sequence")},
+					Position: compiler.CompiledPosName("default-sequence"),
+				},
+			},
+			Position: compiler.CompiledPosName("default-sequence"),
+		})
+	}
+
+	return fieldDef, nil
+}
+
+// graphQLType converts a string to a GraphQL type
+// The struct, map ignored
+func graphQLType(name string) *ast.Type {
+	if strings.HasSuffix(name, "[]") {
+		// Handle array types
+		elemType := graphQLType(strings.TrimSuffix(name, "[]"))
+		if elemType == nil {
+			return nil
+		}
+		return ast.ListType(elemType, compiler.CompiledPosName("self-described-type"))
+	}
+
+	pos := compiler.CompiledPosName("self-described-type")
+	if strings.HasPrefix(name, "DECIMAL") ||
+		strings.HasPrefix(name, "NUMERIC") {
+		return ast.NamedType("Float", pos)
+	}
+	switch strings.ToUpper(name) {
+	case "INT", "INTEGER", "INT4", "SIGNED":
+		return ast.NamedType("Int", pos)
+	case "BIGINT", "INT8", "LONG", "UINTEGER":
+		return ast.NamedType("BigInt", pos)
+	case "SMALLINT", "INT2", "SHORT", "TINYINT":
+		return ast.NamedType("Int", pos)
+	case "FLOAT", "REAL", "FLOAT4", "DOUBLE", "FLOAT8":
+		return ast.NamedType("Float", pos)
+	case "BLOB", "BYTEA", "BINARY", "VARBINARY":
+		return ast.NamedType("String", pos)
+	case "BIT", "BITSTRING":
+		return ast.NamedType("String", pos)
+	case "BOOLEAN", "BOOL", "LOGICAL":
+		return ast.NamedType("Boolean", pos)
+	case "DATE":
+		return ast.NamedType("Date", pos)
+	case "TIME":
+		return ast.NamedType("Time", pos)
+	case "TIMESTAMP", "DATETIME", "TIMESTAMPTZ", "TIMESTAMP WITH TIME ZONE":
+		return ast.NamedType("Timestamp", pos)
+	case "INTERVAL":
+		return ast.NamedType("Interval", pos)
+	case "JSON":
+		return ast.NamedType("JSON", pos)
+	case "TEXT", "VARCHAR", "CHAR", "BPCHAR", "STRING":
+		return ast.NamedType("String", pos)
+	case "UUID":
+		return ast.NamedType("String", pos)
+	case "GEOMETRY", "GEOGRAPHY", "WKB_BLOB":
+		return ast.NamedType("Geometry", pos)
+	default:
+		return nil
+	}
+}
+
+// Makes valid graphql identifier
+func identGraphQL(name string) string {
+	// Replace invalid characters with underscores
+	name = strings.Map(func(r rune) rune {
+		// allow alphanumeric english characters and underscores
+		if r >= 'a' && r <= 'z' ||
+			r >= 'A' && r <= 'Z' ||
+			r >= '0' && r <= '9' ||
+			r == '_' {
+			return r
+		}
+		return '_'
+	}, name)
+	if strings.HasPrefix(name, "_") {
+		// Ensure it doesn't start with an underscore
+		name = "db_" + name[1:]
+	}
+	return name
+}
+
+var skipSchemaModules = map[string]bool{
+	"public": true,
+	"main":   true,
+}
+
+func dataObjectName(schema, name string) string {
+	// if schema is empty, use name as is
+	if schema == "" {
+		return name
+	}
+	// if schema is in skipSchemaModules, return name only
+	if _, ok := skipSchemaModules[schema]; ok {
+		return name
+	}
+	// otherwise return schema.name
+	return schema + "." + name
+}

--- a/pkg/catalogs/sources/db_info_test.go
+++ b/pkg/catalogs/sources/db_info_test.go
@@ -1,0 +1,574 @@
+package sources
+
+import (
+	"testing"
+
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func Test_graphQLType(t *testing.T) {
+	tests := []struct {
+		name     string
+		wantType *ast.Type
+	}{
+		{"INT", ast.NamedType("Int", nil)},
+		{"INTEGER", ast.NamedType("Int", nil)},
+		{"INT4", ast.NamedType("Int", nil)},
+		{"SIGNED", ast.NamedType("Int", nil)},
+		{"BIGINT", ast.NamedType("BigInt", nil)},
+		{"INT8", ast.NamedType("BigInt", nil)},
+		{"LONG", ast.NamedType("BigInt", nil)},
+		{"UINTEGER", ast.NamedType("BigInt", nil)},
+		{"SMALLINT", ast.NamedType("Int", nil)},
+		{"INT2", ast.NamedType("Int", nil)},
+		{"SHORT", ast.NamedType("Int", nil)},
+		{"TINYINT", ast.NamedType("Int", nil)},
+		{"FLOAT", ast.NamedType("Float", nil)},
+		{"REAL", ast.NamedType("Float", nil)},
+		{"FLOAT4", ast.NamedType("Float", nil)},
+		{"DOUBLE", ast.NamedType("Float", nil)},
+		{"FLOAT8", ast.NamedType("Float", nil)},
+		{"DECIMAL", ast.NamedType("Float", nil)},
+		{"DECIMAL(10,2)", ast.NamedType("Float", nil)},
+		{"NUMERIC", ast.NamedType("Float", nil)},
+		{"BLOB", ast.NamedType("String", nil)},
+		{"BYTEA", ast.NamedType("String", nil)},
+		{"BINARY", ast.NamedType("String", nil)},
+		{"VARBINARY", ast.NamedType("String", nil)},
+		{"BIT", ast.NamedType("String", nil)},
+		{"BITSTRING", ast.NamedType("String", nil)},
+		{"BOOLEAN", ast.NamedType("Boolean", nil)},
+		{"BOOL", ast.NamedType("Boolean", nil)},
+		{"LOGICAL", ast.NamedType("Boolean", nil)},
+		{"DATE", ast.NamedType("Date", nil)},
+		{"TIME", ast.NamedType("Time", nil)},
+		{"TIMESTAMP", ast.NamedType("Timestamp", nil)},
+		{"DATETIME", ast.NamedType("Timestamp", nil)},
+		{"TIMESTAMPTZ", ast.NamedType("Timestamp", nil)},
+		{"TIMESTAMP WITH TIME ZONE", ast.NamedType("Timestamp", nil)},
+		{"INTERVAL", ast.NamedType("Interval", nil)},
+		{"JSON", ast.NamedType("JSON", nil)},
+		{"TEXT", ast.NamedType("String", nil)},
+		{"VARCHAR", ast.NamedType("String", nil)},
+		{"CHAR", ast.NamedType("String", nil)},
+		{"BPCHAR", ast.NamedType("String", nil)},
+		{"STRING", ast.NamedType("String", nil)},
+		{"UUID", ast.NamedType("String", nil)},
+		{"UNKNOWN", nil},
+		{"INT[]", ast.ListType(ast.NamedType("Int", nil), nil)},
+		{"VARCHAR[]", ast.ListType(ast.NamedType("String", nil), nil)},
+		{"FLOAT[]", ast.ListType(ast.NamedType("Float", nil), nil)},
+		{"BOOLEAN[]", ast.ListType(ast.NamedType("Boolean", nil), nil)},
+		{"UNKNOWN[]", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := graphQLType(tt.name)
+			if (got == nil) != (tt.wantType == nil) {
+				t.Errorf("graphQLType(%q) = %v, want %v", tt.name, got, tt.wantType)
+				return
+			}
+			if got != nil && tt.wantType != nil {
+				if got.Name() != tt.wantType.Name() || (got.Elem != nil) != (tt.wantType.Elem != nil) {
+					t.Errorf("graphQLType(%q) = %v, want %v", tt.name, got, tt.wantType)
+				}
+			}
+		})
+	}
+}
+
+func TestDBColumnInfo_Definition(t *testing.T) {
+	tests := []struct {
+		name           string
+		column         DBColumnInfo
+		wantNil        bool
+		wantName       string
+		wantType       string
+		wantNonNull    bool
+		wantDirectives []string
+	}{
+		{
+			name: "simple int nullable",
+			column: DBColumnInfo{
+				Name:        "id",
+				Description: "primary key",
+				DataType:    "INT",
+				IsNullable:  true,
+			},
+			wantNil:        false,
+			wantName:       "id",
+			wantType:       "Int",
+			wantNonNull:    false,
+			wantDirectives: nil,
+		},
+		{
+			name: "simple int non-nullable",
+			column: DBColumnInfo{
+				Name:        "id",
+				Description: "primary key",
+				DataType:    "INT",
+				IsNullable:  false,
+			},
+			wantNil:        false,
+			wantName:       "id",
+			wantType:       "Int",
+			wantNonNull:    true,
+			wantDirectives: nil,
+		},
+		{
+			name: "unknown type returns nil",
+			column: DBColumnInfo{
+				Name:        "foo",
+				Description: "unknown type",
+				DataType:    "FOOBAR",
+				IsNullable:  true,
+			},
+			wantNil: true,
+		},
+		{
+			name: "qualified name triggers field_source directive",
+			column: DBColumnInfo{
+				Name:        "foo.bar",
+				Description: "qualified",
+				DataType:    "VARCHAR",
+				IsNullable:  true,
+			},
+			wantNil:        false,
+			wantName:       "foo_bar",
+			wantType:       "String",
+			wantNonNull:    false,
+			wantDirectives: []string{"field_source"},
+		},
+		{
+			name: "default nextval triggers default directive",
+			column: DBColumnInfo{
+				Name:        "id",
+				Description: "with default",
+				DataType:    "BIGINT",
+				IsNullable:  false,
+				Default:     "nextval('my_seq')",
+			},
+			wantNil:        false,
+			wantName:       "id",
+			wantType:       "BigInt",
+			wantNonNull:    true,
+			wantDirectives: []string{"default"},
+		},
+		{
+			name: "default not nextval does not trigger default directive",
+			column: DBColumnInfo{
+				Name:        "created_at",
+				Description: "with default",
+				DataType:    "TIMESTAMP",
+				IsNullable:  false,
+				Default:     "CURRENT_TIMESTAMP",
+			},
+			wantNil:        false,
+			wantName:       "created_at",
+			wantType:       "Timestamp",
+			wantNonNull:    true,
+			wantDirectives: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def, err := tt.column.Definition()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if def != nil {
+					t.Errorf("expected nil, got %+v", def)
+				}
+				return
+			}
+			if def == nil {
+				t.Fatalf("expected non-nil definition")
+			}
+			if def.Name != tt.wantName {
+				t.Errorf("got Name %q, want %q", def.Name, tt.wantName)
+			}
+			if def.Type == nil || def.Type.Name() != tt.wantType {
+				t.Errorf("got Type %v, want %v", def.Type, tt.wantType)
+			}
+			if def.Type != nil && def.Type.NonNull != tt.wantNonNull {
+				t.Errorf("got NonNull %v, want %v", def.Type.NonNull, tt.wantNonNull)
+			}
+			// Check directives
+			gotDirectives := map[string]bool{}
+			for _, d := range def.Directives {
+				gotDirectives[d.Name] = true
+			}
+			for _, wantDir := range tt.wantDirectives {
+				if !gotDirectives[wantDir] {
+					t.Errorf("expected directive %q, not found in %+v", wantDir, def.Directives)
+				}
+			}
+			if len(def.Directives) != len(tt.wantDirectives) {
+				t.Errorf("got %d directives, want %d", len(def.Directives), len(tt.wantDirectives))
+			}
+		})
+	}
+}
+
+func TestDBTableInfo_Definition(t *testing.T) {
+	tests := []struct {
+		name           string
+		table          DBTableInfo
+		wantNil        bool
+		wantName       string
+		wantKind       ast.DefinitionKind
+		wantFields     []string
+		wantDirectives []string
+		pkFields       []string
+		fkDirective    bool
+	}{
+		{
+			name: "empty columns returns nil",
+			table: DBTableInfo{
+				Name:    "users",
+				Columns: nil,
+			},
+			wantNil: true,
+		},
+		{
+			name: "simple table with one column",
+			table: DBTableInfo{
+				Name:        "users",
+				Description: "users table",
+				SchemaName:  "public",
+				Columns: []DBColumnInfo{
+					{Name: "id", DataType: "INT", IsNullable: false},
+				},
+			},
+			wantNil:        false,
+			wantName:       "users",
+			wantKind:       ast.Object,
+			wantFields:     []string{"id"},
+			wantDirectives: []string{"table"},
+		},
+		{
+			name: "qualified schema adds module directive",
+			table: DBTableInfo{
+				Name:        "orders",
+				Description: "orders table",
+				SchemaName:  "sales",
+				Columns: []DBColumnInfo{
+					{Name: "order_id", DataType: "BIGINT", IsNullable: false},
+				},
+			},
+			wantNil:        false,
+			wantName:       "sales.orders",
+			wantKind:       ast.Object,
+			wantFields:     []string{"order_id"},
+			wantDirectives: []string{"table", "module"},
+		},
+		{
+			name: "table with multiple columns and primary key",
+			table: DBTableInfo{
+				Name:        "products",
+				SchemaName:  "public",
+				Description: "products table",
+				Columns: []DBColumnInfo{
+					{Name: "id", DataType: "INT", IsNullable: false},
+					{Name: "name", DataType: "VARCHAR", IsNullable: false},
+				},
+				Constraints: []DBConstraintInfo{
+					{
+						Name:    "pk_products",
+						Type:    "PRIMARY KEY",
+						Columns: []string{"id"},
+					},
+				},
+			},
+			wantNil:        false,
+			wantName:       "products",
+			wantKind:       ast.Object,
+			wantFields:     []string{"id", "name"},
+			wantDirectives: []string{"table"},
+			pkFields:       []string{"id"},
+		},
+		{
+			name: "table with foreign key",
+			table: DBTableInfo{
+				Name:        "orders",
+				SchemaName:  "public",
+				Description: "orders table",
+				Columns: []DBColumnInfo{
+					{Name: "id", DataType: "INT", IsNullable: false},
+					{Name: "user_id", DataType: "INT", IsNullable: false},
+				},
+				Constraints: []DBConstraintInfo{
+					{
+						Name:              "fk_user",
+						Type:              "FOREIGN KEY",
+						Columns:           []string{"user_id"},
+						ReferencedSchema:  "public",
+						ReferencedTable:   "users",
+						ReferencedColumns: []string{"id"},
+					},
+				},
+			},
+			wantNil:        false,
+			wantName:       "orders",
+			wantKind:       ast.Object,
+			wantFields:     []string{"id", "user_id"},
+			wantDirectives: []string{"table", "references"},
+			fkDirective:    true,
+		},
+		{
+			name: "table with no valid columns after filtering",
+			table: DBTableInfo{
+				Name:       "empty",
+				SchemaName: "public",
+				Columns: []DBColumnInfo{
+					{Name: "foo", DataType: "UNKNOWN", IsNullable: true},
+				},
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def, err := tt.table.Definition()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if def != nil {
+					t.Errorf("expected nil, got %+v", def)
+				}
+				return
+			}
+			if def == nil {
+				t.Fatalf("expected non-nil definition")
+			}
+			if def.Name != identGraphQL(tt.wantName) {
+				t.Errorf("got Name %q, want %q", def.Name, identGraphQL(tt.wantName))
+			}
+			if def.Kind != tt.wantKind {
+				t.Errorf("got Kind %v, want %v", def.Kind, tt.wantKind)
+			}
+			// Check fields
+			gotFields := map[string]bool{}
+			for _, f := range def.Fields {
+				gotFields[f.Name] = true
+			}
+			for _, wantField := range tt.wantFields {
+				if !gotFields[wantField] {
+					t.Errorf("expected field %q, not found in %+v", wantField, def.Fields)
+				}
+			}
+			if len(def.Fields) != len(tt.wantFields) {
+				t.Errorf("got %d fields, want %d", len(def.Fields), len(tt.wantFields))
+			}
+			// Check directives
+			gotDirectives := map[string]bool{}
+			for _, d := range def.Directives {
+				gotDirectives[d.Name] = true
+			}
+			for _, wantDir := range tt.wantDirectives {
+				if !gotDirectives[wantDir] {
+					t.Errorf("expected directive %q, not found in %+v", wantDir, def.Directives)
+				}
+			}
+			// Check pk directive on fields if applicable
+			if len(tt.pkFields) > 0 {
+				for _, pkField := range tt.pkFields {
+					field := def.Fields.ForName(identGraphQL(pkField))
+					if field == nil {
+						t.Errorf("expected pk field %q not found", pkField)
+						continue
+					}
+					found := false
+					for _, d := range field.Directives {
+						if d.Name == "pk" {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("expected pk directive on field %q", pkField)
+					}
+				}
+			}
+			// Check foreign key directive if applicable
+			if tt.fkDirective {
+				found := false
+				for _, d := range def.Directives {
+					if d.Name == "References" {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected References directive for foreign key")
+				}
+			}
+		})
+	}
+}
+
+func TestDBSchemaInfo_Definitions(t *testing.T) {
+	tests := []struct {
+		name      string
+		schema    DBSchemaInfo
+		wantNames []string
+		wantKinds []ast.DefinitionKind
+		wantErr   bool
+	}{
+		{
+			name: "empty schema returns empty list",
+			schema: DBSchemaInfo{
+				Name:        "public",
+				Description: "empty schema",
+				Tables:      nil,
+				Views:       nil,
+			},
+			wantNames: nil,
+			wantKinds: nil,
+			wantErr:   false,
+		},
+		{
+			name: "schema with one valid table",
+			schema: DBSchemaInfo{
+				Name: "public",
+				Tables: []DBTableInfo{
+					{
+						Name:       "users",
+						SchemaName: "public",
+						Columns: []DBColumnInfo{
+							{Name: "id", DataType: "INT", IsNullable: false},
+						},
+					},
+				},
+			},
+			wantNames: []string{"users"},
+			wantKinds: []ast.DefinitionKind{ast.Object},
+			wantErr:   false,
+		},
+		{
+			name: "schema with one valid view",
+			schema: DBSchemaInfo{
+				Name: "public",
+				Views: []DBViewInfo{
+					{
+						Name:       "active_users",
+						SchemaName: "public",
+						Columns: []DBColumnInfo{
+							{Name: "id", DataType: "INT", IsNullable: false},
+						},
+					},
+				},
+			},
+			wantNames: []string{"active_users"},
+			wantKinds: []ast.DefinitionKind{ast.Object},
+			wantErr:   false,
+		},
+		{
+			name: "schema with table and view",
+			schema: DBSchemaInfo{
+				Name: "public",
+				Tables: []DBTableInfo{
+					{
+						Name:       "users",
+						SchemaName: "public",
+						Columns: []DBColumnInfo{
+							{Name: "id", DataType: "INT", IsNullable: false},
+						},
+					},
+				},
+				Views: []DBViewInfo{
+					{
+						Name:       "active_users",
+						SchemaName: "public",
+						Columns: []DBColumnInfo{
+							{Name: "id", DataType: "INT", IsNullable: false},
+						},
+					},
+				},
+			},
+			wantNames: []string{"users", "active_users"},
+			wantKinds: []ast.DefinitionKind{ast.Object, ast.Object},
+			wantErr:   false,
+		},
+		{
+			name: "schema with invalid table and valid view",
+			schema: DBSchemaInfo{
+				Name: "public",
+				Tables: []DBTableInfo{
+					{
+						Name:       "invalid",
+						SchemaName: "public",
+						Columns: []DBColumnInfo{
+							{Name: "foo", DataType: "UNKNOWN", IsNullable: true},
+						},
+					},
+				},
+				Views: []DBViewInfo{
+					{
+						Name:       "v1",
+						SchemaName: "public",
+						Columns: []DBColumnInfo{
+							{Name: "id", DataType: "INT", IsNullable: false},
+						},
+					},
+				},
+			},
+			wantNames: []string{"v1"},
+			wantKinds: []ast.DefinitionKind{ast.Object},
+			wantErr:   false,
+		},
+		{
+			name: "schema with table returning error",
+			schema: DBSchemaInfo{
+				Name: "public",
+				Tables: []DBTableInfo{
+					{
+						Name:       "errtable",
+						SchemaName: "public",
+						Columns: []DBColumnInfo{
+							{Name: "id", DataType: "INT", IsNullable: false},
+						},
+					},
+				},
+			},
+			wantNames: []string{"errtable"},
+			wantKinds: []ast.DefinitionKind{ast.Object},
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defs, err := tt.schema.Definitions()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(defs) != len(tt.wantNames) {
+				t.Errorf("got %d definitions, want %d", len(defs), len(tt.wantNames))
+			}
+			for i, wantName := range tt.wantNames {
+				if i >= len(defs) {
+					t.Errorf("missing definition for %q", wantName)
+					continue
+				}
+				if defs[i].Name != identGraphQL(wantName) {
+					t.Errorf("definition[%d] got Name %q, want %q", i, defs[i].Name, identGraphQL(wantName))
+				}
+				if defs[i].Kind != tt.wantKinds[i] {
+					t.Errorf("definition[%d] got Kind %v, want %v", i, defs[i].Kind, tt.wantKinds[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/compiler/aggregations.go
+++ b/pkg/compiler/aggregations.go
@@ -282,7 +282,7 @@ func objectAggregationTypeName(schema *ast.SchemaDocument, opt *Options, def *as
 			continue
 		}
 		aggFieldDirectives := ast.DirectiveList{aggObjectFieldAggregationDirective(field)}
-		if def.Name == QueryTimeJoinsTypeName || def.Name != QueryTimeSpatialTypeName {
+		if def.Name == QueryTimeJoinsTypeName || def.Name == QueryTimeSpatialTypeName {
 			aggFieldDirectives = append(aggFieldDirectives, aggQueryDirective(field, false), opt.catalog)
 		}
 		fieldName := field.Name

--- a/pkg/compiler/base/keywords.go
+++ b/pkg/compiler/base/keywords.go
@@ -500,14 +500,12 @@ func Ident(s string) string {
 	return s
 }
 
-// Функция для проверки идентификатора
 func IsValidIdentifier(s string) bool {
 	upperStr := strings.ToUpper(s)
 	_, isKeyword := sqlKeywords[upperStr]
 	if isKeyword {
 		return false
 	}
-	// Проверка валидности идентификатора
 	if len(s) == 0 {
 		return false
 	}

--- a/pkg/data-sources/catalogs.go
+++ b/pkg/data-sources/catalogs.go
@@ -5,9 +5,77 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/hugr-lab/query-engine/pkg/catalogs"
 	"github.com/hugr-lab/query-engine/pkg/catalogs/sources"
 	"github.com/hugr-lab/query-engine/pkg/types"
+
+	//lint:ignore ST1001 "github.com/hugr-lab/query-engine/pkg/data-sources/sources" is a valid package name
+	. "github.com/hugr-lab/query-engine/pkg/data-sources/sources"
 )
+
+func (s *Service) dataSourceCatalog(ctx context.Context, name string) (*catalogs.Catalog, error) {
+	ds := s.dataSources[name]
+	source, err := s.catalogSource(ctx, ds, false)
+	if err != nil {
+		return nil, err
+	}
+	if source == nil {
+		return nil, nil
+	}
+	def := ds.Definition()
+	return catalogs.NewCatalog(ctx, def.Name, def.Prefix, ds.Engine(), source, def.AsModule, ds.ReadOnly())
+}
+
+func (s *Service) extensionCatalog(ctx context.Context, name string) (*catalogs.Extension, error) {
+	ds := s.dataSources[name]
+	source, err := s.catalogSource(ctx, ds, false)
+	if err != nil {
+		return nil, err
+	}
+	def := ds.Definition()
+	return s.catalogs.NewExtension(ctx, def, source)
+}
+
+func (s *Service) catalogSource(ctx context.Context, ds Source, self bool) (source sources.Source, err error) {
+	var ss []sources.Source
+	def := ds.Definition()
+	if def.SelfDefined || self {
+		if ds, ok := ds.(SelfDescriber); ok {
+			source, err = ds.CatalogSource(ctx, s.db)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			source, err = sources.DescribeDataSource(ctx, s.qe, def.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to describe data source %s: %w", def.Name, err)
+			}
+		}
+		if self {
+			return source, nil
+		}
+		if s != nil {
+			ss = append(ss, source)
+		}
+	}
+	for _, cs := range def.Sources {
+		s, err := s.loadCatalogSource(ctx, cs.Type, cs.Path)
+		if err != nil {
+			return nil, err
+		}
+		ss = append(ss, s)
+	}
+	if len(ss) == 0 {
+		return nil, nil
+	}
+	if len(ss) == 1 {
+		source = ss[0]
+	}
+	if len(ss) > 1 {
+		source = sources.MergeSource(ss...)
+	}
+	return source, nil
+}
 
 func (s *Service) loadCatalogSource(ctx context.Context, t types.CatalogSourceType, path string) (sources.Source, error) {
 	switch t {

--- a/pkg/data-sources/catalogs.go
+++ b/pkg/data-sources/catalogs.go
@@ -54,7 +54,7 @@ func (s *Service) catalogSource(ctx context.Context, ds Source, self bool) (sour
 		if self {
 			return source, nil
 		}
-		if s != nil {
+		if source != nil {
 			ss = append(ss, source)
 		}
 	}

--- a/pkg/data-sources/data_source.go
+++ b/pkg/data-sources/data_source.go
@@ -3,8 +3,11 @@ package datasources
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/hugr-lab/query-engine/pkg/types"
+	"github.com/vektah/gqlparser/v2/formatter"
+
 	//lint:ignore ST1001 "github.com/hugr-lab/query-engine/pkg/data-sources/sources" is a valid package name
 	. "github.com/hugr-lab/query-engine/pkg/data-sources/sources"
 )
@@ -85,4 +88,27 @@ func (s *Service) UnloadDataSource(ctx context.Context, name string) error {
 		return err
 	}
 	return nil
+}
+
+func (s *Service) DescribeDataSource(ctx context.Context, name string, self bool) (string, error) {
+	ds, err := s.DataSource(name)
+	if err != nil {
+		return "", err
+	}
+
+	source, err := s.catalogSource(ctx, ds, self)
+	if err != nil {
+		return "", err
+	}
+	if source == nil {
+		return "", nil
+	}
+
+	sd, err := source.SchemaDocument(ctx)
+	if err != nil {
+		return "", err
+	}
+	var sb strings.Builder
+	formatter.NewFormatter(&sb).FormatSchemaDocument(sd)
+	return sb.String(), nil
 }

--- a/pkg/data-sources/sources/runtime/data-sources/schema.graphql
+++ b/pkg/data-sources/sources/runtime/data-sources/schema.graphql
@@ -21,4 +21,11 @@ extend type Function {
     name: String!
   ): String @module(name: "core")
     @function(name: "data_source_status")
+
+  describe_data_source_schema(
+    name: String!
+    self: Boolean = false
+    log: Boolean = false
+  ): String @module(name: "core")
+    @function(name: "describe_data_source_schema")
 }

--- a/pkg/data-sources/sources/runtime/data-sources/udf.go
+++ b/pkg/data-sources/sources/runtime/data-sources/udf.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/hugr-lab/query-engine/pkg/auth"
 	"github.com/hugr-lab/query-engine/pkg/data-sources/sources/runtime"

--- a/pkg/data-sources/sources/runtime/data-sources/udf.go
+++ b/pkg/data-sources/sources/runtime/data-sources/udf.go
@@ -105,7 +105,7 @@ func (s *Source) registerUDF(ctx context.Context) error {
 				return "", err
 			}
 			if p.log {
-				fmt.Println("describe_data_source_schema output:", out)
+				log.Printf("describe_data_source_schema output: %s", out)
 			}
 			return out, nil
 		},

--- a/pkg/data-sources/sources/runtime/data-sources/udf.go
+++ b/pkg/data-sources/sources/runtime/data-sources/udf.go
@@ -111,7 +111,7 @@ func (s *Source) registerUDF(ctx context.Context) error {
 		},
 		ConvertInput: func(args []driver.Value) (describeArgs, error) {
 			if len(args) != 3 {
-				return describeArgs{}, errors.New("invalid number of arguments")
+				return describeArgs{}, fmt.Errorf("invalid number of arguments: expected 3, got %d", len(args))
 			}
 			return describeArgs{
 				name: args[0].(string),

--- a/pkg/data-sources/sources/runtime/meta-info/schema.graphql
+++ b/pkg/data-sources/sources/runtime/meta-info/schema.graphql
@@ -1,0 +1,305 @@
+# Databases
+type databases @view(name: "duckdb_databases" sql: "FROM duckdb_databases") 
+  @unique(fields: ["name"], query_suffix: "by_name"){
+  id: BigInt! @pk @field_source(field: "database_oid")
+  name: String! @field_source(field: "database_name")
+  type: String!
+  comment: String
+  tags: JSON
+  readonly: Boolean
+  internal: Boolean
+}
+
+# schemas
+type schemas @view(name: "duckdb_schemas" sql: "FROM duckdb_schemas()") {
+  id: BigInt! @pk @field_source(field: "oid")
+  name: String! @pk @field_source(field: "schema_name")
+  database_id: BigInt! @field_source(field: "database_oid")
+    @field_references(
+        name: "schemas_databases_id"
+        references_name: "databases"
+        field: "id"
+        query: "database"
+        references_query: "schemas"
+    )
+  database_name: String!
+  comment: String
+  tags: JSON
+  internal: Boolean
+}
+
+# tables
+type tables @view(name: "duckdb_tables", sql: "FROM duckdb_tables") {
+  id: BigInt! @pk @field_source(field: "table_oid")
+  name: String! @field_source(field: "table_name")
+  database_id: BigInt! @field_source(field: "database_oid")
+    @field_references(
+        name: "tables_databases_id"
+        references_name: "databases"
+        field: "id"
+        query: "database"
+        references_query: "tables"
+    )
+  database_name: String!
+  schema_id: BigInt! @field_source(field: "schema_oid")
+    @field_references(
+        name: "tables_schemas_id"
+        references_name: "schemas"
+        field: "id"
+        query: "schema"
+        references_query: "tables"
+    )
+  schema_name: String!
+  comment: String
+  tags: JSON
+  internal: Boolean
+  temporary: Boolean
+  has_primary_key: Boolean
+  estimated_size: BigInt
+  column_count: Int
+  index_count: Int
+}
+
+# views
+type views @view(name: "duckdb_views", sql: "FROM duckdb_views") {
+  id: BigInt! @pk @field_source(field: "view_oid")
+  name: String! @pk @field_source(field: "view_name")
+  database_id: BigInt! @field_source(field: "database_oid")
+    @field_references(
+        name: "views_databases_id"
+        references_name: "databases"
+        field: "id"
+        query: "database"
+        references_query: "views"
+    )
+  database_name: String!
+  schema_id: BigInt! @field_source(field: "schema_oid")
+    @field_references(
+        name: "views_schemas_id"
+        references_name: "schemas"
+        field: "id"
+        query: "schema"
+        references_query: "views"
+    )
+  schema_name: String!
+  comment: String
+  tags: JSON
+  internal: Boolean
+  temporary: Boolean
+  column_count: Int
+}
+
+# columns
+type columns @view(name: "duckdb_columns", sql: "FROM duckdb_columns") {
+  name: String! @pk @field_source(field: "column_name")
+  database_id: BigInt! @field_source(field: "database_oid")
+    @field_references(
+        name: "columns_databases_id"
+        references_name: "databases"
+        field: "id"
+        query: "database"
+        references_query: "columns"
+    )
+  database_name: String!
+  schema_id: BigInt! @field_source(field: "schema_oid")
+    @field_references(
+        name: "columns_schemas_id"
+        references_name: "schemas"
+        field: "id"
+        query: "schema"
+        references_query: "columns"
+    )
+  schema_name: String!
+  table_id: BigInt! @field_source(field: "table_oid")
+    @field_references(
+        name: "columns_tables_id"
+        references_name: "tables"
+        field: "id"
+        query: "table"
+        references_query: "columns"
+    )
+    @field_references(
+        name: "columns_views_id"
+        references_name: "views"
+        field: "id"
+        query: "view"
+        references_query: "columns"
+    )
+  table_name: String!
+  data_type: String
+  is_nullable: Boolean
+  default: String @field_source(field: "column_default")
+  comment: String
+  tags: JSON
+  internal: Boolean
+  ordinal_position: Int
+}
+
+# constraints
+type constraints @view(name: "duckdb_constraints", sql: "FROM duckdb_constraints") {
+  name: String! @pk @field_source(field: "constraint_name")
+  database_id: BigInt! @field_source(field: "database_oid")
+    @field_references(
+        name: "constraints_databases_id"
+        references_name: "databases"
+        field: "id"
+        query: "database"
+        references_query: "constraints"
+    )
+  database_name: String!
+  schema_id: BigInt! @field_source(field: "schema_oid")
+    @field_references(
+        name: "constraints_schemas_id"
+        references_name: "schemas"
+        field: "id"
+        query: "schema"
+        references_query: "constraints"
+    )
+  schema_name: String!
+  table_id: BigInt! @field_source(field: "table_oid")
+    @field_references(
+        name: "constraints_tables_id"
+        references_name: "tables"
+        field: "id"
+        query: "table"
+        references_query: "constraints"
+    )
+  table_name: String!
+  type: String @field_source(field: "constraint_type")
+  columns: [String!] @field_source(field: "constraint_column_names")
+  references_table_name: String @field_source(field: "referenced_table")
+    @field_references(
+        name: "constraints_references_name"
+        references_name: "tables"
+        field: "name"
+        query: "references"
+        references_query: "referenced_constraints"
+    )
+  references_columns: [String!] @field_source(field: "referenced_column_names")
+}
+
+# Extensions
+type extensions @view(name: "duckdb_extensions", sql: "FROM duckdb_extensions()") {
+  name: String! @pk @field_source(field: "extension_name")
+  loaded: Boolean
+  installed: Boolean
+  install_path: String
+  description: String
+  aliases: [String]
+  version: String @field_source(field: "extension_version")
+  install_mode: String
+  installed_from: String
+}
+
+# Functions
+type functions @view(name: "duckdb_functions", sql: "FROM duckdb_functions()") {
+  name: String! @pk @field_source(field: "function_name")
+  database_name: String!
+    @field_references(
+        name: "functions_databases_name"
+        references_name: "databases"
+        field: "name"
+        query: "database"
+        references_query: "functions"
+    )
+  schema_name: String!
+    @field_references(
+        name: "functions_schemas_name"
+        references_name: "schemas"
+        field: "name"
+        query: "schema"
+        references_query: "functions"
+    )
+  type: String @field_source(field: "function_type")
+  description: String
+  comment: String
+  tags: JSON
+  return_type: String
+  parameters: [String!]
+  parameter_types: [String!]
+  has_side_effects: Boolean
+  internal: Boolean
+  examples: [String!]
+  stability: String
+}
+
+# Log contexts
+type log_contexts @view(name: "duckdb_log_contexts", sql: "FROM duckdb_log_contexts()") {
+  id: BigInt! @pk @field_source(field: "context_id")
+  scope: String!
+  connection_id: String
+  transaction_id: String
+  query_id: String
+  thread_id: String
+}
+
+# Log entries
+type log_entries @view(name: "duckdb_log_entries", sql: "FROM duckdb_logs()") {
+  context_id: BigInt!
+    @field_references(
+        name: "log_entries_contexts_id"
+        references_name: "log_contexts"
+        field: "id"
+        query: "context"
+        references_query: "entries"
+    )
+  timestamp: Timestamp!
+  type: String
+  log_level: String
+  message: String
+}
+
+# duckdb_memory
+type duckdb_memory @view(name: "duckdb_memory", sql: "FROM duckdb_memory()") {
+  tag: String! @pk
+  memory_usage: BigInt @field_source(field: "memory_usage_bytes")
+  temporary_storage: BigInt @field_source(field: "temporary_storage_bytes")
+}
+
+# secret types
+type secret_types @view(name: "duckdb_secret_types", sql: "FROM duckdb_secret_types()") {
+  type: String! @pk
+  default_provider: String
+  extension_name: String @field_source(field: "extension")
+    @field_references(
+        name: "secret_types_extension_name"
+        references_name: "extensions"
+        field: "name"
+        query: "extension"
+        references_query: "secret_types"
+    )
+}
+
+# secrets
+type secrets @view(name: "duckdb_secrets", sql: "FROM duckdb_secrets()") {
+  name: String! @pk
+  type_name: String! @field_source(field: "type")
+    @field_references(
+        name: "secrets_types_type"
+        references_name: "secret_types"
+        field: "type"
+        query: "type"
+        references_query: "secrets"
+    )
+  provider: String
+  persistent: Boolean
+  storage: String
+  scope: [String]
+  secret_string: String
+}
+
+# Settings
+type settings @view(name: "duckdb_settings", sql: "FROM duckdb_settings()") {
+  name: String! @pk
+  value: String
+  description: String
+  input_type: String
+  scope: String
+}
+
+# temporary files
+type temporary_files @view(name: "duckdb_temporary_files", sql: "FROM duckdb_temporary_files()") {
+  path: String! @pk
+  size: BigInt
+}
+

--- a/pkg/data-sources/sources/runtime/meta-info/source.go
+++ b/pkg/data-sources/sources/runtime/meta-info/source.go
@@ -1,0 +1,49 @@
+package metainfo
+
+import (
+	"context"
+
+	"github.com/hugr-lab/query-engine/pkg/catalogs/sources"
+	"github.com/hugr-lab/query-engine/pkg/db"
+	"github.com/hugr-lab/query-engine/pkg/engines"
+
+	_ "embed" // for embedding the schema
+)
+
+// The runtime meta-info source provides access to the metadata of DuckDB attached databases, their schemas, relations, and columns.
+
+//go:embed schema.graphql
+var schema string
+
+type Source struct {
+	db *db.Pool
+}
+
+func New() *Source {
+	return &Source{}
+}
+
+func (s *Source) Name() string {
+	return "core.meta"
+}
+
+func (s *Source) Engine() engines.Engine {
+	return engines.NewDuckDB()
+}
+
+func (s *Source) IsReadonly() bool {
+	return false
+}
+
+func (s *Source) AsModule() bool {
+	return true
+}
+
+func (s *Source) Attach(ctx context.Context, pool *db.Pool) error {
+	s.db = pool
+	return nil
+}
+
+func (s *Source) Catalog(ctx context.Context) sources.Source {
+	return sources.NewStringSource("core_meta", schema)
+}

--- a/pkg/data-sources/udf.graphql
+++ b/pkg/data-sources/udf.graphql
@@ -20,5 +20,4 @@ extend type Function {
     jq: String!
   ):JSON @module(name: "core")
     @function(name: "http_data_source_request_scalar")
-    
 }

--- a/pkg/planner/node_aggregations.go
+++ b/pkg/planner/node_aggregations.go
@@ -234,6 +234,10 @@ func aggregateDataNode(ctx context.Context, defs compiler.DefinitionsSource, pla
 			if a := f.Arguments.ForName("order_by"); a != nil {
 				baseQuery.Arguments = append(baseQuery.Arguments, a)
 			}
+			// args for parameterized view
+			if a := query.Arguments.ForName("args"); a != nil {
+				baseQuery.Arguments = append(baseQuery.Arguments, a)
+			}
 			// filter arguments
 			if qa := query.Arguments.ForName("filter"); qa != nil {
 				if a := f.Arguments.ForName("filter"); a != nil {

--- a/pkg/planner/node_select.go
+++ b/pkg/planner/node_select.go
@@ -244,7 +244,10 @@ func selectDataObjectNode(ctx context.Context, defs compiler.DefinitionsSource, 
 	}
 	if info.HasArguments() {
 		arg := queryArg.ForName("args")
-		am, _ := arg.Value.(map[string]any)
+		am := map[string]any{}
+		if arg != nil {
+			am, _ = arg.Value.(map[string]any)
+		}
 		err = info.ApplyArguments(defs, am, e)
 		if err != nil {
 			return nil, false, err

--- a/pkg/planner/node_select.go
+++ b/pkg/planner/node_select.go
@@ -244,9 +244,9 @@ func selectDataObjectNode(ctx context.Context, defs compiler.DefinitionsSource, 
 	}
 	if info.HasArguments() {
 		arg := queryArg.ForName("args")
-		am := map[string]any{}
-		if arg != nil {
-			am, _ = arg.Value.(map[string]any)
+		am, ok := arg.Value.(map[string]any)
+		if !ok {
+			am = map[string]any{}
 		}
 		err = info.ApplyArguments(defs, am, e)
 		if err != nil {

--- a/pkg/types/engine.go
+++ b/pkg/types/engine.go
@@ -16,6 +16,7 @@ type Querier interface {
 	LoadDataSource(ctx context.Context, name string) error
 	UnloadDataSource(ctx context.Context, name string) error
 	DataSourceStatus(ctx context.Context, name string) (string, error)
+	DescribeDataSource(ctx context.Context, name string, self bool) (string, error)
 }
 
 type Response struct {


### PR DESCRIPTION
- Fixed conditional logic in objectAggregationTypeName to correctly handle QueryTimeSpatialTypeName.
- Cleaned up IsValidIdentifier function by removing unnecessary comments.
- Extended Date scalar type with additional arguments and an extra field for part extraction.
- Implemented dataSourceCatalog and extensionCatalog methods to retrieve catalogs for data sources.
- Added DescribeDataSource method to provide schema descriptions for data sources.
- Introduced describe_data_source_schema function in GraphQL schema for metadata retrieval.
- Registered describe_data_source_schema UDF for querying data source metadata.
- Created new meta-info schema.graphql for DuckDB metadata representation.
- Updated UDF GraphQL schema to remove unnecessary newline.
- Enhanced aggregateDataNode and selectDataObjectNode functions to support parameterized views.
- Added DescribeDataSource method to the Querier interface for improved data source introspection.