### PR TITLE
Support variable interpolation in JSON aggregation path arguments

### DIFF
--- a/pkg/catalog/sdl/scalars.go
+++ b/pkg/catalog/sdl/scalars.go
@@ -2,11 +2,52 @@ package sdl
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
 	"github.com/hugr-lab/query-engine/pkg/catalog/types"
 	"github.com/vektah/gqlparser/v2/ast"
 )
+
+// varPattern matches $VarName references inside string values.
+var varPattern = regexp.MustCompile(`\$([A-Za-z_][A-Za-z0-9_]*)`)
+
+// InterpolateVars replaces $VarName references inside string values
+// of an argument map with corresponding values from the vars map.
+// Non-string values and unresolved references are left as-is.
+func InterpolateVars(args map[string]any, vars map[string]any) map[string]any {
+	if vars == nil || args == nil {
+		return args
+	}
+	out := make(map[string]any, len(args))
+	for k, v := range args {
+		if s, ok := v.(string); ok && strings.Contains(s, "$") {
+			out[k] = interpolateVarsInString(s, vars)
+		} else {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// FieldArgumentMap resolves a field's arguments and interpolates
+// $VarName references in string values from query variables.
+func FieldArgumentMap(field *ast.Field, vars map[string]any) map[string]any {
+	return InterpolateVars(field.ArgumentMap(vars), vars)
+}
+
+func interpolateVarsInString(s string, vars map[string]any) string {
+	return varPattern.ReplaceAllStringFunc(s, func(match string) string {
+		name := match[1:] // strip leading '$'
+		v, ok := vars[name]
+		if !ok {
+			return match
+		}
+		return fmt.Sprint(v)
+	})
+}
 
 // IsScalarType returns true if typeName is a registered scalar type.
 func IsScalarType(typeName string) bool {

--- a/pkg/catalog/sdl/scalars_test.go
+++ b/pkg/catalog/sdl/scalars_test.go
@@ -1,0 +1,144 @@
+package sdl
+
+import (
+	"testing"
+)
+
+func TestInterpolateVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     map[string]any
+		vars     map[string]any
+		expected map[string]any
+	}{
+		{
+			name:     "nil args",
+			args:     nil,
+			vars:     map[string]any{"Year": "2026"},
+			expected: nil,
+		},
+		{
+			name:     "nil vars",
+			args:     map[string]any{"path": "gkh_kapremont_$Year.fed_price"},
+			vars:     nil,
+			expected: map[string]any{"path": "gkh_kapremont_$Year.fed_price"},
+		},
+		{
+			name:     "no variables in string",
+			args:     map[string]any{"path": "field.subfield"},
+			vars:     map[string]any{"Year": "2026"},
+			expected: map[string]any{"path": "field.subfield"},
+		},
+		{
+			name:     "single variable interpolation",
+			args:     map[string]any{"path": "gkh_kapremont_$Year.fed_price"},
+			vars:     map[string]any{"Year": "2026"},
+			expected: map[string]any{"path": "gkh_kapremont_2026.fed_price"},
+		},
+		{
+			name:     "integer variable",
+			args:     map[string]any{"path": "catalog_$Year.field"},
+			vars:     map[string]any{"Year": 2026},
+			expected: map[string]any{"path": "catalog_2026.field"},
+		},
+		{
+			name:     "multiple variables separated by dot",
+			args:     map[string]any{"path": "$Prefix.$Year.field"},
+			vars:     map[string]any{"Prefix": "gkh_kapremont", "Year": "2026"},
+			expected: map[string]any{"path": "gkh_kapremont.2026.field"},
+		},
+		{
+			name:     "unresolved variable left as-is",
+			args:     map[string]any{"path": "prefix_$Unknown.field"},
+			vars:     map[string]any{"Year": "2026"},
+			expected: map[string]any{"path": "prefix_$Unknown.field"},
+		},
+		{
+			name:     "non-string values unchanged",
+			args:     map[string]any{"path": "catalog_$Year.field", "limit": 10},
+			vars:     map[string]any{"Year": "2026"},
+			expected: map[string]any{"path": "catalog_2026.field", "limit": 10},
+		},
+		{
+			name:     "variable at start of string",
+			args:     map[string]any{"path": "$Catalog.field"},
+			vars:     map[string]any{"Catalog": "gkh_kapremont_2026"},
+			expected: map[string]any{"path": "gkh_kapremont_2026.field"},
+		},
+		{
+			name:     "variable at end of string",
+			args:     map[string]any{"path": "catalog.$Field"},
+			vars:     map[string]any{"Field": "fed_price"},
+			expected: map[string]any{"path": "catalog.fed_price"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := InterpolateVars(tt.args, tt.vars)
+			if tt.expected == nil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+				return
+			}
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d keys, got %d", len(tt.expected), len(result))
+				return
+			}
+			for k, ev := range tt.expected {
+				rv, ok := result[k]
+				if !ok {
+					t.Errorf("missing key %q in result", k)
+					continue
+				}
+				if rv != ev {
+					t.Errorf("key %q: expected %v, got %v", k, ev, rv)
+				}
+			}
+		})
+	}
+}
+
+func Test_interpolateVarsInString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		vars     map[string]any
+		expected string
+	}{
+		{
+			name:     "no vars",
+			input:    "plain.path",
+			vars:     map[string]any{},
+			expected: "plain.path",
+		},
+		{
+			name:     "single substitution",
+			input:    "gkh_kapremont_$Year.field",
+			vars:     map[string]any{"Year": "2026"},
+			expected: "gkh_kapremont_2026.field",
+		},
+		{
+			name:     "underscore in var name",
+			input:    "prefix_$My_Var.field",
+			vars:     map[string]any{"My_Var": "value"},
+			expected: "prefix_value.field",
+		},
+		{
+			name:     "adjacent to dot",
+			input:    "$A.$B",
+			vars:     map[string]any{"A": "foo", "B": "bar"},
+			expected: "foo.bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := interpolateVarsInString(tt.input, tt.vars)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/planner/node_aggregations.go
+++ b/pkg/planner/node_aggregations.go
@@ -739,7 +739,7 @@ func aggAggregationFieldNodes(ctx context.Context, e engines.EngineAggregator, d
 						}
 						return "SUM(1./" + field + ")::BIGINT", params, nil
 					}
-					return e.AggregateFuncSQL("count", "", "", "", nil, false, f.Field.ArgumentMap(vars), params)
+					return e.AggregateFuncSQL("count", "", "", "", nil, false, sdl.FieldArgumentMap(f.Field, vars), params)
 				},
 			})
 			continue
@@ -788,7 +788,7 @@ func aggAggregationFieldNodes(ctx context.Context, e engines.EngineAggregator, d
 							}
 							factor = "(1. / " + factor + ")"
 						}
-						sql, params, err := e.AggregateFuncSQL(ac.Field.Name, sql, sp, factor, fd, false, ac.Field.ArgumentMap(vars), params)
+						sql, params, err := e.AggregateFuncSQL(ac.Field.Name, sql, sp, factor, fd, false, sdl.FieldArgumentMap(ac.Field, vars), params)
 						if err != nil {
 							return "", nil, err
 						}


### PR DESCRIPTION
Currently, the path argument in JSON aggregation functions (sum, count, avg, etc.) only accepts literal strings or whole-variable substitution (path: $Var). This makes it impossible to use a single GraphQL query for dynamic catalog selection like path: "gkh_capital_repair_$Year.fed_price".

This change adds $VarName interpolation inside string argument values passed to aggregation functions. When a path string contains $Year and the query variables include {"Year": 2026}, the path is resolved to "gkh_capital_repair_2026.fed_price" before SQL generation.

Example usage:

```
query ($GeozoneID: Int!, $Year: Int!) {
  gis {
    tf_geozones_by_pk(id: $GeozoneID) {
      _spatial(field: "geom", type: INTERSECTS) {
        tf_spatial_objects_view_aggregation(
          field: "geom"
          filter: { type_id: { eq: 1000089 } }
        ) {
          fed: attributes { sum(path: "gkh_capital_repair_$Year.fed_price") }
        }
      }
    }
  }
}
```