### PR TITLE
feat: function argument placeholders ([$auth.*], @arg_default)

### DIFF
--- a/client/app/README.md
+++ b/client/app/README.md
@@ -89,7 +89,41 @@ After connecting, your app is queryable:
 
 ## Options
 
-**Function options**: `Arg(name, type)`, `ArgDesc(name, type, desc)`, `Return(type)`, `Desc(description)`, `Mutation()`
+**Function options**: `Arg(name, type)`, `ArgDesc(name, type, desc)`, `ArgFromContext(name, type, placeholder)`, `Return(type)`, `Desc(description)`, `Mutation()`
+
+`ArgFromContext()` declares a server-injected function argument bound to a context placeholder. The argument is hidden from the GraphQL schema — clients cannot see or set it. At handler execution time, read it via `r.String(name)` / `r.Int64(name)` like any other argument.
+
+```go
+mux.HandleFunc("default", "my_orders",
+    func(w *app.Result, r *app.Request) error {
+        userID := r.String("user_id") // injected from auth context
+        limit := r.Int64("limit")
+        // ... fetch orders for userID ...
+        return w.Set("ok")
+    },
+    app.Arg("limit", app.Int64),
+    app.ArgFromContext("user_id", app.String, app.AuthUserID),
+    app.Return(app.String),
+)
+
+// GraphQL: { function { my_app { my_orders(limit: 10) } } }
+// Note: user_id is NOT in the schema — server-injected.
+```
+
+**Available placeholders** (typed `app.ContextPlaceholder` constants):
+
+| Constant | Resolves to |
+|----------|-------------|
+| `app.AuthUserID` | Authenticated user ID (string) |
+| `app.AuthUserIDInt` | Authenticated user ID parsed as integer |
+| `app.AuthUserName` | Authenticated user display name |
+| `app.AuthRole` | Authenticated role |
+| `app.AuthType` | Auth method (`apiKey`, `jwt`, `oidc`, etc.) |
+| `app.AuthProvider` | Auth provider name |
+| `app.AuthImpersonatedByRole` | Original role when impersonating |
+| `app.AuthImpersonatedByUserID` | Original user ID when impersonating |
+| `app.AuthImpersonatedByUserName` | Original user name when impersonating |
+| `app.Catalog` | Current catalog name |
 
 `Mutation()` marks a scalar function as a GraphQL mutation. Without it, the function is exposed as a query (extends `Function`); with it, the function extends `MutationFunction` and must be called via `mutation { ... }`. Use it for operations with side effects.
 

--- a/client/app/handler.go
+++ b/client/app/handler.go
@@ -49,6 +49,12 @@ type argDef struct {
 	name        string
 	typ         Type
 	description string
+
+	// contextValue, if non-empty, marks this argument as server-injected from
+	// a context placeholder (e.g. AuthUserID). The generated SDL emits an
+	// @arg_default directive on the argument, hugr filters it from clients,
+	// and the planner injects the resolved context value at request time.
+	contextValue ContextPlaceholder
 }
 
 type colDef struct {
@@ -60,7 +66,7 @@ type colDef struct {
 }
 
 type funcDef struct {
-	description string   // function description
+	description string // function description
 	args        []argDef
 	cols        []colDef // for table functions: result columns
 	retType     *Type    // for scalar functions: return type
@@ -101,6 +107,31 @@ func Return(typ Type) Option {
 func Mutation() Option {
 	return func(d *funcDef) {
 		d.isMutation = true
+	}
+}
+
+// ArgFromContext declares a function argument whose value is server-injected
+// from a context placeholder. The argument is hidden from the GraphQL schema —
+// clients cannot pass a value for it. At handler execution time, read it via
+// Request.String(name), Request.Int64(name), etc., the same as a regular argument.
+//
+// Use the predefined ContextPlaceholder constants (AuthUserID, AuthRole, etc.).
+// Passing an unknown placeholder fails at registration time.
+//
+// Example:
+//
+//	mux.HandleFunc("default", "my_orders", handler,
+//	    app.Arg("limit", app.Int64),
+//	    app.ArgFromContext("user_id", app.String, app.AuthUserID),
+//	    app.Return(app.String),
+//	)
+func ArgFromContext(name string, typ Type, placeholder ContextPlaceholder) Option {
+	return func(d *funcDef) {
+		d.args = append(d.args, argDef{
+			name:         name,
+			typ:          typ,
+			contextValue: placeholder,
+		})
 	}
 }
 
@@ -192,6 +223,9 @@ func registerScalarFunc(m *CatalogMux, schema, name string, handler HandlerFunc,
 	if def.retType == nil {
 		return fmt.Errorf("HandleFunc %s.%s: Return() option is required", schema, name)
 	}
+	if err := validateArgs(schema, name, def.args); err != nil {
+		return err
+	}
 
 	sf := &handlerScalarFunc{
 		funcName: strings.ToUpper(name),
@@ -215,6 +249,9 @@ func registerTableFunc(m *CatalogMux, schema, name string, handler HandlerFunc, 
 	if def.isMutation {
 		return fmt.Errorf("HandleTableFunc %s.%s: Mutation() is only valid for scalar functions", schema, name)
 	}
+	if err := validateArgs(schema, name, def.args); err != nil {
+		return err
+	}
 
 	tf := &handlerTableFunc{
 		funcName: strings.ToUpper(name),
@@ -223,6 +260,22 @@ func registerTableFunc(m *CatalogMux, schema, name string, handler HandlerFunc, 
 	}
 	tf.sdl = generateTableFuncSDL(schema, name, def)
 	m.TableFunc(schema, tf)
+	return nil
+}
+
+// validateArgs checks the function's argument list for duplicate names and
+// validates ArgFromContext placeholders against the known whitelist.
+func validateArgs(schema, name string, args []argDef) error {
+	seen := make(map[string]bool, len(args))
+	for _, a := range args {
+		if seen[a.name] {
+			return fmt.Errorf("%s.%s: duplicate argument name %q", schema, name, a.name)
+		}
+		seen[a.name] = true
+		if a.contextValue != "" && !IsKnownArgPlaceholder(a.contextValue) {
+			return fmt.Errorf("%s.%s: ArgFromContext placeholder %q is not a known context variable", schema, name, string(a.contextValue))
+		}
+	}
 	return nil
 }
 
@@ -360,8 +413,8 @@ func (f *handlerTableFunc) Execute(ctx context.Context, params []any, opts *cata
 		}
 	}()
 
-	rec := array.NewRecord(schema, arrays, int64(nRows))
-	return array.NewRecordReader(schema, []arrow.Record{rec})
+	rec := array.NewRecordBatch(schema, arrays, int64(nRows))
+	return array.NewRecordReader(schema, []arrow.RecordBatch{rec})
 }
 
 // --- Arrow helpers ---

--- a/client/app/mux_test.go
+++ b/client/app/mux_test.go
@@ -116,6 +116,46 @@ func TestMux_HandleTableFunc_MutationRejected(t *testing.T) {
 	}
 }
 
+func TestMux_ArgFromContext_InvalidPlaceholder(t *testing.T) {
+	mux := New()
+	err := mux.HandleFunc("default", "bad", func(w *Result, r *Request) error {
+		return nil
+	}, Return(String), ArgFromContext("user_id", String, ContextPlaceholder("[$invalid]")))
+	if err == nil {
+		t.Fatal("expected error for unknown placeholder")
+	}
+	if !strings.Contains(err.Error(), "not a known context variable") {
+		t.Errorf("error should mention unknown context variable, got: %v", err)
+	}
+}
+
+func TestMux_ArgFromContext_DuplicateName(t *testing.T) {
+	mux := New()
+	err := mux.HandleFunc("default", "bad", func(w *Result, r *Request) error {
+		return nil
+	},
+		Return(String),
+		Arg("user_id", String),
+		ArgFromContext("user_id", String, AuthUserID),
+	)
+	if err == nil {
+		t.Fatal("expected error for duplicate argument name")
+	}
+	if !strings.Contains(err.Error(), "duplicate argument") {
+		t.Errorf("error should mention duplicate argument, got: %v", err)
+	}
+}
+
+func TestMux_ArgFromContext_TableFunc_Allowed(t *testing.T) {
+	mux := New()
+	err := mux.HandleTableFunc("default", "ok", func(w *Result, r *Request) error {
+		return nil
+	}, ArgFromContext("user_id", String, AuthUserID), ColPK("id", Int64))
+	if err != nil {
+		t.Fatalf("ArgFromContext should be allowed on table functions, got error: %v", err)
+	}
+}
+
 func TestMux_Table_AutoSDL(t *testing.T) {
 	mux := New()
 

--- a/client/app/placeholders.go
+++ b/client/app/placeholders.go
@@ -1,0 +1,55 @@
+package app
+
+// ContextPlaceholder is a typed wrapper for server-side context placeholders
+// used with app.ArgFromContext. Use the predefined constants below — passing
+// a string that isn't in the recognized whitelist will fail at registration.
+type ContextPlaceholder string
+
+// Recognized context placeholders. The hugr planner resolves these via
+// perm.AuthVars(ctx) at request time. When the underlying value is unavailable
+// (e.g. unauthenticated request), the planner substitutes NULL.
+//
+// This list mirrors pkg/catalog/sdl/placeholders.go on the server side; keep
+// them in sync.
+const (
+	// AuthUserID — current user's ID as a string.
+	AuthUserID ContextPlaceholder = "[$auth.user_id]"
+	// AuthUserIDInt — current user's ID parsed as integer.
+	AuthUserIDInt ContextPlaceholder = "[$auth.user_id_int]"
+	// AuthUserName — current user's display name.
+	AuthUserName ContextPlaceholder = "[$auth.user_name]"
+	// AuthRole — current authenticated role.
+	AuthRole ContextPlaceholder = "[$auth.role]"
+	// AuthType — auth method (e.g. "apiKey", "jwt", "oidc", "impersonation").
+	AuthType ContextPlaceholder = "[$auth.auth_type]"
+	// AuthProvider — auth provider name.
+	AuthProvider ContextPlaceholder = "[$auth.provider]"
+	// AuthImpersonatedByRole — original role when impersonating.
+	AuthImpersonatedByRole ContextPlaceholder = "[$auth.impersonated_by_role]"
+	// AuthImpersonatedByUserID — original user ID when impersonating.
+	AuthImpersonatedByUserID ContextPlaceholder = "[$auth.impersonated_by_user_id]"
+	// AuthImpersonatedByUserName — original user name when impersonating.
+	AuthImpersonatedByUserName ContextPlaceholder = "[$auth.impersonated_by_user_name]"
+	// Catalog — current catalog name.
+	Catalog ContextPlaceholder = "[$catalog]"
+)
+
+// knownArgPlaceholders is the validation set used by ArgFromContext.
+var knownArgPlaceholders = map[ContextPlaceholder]bool{
+	AuthUserID:                 true,
+	AuthUserIDInt:              true,
+	AuthUserName:               true,
+	AuthRole:                   true,
+	AuthType:                   true,
+	AuthProvider:               true,
+	AuthImpersonatedByRole:     true,
+	AuthImpersonatedByUserID:   true,
+	AuthImpersonatedByUserName: true,
+	Catalog:                    true,
+}
+
+// IsKnownArgPlaceholder reports whether the given context placeholder is in
+// the recognized whitelist for app.ArgFromContext.
+func IsKnownArgPlaceholder(p ContextPlaceholder) bool {
+	return knownArgPlaceholders[p]
+}

--- a/client/app/placeholders.go
+++ b/client/app/placeholders.go
@@ -30,8 +30,6 @@ const (
 	AuthImpersonatedByUserID ContextPlaceholder = "[$auth.impersonated_by_user_id]"
 	// AuthImpersonatedByUserName — original user name when impersonating.
 	AuthImpersonatedByUserName ContextPlaceholder = "[$auth.impersonated_by_user_name]"
-	// Catalog — current catalog name.
-	Catalog ContextPlaceholder = "[$catalog]"
 )
 
 // knownArgPlaceholders is the validation set used by ArgFromContext.
@@ -45,7 +43,6 @@ var knownArgPlaceholders = map[ContextPlaceholder]bool{
 	AuthImpersonatedByRole:     true,
 	AuthImpersonatedByUserID:   true,
 	AuthImpersonatedByUserName: true,
-	Catalog:                    true,
 }
 
 // IsKnownArgPlaceholder reports whether the given context placeholder is in

--- a/client/app/sdl_gen.go
+++ b/client/app/sdl_gen.go
@@ -146,6 +146,14 @@ func moduleDirective(moduleName string) *ast.Directive {
 	}
 }
 
+// argDefaultDirective creates @arg_default(value: "...") for server-injected arguments.
+func argDefaultDirective(placeholder ContextPlaceholder) *ast.Directive {
+	return &ast.Directive{
+		Name:      "arg_default",
+		Arguments: ast.ArgumentList{{Name: "value", Value: strVal(string(placeholder))}},
+	}
+}
+
 // --- Generators for handler.go ---
 
 // generateScalarFuncSDL generates SDL for a scalar function using gqlparser AST.
@@ -164,11 +172,18 @@ func generateScalarFuncSDL(schema, name string, def *funcDef) string {
 		Directives:  directives,
 	}
 	for _, a := range def.args {
-		field.Arguments = append(field.Arguments, &ast.ArgumentDefinition{
+		// Server-injected args via @arg_default are nullable in the public schema
+		// (clients never set them; the planner injects the value or NULL).
+		nonNull := a.contextValue == ""
+		argDef := &ast.ArgumentDefinition{
 			Name:        a.name,
 			Description: a.description,
-			Type:        gqlType(a.typ.graphql, true),
-		})
+			Type:        gqlType(a.typ.graphql, nonNull),
+		}
+		if a.contextValue != "" {
+			argDef.Directives = append(argDef.Directives, argDefaultDirective(a.contextValue))
+		}
+		field.Arguments = append(field.Arguments, argDef)
 	}
 
 	// extend type Function (or MutationFunction for mutation-flagged scalar functions) { ... }
@@ -203,11 +218,17 @@ func generateTableFuncSDL(schema, name string, def *funcDef) string {
 			Name: inputTypeName,
 		}
 		for _, a := range def.args {
-			inputDef.Fields = append(inputDef.Fields, &ast.FieldDefinition{
+			// Server-injected args via @arg_default are nullable in the public schema.
+			nonNull := a.contextValue == ""
+			fd := &ast.FieldDefinition{
 				Name:        a.name,
 				Description: a.description,
-				Type:        gqlType(a.typ.graphql, true),
-			})
+				Type:        gqlType(a.typ.graphql, nonNull),
+			}
+			if a.contextValue != "" {
+				fd.Directives = append(fd.Directives, argDefaultDirective(a.contextValue))
+			}
+			inputDef.Fields = append(inputDef.Fields, fd)
 		}
 		defs = append(defs, inputDef)
 	}

--- a/client/app/sdl_gen_test.go
+++ b/client/app/sdl_gen_test.go
@@ -338,6 +338,82 @@ func TestGenerateScalarFuncSDL_Mutation_NamedSchema(t *testing.T) {
 	mustContain(t, sdl, `@function(name: "\"admin\".\"RESET\""`)
 }
 
+func TestGenerateScalarFuncSDL_ArgFromContext(t *testing.T) {
+	retType := String
+	def := &funcDef{
+		description: "Get current user's display name",
+		args: []argDef{
+			{name: "user_id", typ: String, contextValue: AuthUserID},
+		},
+		retType: &retType,
+	}
+
+	sdl := generateScalarFuncSDL("default", "whoami", def)
+	mustContain(t, sdl, "extend type Function")
+	// Server-injected args are nullable (clients never set them)
+	mustContain(t, sdl, "user_id: String")
+	mustNotContain(t, sdl, "user_id: String!")
+	mustContain(t, sdl, `@arg_default(value: "[$auth.user_id]")`)
+}
+
+func TestGenerateScalarFuncSDL_MixedArgs(t *testing.T) {
+	retType := String
+	def := &funcDef{
+		args: []argDef{
+			{name: "limit", typ: Int64},
+			{name: "user_id", typ: String, contextValue: AuthUserID},
+			{name: "role", typ: String, contextValue: AuthRole},
+		},
+		retType: &retType,
+	}
+
+	sdl := generateScalarFuncSDL("default", "my_orders", def)
+	mustContain(t, sdl, "limit: BigInt!")  // regular arg stays non-null
+	mustContain(t, sdl, "user_id: String") // server-injected, nullable
+	mustContain(t, sdl, "role: String")    // server-injected, nullable
+	mustNotContain(t, sdl, "user_id: String!")
+	mustNotContain(t, sdl, "role: String!")
+	mustContain(t, sdl, `@arg_default(value: "[$auth.user_id]")`)
+	mustContain(t, sdl, `@arg_default(value: "[$auth.role]")`)
+}
+
+func TestGenerateScalarFuncSDL_ArgFromContext_NamedSchema(t *testing.T) {
+	retType := Int64
+	def := &funcDef{
+		args: []argDef{
+			{name: "user_id", typ: String, contextValue: AuthUserID},
+		},
+		retType: &retType,
+	}
+
+	sdl := generateScalarFuncSDL("admin", "audit", def)
+	mustContain(t, sdl, "extend type Function")
+	mustContain(t, sdl, `@module(name: "admin")`)
+	mustContain(t, sdl, `@arg_default(value: "[$auth.user_id]")`)
+}
+
+func TestGenerateTableFuncSDL_ArgFromContext(t *testing.T) {
+	def := &funcDef{
+		args: []argDef{
+			{name: "limit", typ: Int64},
+			{name: "user_id", typ: String, contextValue: AuthUserID},
+		},
+		cols: []colDef{
+			{name: "id", typ: Int64, pk: true},
+			{name: "title", typ: String},
+		},
+	}
+
+	sdl := generateTableFuncSDL("default", "my_items", def)
+	// Input type contains both regular and context args
+	mustContain(t, sdl, "input my_items_args")
+	mustContain(t, sdl, "limit: BigInt!")
+	// Server-injected args are nullable
+	mustContain(t, sdl, "user_id: String")
+	mustNotContain(t, sdl, "user_id: String!")
+	mustContain(t, sdl, `@arg_default(value: "[$auth.user_id]")`)
+}
+
 // --- Table function SDL (parameterized view) ---
 
 func TestGenerateTableFuncSDL(t *testing.T) {

--- a/integration-test/e2e-hugrapp/run.sh
+++ b/integration-test/e2e-hugrapp/run.sh
@@ -34,6 +34,26 @@ run_test() {
     fi
 }
 
+run_test_not_contains() {
+    local name="$1"
+    local query="$2"
+    local forbidden="$3"
+
+    result=$(curl -sf -X POST "$HUGR_URL/query" \
+        -H "Content-Type: application/json" \
+        -d "{\"query\": \"$query\"}" 2>/dev/null || echo "CURL_FAILED")
+
+    if echo "$result" | grep -q "$forbidden"; then
+        echo "  FAIL: $name"
+        echo "    Did NOT expect to contain: $forbidden"
+        echo "    Got: $result"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+    fi
+}
+
 echo ""
 echo "=== Happy path tests ==="
 echo ""
@@ -92,6 +112,23 @@ run_test "mutation function not callable as query" \
 run_test "admin module mutation reset_counter" \
     'mutation { function { test_app { admin { reset_counter } } } }' \
     '"reset_counter":0'
+
+# ArgFromContext tests (server-injected args via @arg_default)
+run_test "app function whoami_ctx (auth context injected)" \
+    '{ function { test_app { whoami_ctx } } }' \
+    '"whoami_ctx":"anonymous:admin"'
+
+run_test_not_contains "whoami_ctx hides user_id arg from introspection" \
+    '{ __type(name: \"function_test_app\") { fields { name args { name } } } }' \
+    'user_id'
+
+run_test "whoami_ctx rejects client-supplied server-injected arg" \
+    '{ function { test_app { whoami_ctx(user_id: \"attacker\") } } }' \
+    'error'
+
+run_test "admin module audit_ctx with @arg_default in named schema" \
+    '{ function { test_app { admin { audit_ctx } } } }' \
+    '"audit_ctx":"audit:anonymous:admin"'
 
 # HugrSchema test (custom SDL for DS — has payload field with description)
 run_test "app DS with HugrSchema (custom SDL)" \

--- a/integration-test/e2e-hugrapp/test-app/main.go
+++ b/integration-test/e2e-hugrapp/test-app/main.go
@@ -194,6 +194,23 @@ func (a *TestApp) Catalog(ctx context.Context) (catalog.Catalog, error) {
 		return nil, err
 	}
 
+	// whoami_ctx: scalar function with two server-injected arguments via
+	// ArgFromContext. The arguments are hidden from the GraphQL schema; the
+	// hugr planner injects [$auth.user_id] and [$auth.role] at request time.
+	err = mux.HandleFunc("default", "whoami_ctx", func(w *app.Result, r *app.Request) error {
+		userID := r.String("user_id")
+		role := r.String("role")
+		return w.Set(fmt.Sprintf("%s:%s", userID, role))
+	},
+		app.Desc("Return the caller's identity from auth context"),
+		app.ArgFromContext("user_id", app.String, app.AuthUserID),
+		app.ArgFromContext("role", app.String, app.AuthRole),
+		app.Return(app.String),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	mux.Table("default", &staticTable{})
 
 	// Table function: search(query) returns filtered items
@@ -233,6 +250,22 @@ func (a *TestApp) Catalog(ctx context.Context) (catalog.Catalog, error) {
 		app.Desc("Reset the counter (admin mutation)"),
 		app.Return(app.Int64),
 		app.Mutation(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// audit_ctx: ArgFromContext in a named schema — verifies @module + @arg_default
+	// together. Returns the impersonating user's identity if available, else current.
+	err = mux.HandleFunc("admin", "audit_ctx", func(w *app.Result, r *app.Request) error {
+		userID := r.String("user_id")
+		role := r.String("role")
+		return w.Set(fmt.Sprintf("audit:%s:%s", userID, role))
+	},
+		app.Desc("Audit caller identity (admin module)"),
+		app.ArgFromContext("user_id", app.String, app.AuthUserID),
+		app.ArgFromContext("role", app.String, app.AuthRole),
+		app.Return(app.String),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/catalog/compiler/base/base.graphql
+++ b/pkg/catalog/compiler/base/base.graphql
@@ -10,6 +10,16 @@ directive @function(
 	json_cast: Boolean
 ) on FIELD_DEFINITION
 
+# Bind a function/view argument to a server-injected context placeholder.
+# The argument is hidden from clients (introspection, MCP, validation) and the
+# resolved context value is injected into the function call SQL at request time.
+# Allowed values are limited to a whitelist of known placeholders, see
+# pkg/catalog/sdl/placeholders.go.
+directive @arg_default(
+	"Context placeholder expression, e.g. \"[$auth.user_id]\""
+	value: String!
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
 
 # Mark object as table in the datasource
 directive @table(

--- a/pkg/catalog/compiler/base/constants.go
+++ b/pkg/catalog/compiler/base/constants.go
@@ -36,6 +36,7 @@ const (
 	QueryDirectiveName                     = "query"
 	MutationDirectiveName                  = "mutation"
 	FunctionDirectiveName                  = "function"
+	ArgDefaultDirectiveName                = "arg_default"
 	FunctionCallDirectiveName              = "function_call"
 	FunctionCallTableJoinDirectiveName     = "table_function_call_join"
 	JoinDirectiveName                      = "join"
@@ -246,4 +247,5 @@ const (
 	ArgLen                   = "len"
 	ArgSRID                  = "srid"
 	ArgArgs                  = "args"
+	ArgValue                 = "value"
 )

--- a/pkg/catalog/compiler/rules/validate_arg_default_test.go
+++ b/pkg/catalog/compiler/rules/validate_arg_default_test.go
@@ -1,0 +1,248 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func argDefaultPos() *ast.Position {
+	return &ast.Position{Src: &ast.Source{Name: "test"}}
+}
+
+func argDefaultDirective(value string) *ast.Directive {
+	return &ast.Directive{
+		Name:     base.ArgDefaultDirectiveName,
+		Position: argDefaultPos(),
+		Arguments: ast.ArgumentList{
+			{
+				Name: base.ArgValue,
+				Value: &ast.Value{
+					Raw:      value,
+					Kind:     ast.StringValue,
+					Position: argDefaultPos(),
+				},
+				Position: argDefaultPos(),
+			},
+		},
+	}
+}
+
+func TestValidateArgDefaults_OnFunctionField(t *testing.T) {
+	def := &ast.Definition{
+		Kind: ast.Object,
+		Name: "Function",
+		Fields: ast.FieldList{
+			{
+				Name:     "list_my_orders",
+				Position: argDefaultPos(),
+				Directives: ast.DirectiveList{
+					{Name: base.FunctionDirectiveName, Position: argDefaultPos()},
+				},
+				Arguments: ast.ArgumentDefinitionList{
+					{
+						Name:     "user_id",
+						Type:     ast.NamedType("String", argDefaultPos()),
+						Position: argDefaultPos(),
+						Directives: ast.DirectiveList{
+							argDefaultDirective("[$auth.user_id]"),
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := validateArgDefaults(def); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateArgDefaults_UnknownPlaceholder(t *testing.T) {
+	def := &ast.Definition{
+		Kind: ast.Object,
+		Name: "Function",
+		Fields: ast.FieldList{
+			{
+				Name:     "bad",
+				Position: argDefaultPos(),
+				Directives: ast.DirectiveList{
+					{Name: base.FunctionDirectiveName, Position: argDefaultPos()},
+				},
+				Arguments: ast.ArgumentDefinitionList{
+					{
+						Name:     "x",
+						Type:     ast.NamedType("String", argDefaultPos()),
+						Position: argDefaultPos(),
+						Directives: ast.DirectiveList{
+							argDefaultDirective("[$typo.user_id]"),
+						},
+					},
+				},
+			},
+		},
+	}
+	err := validateArgDefaults(def)
+	if err == nil {
+		t.Fatal("expected error for unknown placeholder")
+	}
+	if !strings.Contains(err.Error(), "not a known context variable") {
+		t.Errorf("error should mention unknown placeholder, got: %v", err)
+	}
+}
+
+func TestValidateArgDefaults_DefaultValueCollision(t *testing.T) {
+	def := &ast.Definition{
+		Kind: ast.Object,
+		Name: "Function",
+		Fields: ast.FieldList{
+			{
+				Name:     "bad",
+				Position: argDefaultPos(),
+				Directives: ast.DirectiveList{
+					{Name: base.FunctionDirectiveName, Position: argDefaultPos()},
+				},
+				Arguments: ast.ArgumentDefinitionList{
+					{
+						Name:         "x",
+						Type:         ast.NamedType("String", argDefaultPos()),
+						Position:     argDefaultPos(),
+						DefaultValue: &ast.Value{Raw: "static", Kind: ast.StringValue, Position: argDefaultPos()},
+						Directives: ast.DirectiveList{
+							argDefaultDirective("[$auth.user_id]"),
+						},
+					},
+				},
+			},
+		},
+	}
+	err := validateArgDefaults(def)
+	if err == nil {
+		t.Fatal("expected error for default+arg_default collision")
+	}
+	if !strings.Contains(err.Error(), "default value") {
+		t.Errorf("error should mention default value collision, got: %v", err)
+	}
+}
+
+func TestValidateArgDefaults_OnNonFunctionField(t *testing.T) {
+	// @arg_default on a regular table field's argument — should be rejected.
+	def := &ast.Definition{
+		Kind: ast.Object,
+		Name: "users",
+		Directives: ast.DirectiveList{
+			{Name: base.ObjectTableDirectiveName, Position: argDefaultPos()},
+		},
+		Fields: ast.FieldList{
+			{
+				Name:     "name",
+				Position: argDefaultPos(),
+				Type:     ast.NamedType("String", argDefaultPos()),
+				Arguments: ast.ArgumentDefinitionList{
+					{
+						Name:     "filter",
+						Type:     ast.NamedType("String", argDefaultPos()),
+						Position: argDefaultPos(),
+						Directives: ast.DirectiveList{
+							argDefaultDirective("[$auth.user_id]"),
+						},
+					},
+				},
+			},
+		},
+	}
+	err := validateArgDefaults(def)
+	if err == nil {
+		t.Fatal("expected error for @arg_default on non-function field")
+	}
+	if !strings.Contains(err.Error(), "only valid on arguments of fields with @function") {
+		t.Errorf("error should mention function-only restriction, got: %v", err)
+	}
+}
+
+func TestValidateArgDefaults_OnFunctionCallField(t *testing.T) {
+	// @function_call field IS allowed.
+	def := &ast.Definition{
+		Kind: ast.Object,
+		Name: "users",
+		Fields: ast.FieldList{
+			{
+				Name:     "orders",
+				Position: argDefaultPos(),
+				Type:     ast.NamedType("Order", argDefaultPos()),
+				Directives: ast.DirectiveList{
+					{Name: base.FunctionCallDirectiveName, Position: argDefaultPos()},
+				},
+				Arguments: ast.ArgumentDefinitionList{
+					{
+						Name:     "user_id",
+						Type:     ast.NamedType("String", argDefaultPos()),
+						Position: argDefaultPos(),
+						Directives: ast.DirectiveList{
+							argDefaultDirective("[$auth.user_id]"),
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := validateArgDefaults(def); err != nil {
+		t.Errorf("expected no error for @arg_default on @function_call, got: %v", err)
+	}
+}
+
+func TestValidateArgDefaults_OnInputObjectField(t *testing.T) {
+	// @arg_default on input field of an args input type — allowed.
+	def := &ast.Definition{
+		Kind: ast.InputObject,
+		Name: "my_view_args",
+		Fields: ast.FieldList{
+			{
+				Name:     "user_id",
+				Type:     ast.NamedType("String", argDefaultPos()),
+				Position: argDefaultPos(),
+				Directives: ast.DirectiveList{
+					argDefaultDirective("[$auth.user_id]"),
+				},
+			},
+		},
+	}
+	if err := validateArgDefaults(def); err != nil {
+		t.Errorf("expected no error for @arg_default on input field, got: %v", err)
+	}
+}
+
+func TestValidateArgDefaults_CatalogPlaceholderRejected(t *testing.T) {
+	// [$catalog] is intentionally NOT in the @arg_default whitelist.
+	def := &ast.Definition{
+		Kind: ast.Object,
+		Name: "Function",
+		Fields: ast.FieldList{
+			{
+				Name:     "bad",
+				Position: argDefaultPos(),
+				Directives: ast.DirectiveList{
+					{Name: base.FunctionDirectiveName, Position: argDefaultPos()},
+				},
+				Arguments: ast.ArgumentDefinitionList{
+					{
+						Name:     "cat",
+						Type:     ast.NamedType("String", argDefaultPos()),
+						Position: argDefaultPos(),
+						Directives: ast.DirectiveList{
+							argDefaultDirective("[$catalog]"),
+						},
+					},
+				},
+			},
+		},
+	}
+	err := validateArgDefaults(def)
+	if err == nil {
+		t.Fatal("expected error: [$catalog] not allowed in @arg_default")
+	}
+	if !strings.Contains(err.Error(), "not a known context variable") {
+		t.Errorf("error should mention unknown placeholder, got: %v", err)
+	}
+}

--- a/pkg/catalog/compiler/rules/validate_definitions.go
+++ b/pkg/catalog/compiler/rules/validate_definitions.go
@@ -29,9 +29,6 @@ func (r *DefinitionValidator) ProcessAll(ctx base.CompilationContext) error {
 			if err := validateFunctionSQL(def); err != nil {
 				return err
 			}
-			if err := validateArgDefaultsOnFunction(def); err != nil {
-				return err
-			}
 		}
 		// Validate @view + @args consistency
 		if def.Directives.ForName(base.ObjectViewDirectiveName) != nil && def.Directives.ForName(base.ViewArgsDirectiveName) != nil {
@@ -39,40 +36,22 @@ func (r *DefinitionValidator) ProcessAll(ctx base.CompilationContext) error {
 				return err
 			}
 		}
-		// Validate @arg_default on input type fields (used by parameterized view args input types)
-		if def.Kind == ast.InputObject {
-			if err := validateArgDefaultsOnInput(def); err != nil {
-				return err
-			}
+		// Validate @arg_default on field arguments and on input type fields.
+		// Catches all definitions — fields with @function/@function_call/
+		// @table_function_call_join, plus input types used as @args(name:).
+		if err := validateArgDefaults(def); err != nil {
+			return err
 		}
 	}
-	// Also validate extensions (e.g. "extend type Function { ... }" kept separate
-	// by ExtensionsSource). Only Function/MutationFunction SQL validation applies.
+	// Also validate extensions for SQL refs and @arg_default usage.
 	if extSrc, ok := ctx.Source().(base.ExtensionsSource); ok {
 		for ext := range extSrc.Extensions(ctx.Context()) {
 			if ext.Name == "Function" || ext.Name == "MutationFunction" {
 				if err := validateFunctionSQL(ext); err != nil {
 					return err
 				}
-				if err := validateArgDefaultsOnFunction(ext); err != nil {
-					return err
-				}
 			}
-		}
-	}
-	return nil
-}
-
-// validateArgDefaultsOnFunction validates @arg_default directives on arguments of
-// fields belonging to Function/MutationFunction types. Each placeholder must be in
-// the whitelist, and the argument must not have a GraphQL default value.
-func validateArgDefaultsOnFunction(def *ast.Definition) error {
-	for _, field := range def.Fields {
-		if field.Directives.ForName(base.FunctionDirectiveName) == nil {
-			continue
-		}
-		for _, arg := range field.Arguments {
-			if err := validateArgDefaultDirective(arg.Directives.ForName(base.ArgDefaultDirectiveName), arg.Name, arg.DefaultValue, arg.Position); err != nil {
+			if err := validateArgDefaults(ext); err != nil {
 				return err
 			}
 		}
@@ -80,11 +59,45 @@ func validateArgDefaultsOnFunction(def *ast.Definition) error {
 	return nil
 }
 
-// validateArgDefaultsOnInput validates @arg_default directives on input object fields.
-func validateArgDefaultsOnInput(def *ast.Definition) error {
+// validateArgDefaults walks a type definition and validates every @arg_default
+// directive it contains:
+//
+//   - On field arguments: only allowed when the field has @function,
+//     @function_call, or @table_function_call_join.
+//   - On input type fields: always allowed (input types are validated by
+//     consumers like @args(name:)).
+//
+// Each directive's value must be a known placeholder, and the underlying
+// argument/field must not have a GraphQL default value.
+func validateArgDefaults(def *ast.Definition) error {
+	if def.Kind == ast.InputObject {
+		for _, field := range def.Fields {
+			if err := validateArgDefaultDirective(
+				field.Directives.ForName(base.ArgDefaultDirectiveName),
+				field.Name, field.DefaultValue, field.Position,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 	for _, field := range def.Fields {
-		if err := validateArgDefaultDirective(field.Directives.ForName(base.ArgDefaultDirectiveName), field.Name, field.DefaultValue, field.Position); err != nil {
-			return err
+		isFunctionLike := field.Directives.ForName(base.FunctionDirectiveName) != nil ||
+			field.Directives.ForName(base.FunctionCallDirectiveName) != nil ||
+			field.Directives.ForName(base.FunctionCallTableJoinDirectiveName) != nil
+		for _, arg := range field.Arguments {
+			d := arg.Directives.ForName(base.ArgDefaultDirectiveName)
+			if d == nil {
+				continue
+			}
+			if !isFunctionLike {
+				return gqlerror.ErrorPosf(d.Position,
+					"@arg_default on %s.%s argument %q: only valid on arguments of fields with @function, @function_call, or @table_function_call_join",
+					def.Name, field.Name, arg.Name)
+			}
+			if err := validateArgDefaultDirective(d, arg.Name, arg.DefaultValue, arg.Position); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/catalog/compiler/rules/validate_definitions.go
+++ b/pkg/catalog/compiler/rules/validate_definitions.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
+	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
 	"github.com/hugr-lab/query-engine/pkg/catalog/types"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -28,10 +29,19 @@ func (r *DefinitionValidator) ProcessAll(ctx base.CompilationContext) error {
 			if err := validateFunctionSQL(def); err != nil {
 				return err
 			}
+			if err := validateArgDefaultsOnFunction(def); err != nil {
+				return err
+			}
 		}
 		// Validate @view + @args consistency
 		if def.Directives.ForName(base.ObjectViewDirectiveName) != nil && def.Directives.ForName(base.ViewArgsDirectiveName) != nil {
 			if err := validateViewArgs(ctx, def); err != nil {
+				return err
+			}
+		}
+		// Validate @arg_default on input type fields (used by parameterized view args input types)
+		if def.Kind == ast.InputObject {
+			if err := validateArgDefaultsOnInput(def); err != nil {
 				return err
 			}
 		}
@@ -44,8 +54,58 @@ func (r *DefinitionValidator) ProcessAll(ctx base.CompilationContext) error {
 				if err := validateFunctionSQL(ext); err != nil {
 					return err
 				}
+				if err := validateArgDefaultsOnFunction(ext); err != nil {
+					return err
+				}
 			}
 		}
+	}
+	return nil
+}
+
+// validateArgDefaultsOnFunction validates @arg_default directives on arguments of
+// fields belonging to Function/MutationFunction types. Each placeholder must be in
+// the whitelist, and the argument must not have a GraphQL default value.
+func validateArgDefaultsOnFunction(def *ast.Definition) error {
+	for _, field := range def.Fields {
+		if field.Directives.ForName(base.FunctionDirectiveName) == nil {
+			continue
+		}
+		for _, arg := range field.Arguments {
+			if err := validateArgDefaultDirective(arg.Directives.ForName(base.ArgDefaultDirectiveName), arg.Name, arg.DefaultValue, arg.Position); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// validateArgDefaultsOnInput validates @arg_default directives on input object fields.
+func validateArgDefaultsOnInput(def *ast.Definition) error {
+	for _, field := range def.Fields {
+		if err := validateArgDefaultDirective(field.Directives.ForName(base.ArgDefaultDirectiveName), field.Name, field.DefaultValue, field.Position); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateArgDefaultDirective(d *ast.Directive, name string, defaultValue *ast.Value, pos *ast.Position) error {
+	if d == nil {
+		return nil
+	}
+	value := base.DirectiveArgString(d, base.ArgValue)
+	if value == "" {
+		return gqlerror.ErrorPosf(d.Position,
+			"@arg_default on %q: value is required", name)
+	}
+	if !sdl.IsKnownPlaceholder(value) {
+		return gqlerror.ErrorPosf(d.Position,
+			"@arg_default on %q: placeholder %q is not a known context variable", name, value)
+	}
+	if defaultValue != nil {
+		return gqlerror.ErrorPosf(pos,
+			"@arg_default on %q: argument cannot have both default value and @arg_default directive", name)
 	}
 	return nil
 }

--- a/pkg/catalog/sdl/functions.go
+++ b/pkg/catalog/sdl/functions.go
@@ -17,6 +17,11 @@ type Function struct {
 	JsonCast     bool
 	SkipNullArg  bool
 
+	// ArgDefaults maps argument name → context placeholder expression for
+	// arguments declared with @arg_default. The planner resolves these from
+	// perm.AuthVars(ctx) at request time and injects the value into the SQL call.
+	ArgDefaults map[string]string
+
 	sql   string
 	field *ast.FieldDefinition
 }
@@ -37,9 +42,32 @@ func FunctionInfo(field *ast.FieldDefinition) (*Function, error) {
 		SkipNullArg:  base.DirectiveArgString(d, base.ArgSkipNullArg) == "true" && len(field.Arguments) == 1,
 		JsonCast:     !isTable && base.FieldDefDirectiveArgString(field, base.FunctionDirectiveName, base.ArgJsonCast) == "true",
 		ReturnsTable: isTable,
+		ArgDefaults:  collectArgDefaults(field.Arguments),
 		sql:          base.DirectiveArgString(d, base.ArgSQL),
 		field:        field,
 	}, nil
+}
+
+// collectArgDefaults walks an argument definition list and returns a map of
+// argument name → @arg_default placeholder expression. Returns nil if no
+// argument has the directive.
+func collectArgDefaults(args ast.ArgumentDefinitionList) map[string]string {
+	var out map[string]string
+	for _, a := range args {
+		d := a.Directives.ForName(base.ArgDefaultDirectiveName)
+		if d == nil {
+			continue
+		}
+		value := base.DirectiveArgString(d, base.ArgValue)
+		if value == "" {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string)
+		}
+		out[a.Name] = value
+	}
+	return out
 }
 
 func (f *Function) Definition() *ast.FieldDefinition {
@@ -300,6 +328,15 @@ func (f *FunctionCall) JoinConditionsTemplate() string {
 func (f *FunctionCall) ArgumentValues(ctx context.Context, defs base.DefinitionsSource, vars map[string]any) (FieldQueryArguments, error) {
 	args := make([]FieldQueryArgument, 0, len(f.query.Definition.Arguments))
 	for _, def := range f.query.Definition.Arguments {
+		// Skip arguments declared with @arg_default — their values are server-injected
+		// by the planner before this function runs. Reject client overrides.
+		if def.Directives.ForName(base.ArgDefaultDirectiveName) != nil {
+			if f.query.Arguments.ForName(def.Name) != nil {
+				return nil, ErrorPosf(f.query.Position,
+					"argument %q is server-injected and cannot be set by client", def.Name)
+			}
+			continue
+		}
 		arg := f.query.Arguments.ForName(def.Name)
 		if arg == nil && def.DefaultValue == nil {
 			if def.Type.NonNull {

--- a/pkg/catalog/sdl/objects.go
+++ b/pkg/catalog/sdl/objects.go
@@ -157,8 +157,8 @@ type sqlBuilder interface {
 	FunctionCall(name string, positional []any, named map[string]any) (string, error)
 }
 
-func (info *Object) ApplyArguments(ctx context.Context, defs base.DefinitionsSource, args map[string]any, builder sqlBuilder) (err error) {
-	if !info.HasArguments() || len(args) == 0 {
+func (info *Object) ApplyArguments(ctx context.Context, defs base.DefinitionsSource, args map[string]any, builder sqlBuilder, contextVars map[string]any) (err error) {
+	if !info.HasArguments() {
 		return nil
 	}
 	it := defs.ForName(ctx, info.InputArgsName)
@@ -166,10 +166,46 @@ func (info *Object) ApplyArguments(ctx context.Context, defs base.DefinitionsSou
 		return ErrorPosf(info.def.Position, "input object %s not found", info.InputArgsName)
 	}
 
+	// Backward-compatible early exit: when there are no client-provided args AND
+	// the input type has no @arg_default fields, the original behavior was to
+	// leave the template untouched. Preserve this unless the view template
+	// also references an [$auth.*] / [$catalog] placeholder that needs resolving.
+	if len(args) == 0 && !inputHasArgDefault(it) && !sqlHasContextPlaceholder(info.sql) {
+		return nil
+	}
+
 	var posArgs []any
 	namedArgs := make(map[string]any)
 
 	for _, field := range it.Fields {
+		// Server-injected fields: client cannot pass a value; resolve from context vars.
+		if d := field.Directives.ForName(base.ArgDefaultDirectiveName); d != nil {
+			if _, provided := args[field.Name]; provided {
+				return ErrorPosf(field.Position,
+					"argument %q is server-injected and cannot be set by client", field.Name)
+			}
+			placeholder := base.DirectiveArgString(d, base.ArgValue)
+			val := contextVars[placeholder]
+			if info.sql != "" {
+				sv, sverr := builder.SQLValue(val)
+				if sverr != nil {
+					return ErrorPosf(field.Position, "wrong context value for %s: %s", field.Name, sverr.Error())
+				}
+				info.sql = strings.ReplaceAll(info.sql, "[$"+field.Name+"]", sv)
+				continue
+			}
+			if nd := field.Directives.ForName(base.InputFieldNamedArgDirectiveName); nd != nil {
+				name := field.Name
+				if fn := base.DirectiveArgString(nd, base.ArgName); fn != "" {
+					name = fn
+				}
+				namedArgs[name] = val
+				continue
+			}
+			posArgs = append(posArgs, val)
+			continue
+		}
+
 		val := args[field.Name]
 		if val == nil && field.Type.NonNull {
 			return ErrorPosf(field.Position, "argument %s is required", field.Name)
@@ -193,11 +229,47 @@ func (info *Object) ApplyArguments(ctx context.Context, defs base.DefinitionsSou
 		posArgs = append(posArgs, val)
 	}
 	if info.sql != "" {
+		// Substitute any remaining context placeholders ([$auth.*], [$catalog]) embedded
+		// directly in the @view(sql:) template.
+		for placeholder, value := range contextVars {
+			if !strings.Contains(info.sql, placeholder) {
+				continue
+			}
+			sv, sverr := builder.SQLValue(value)
+			if sverr != nil {
+				return ErrorPosf(info.def.Position, "wrong context value for placeholder %s: %s", placeholder, sverr.Error())
+			}
+			info.sql = strings.ReplaceAll(info.sql, placeholder, sv)
+		}
 		return nil
 	}
 	info.sql, err = builder.FunctionCall(info.Name, posArgs, namedArgs)
 	info.functionCall = true
 	return err
+}
+
+// inputHasArgDefault returns true if any field of the input type has @arg_default.
+func inputHasArgDefault(def *ast.Definition) bool {
+	for _, f := range def.Fields {
+		if f.Directives.ForName(base.ArgDefaultDirectiveName) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// sqlHasContextPlaceholder returns true if the SQL string contains any known
+// context placeholder ([$auth.*], [$catalog]).
+func sqlHasContextPlaceholder(sql string) bool {
+	if sql == "" {
+		return false
+	}
+	for placeholder := range KnownArgPlaceholders {
+		if strings.Contains(sql, placeholder) {
+			return true
+		}
+	}
+	return false
 }
 
 func (info *Object) SQL(ctx context.Context, prefix string) string {

--- a/pkg/catalog/sdl/placeholders.go
+++ b/pkg/catalog/sdl/placeholders.go
@@ -1,0 +1,28 @@
+package sdl
+
+// KnownArgPlaceholders is the whitelist of context-variable placeholders that
+// are allowed in @function(sql: "...") templates and @arg_default directives.
+//
+// At request time, the planner resolves these via perm.AuthVars(ctx). When the
+// underlying value is unavailable (e.g. unauthenticated request, no
+// impersonation), the planner substitutes NULL.
+//
+// Adding a new placeholder is a deliberate change: update this map and ensure
+// perm.AuthVars (or another resolver) populates the value.
+var KnownArgPlaceholders = map[string]bool{
+	"[$auth.user_name]":                  true,
+	"[$auth.user_id]":                    true,
+	"[$auth.user_id_int]":                true,
+	"[$auth.role]":                       true,
+	"[$auth.auth_type]":                  true,
+	"[$auth.provider]":                   true,
+	"[$auth.impersonated_by_role]":       true,
+	"[$auth.impersonated_by_user_id]":    true,
+	"[$auth.impersonated_by_user_name]":  true,
+	"[$catalog]":                         true,
+}
+
+// IsKnownPlaceholder reports whether name is a recognized context placeholder.
+func IsKnownPlaceholder(name string) bool {
+	return KnownArgPlaceholders[name]
+}

--- a/pkg/catalog/sdl/placeholders.go
+++ b/pkg/catalog/sdl/placeholders.go
@@ -1,25 +1,28 @@
 package sdl
 
 // KnownArgPlaceholders is the whitelist of context-variable placeholders that
-// are allowed in @function(sql: "...") templates and @arg_default directives.
-//
-// At request time, the planner resolves these via perm.AuthVars(ctx). When the
-// underlying value is unavailable (e.g. unauthenticated request, no
+// can be embedded in @function(sql: "...") templates and used as @arg_default
+// values. At request time, the planner resolves these via perm.AuthVars(ctx).
+// When the underlying value is unavailable (e.g. unauthenticated request, no
 // impersonation), the planner substitutes NULL.
 //
+// Note: [$catalog] is intentionally NOT in this list. It is resolved upstream
+// by Function.SQL() (in functions.go) before the planner's substitution loop
+// runs, and perm.AuthVars does not populate it. Using it inside @arg_default
+// would silently resolve to NULL, so it is excluded.
+//
 // Adding a new placeholder is a deliberate change: update this map and ensure
-// perm.AuthVars (or another resolver) populates the value.
+// perm.AuthVars populates the value.
 var KnownArgPlaceholders = map[string]bool{
-	"[$auth.user_name]":                  true,
-	"[$auth.user_id]":                    true,
-	"[$auth.user_id_int]":                true,
-	"[$auth.role]":                       true,
-	"[$auth.auth_type]":                  true,
-	"[$auth.provider]":                   true,
-	"[$auth.impersonated_by_role]":       true,
-	"[$auth.impersonated_by_user_id]":    true,
-	"[$auth.impersonated_by_user_name]":  true,
-	"[$catalog]":                         true,
+	"[$auth.user_name]":                 true,
+	"[$auth.user_id]":                   true,
+	"[$auth.user_id_int]":               true,
+	"[$auth.role]":                      true,
+	"[$auth.auth_type]":                 true,
+	"[$auth.provider]":                  true,
+	"[$auth.impersonated_by_role]":      true,
+	"[$auth.impersonated_by_user_id]":   true,
+	"[$auth.impersonated_by_user_name]": true,
 }
 
 // IsKnownPlaceholder reports whether name is a recognized context placeholder.

--- a/pkg/catalog/sdl/placeholders_test.go
+++ b/pkg/catalog/sdl/placeholders_test.go
@@ -13,7 +13,6 @@ func TestIsKnownPlaceholder(t *testing.T) {
 		"[$auth.impersonated_by_role]",
 		"[$auth.impersonated_by_user_id]",
 		"[$auth.impersonated_by_user_name]",
-		"[$catalog]",
 	}
 	for _, p := range known {
 		if !IsKnownPlaceholder(p) {
@@ -29,6 +28,7 @@ func TestIsKnownPlaceholder(t *testing.T) {
 		"$auth.user_id",   // missing brackets
 		"[$auth.user_id", // missing closing bracket
 		"user_id",
+		"[$catalog]", // intentionally NOT in @arg_default whitelist
 	}
 	for _, p := range unknown {
 		if IsKnownPlaceholder(p) {

--- a/pkg/catalog/sdl/placeholders_test.go
+++ b/pkg/catalog/sdl/placeholders_test.go
@@ -1,0 +1,38 @@
+package sdl
+
+import "testing"
+
+func TestIsKnownPlaceholder(t *testing.T) {
+	known := []string{
+		"[$auth.user_name]",
+		"[$auth.user_id]",
+		"[$auth.user_id_int]",
+		"[$auth.role]",
+		"[$auth.auth_type]",
+		"[$auth.provider]",
+		"[$auth.impersonated_by_role]",
+		"[$auth.impersonated_by_user_id]",
+		"[$auth.impersonated_by_user_name]",
+		"[$catalog]",
+	}
+	for _, p := range known {
+		if !IsKnownPlaceholder(p) {
+			t.Errorf("expected %q to be a known placeholder", p)
+		}
+	}
+
+	unknown := []string{
+		"",
+		"[$auth.userid]",  // typo
+		"[$auth]",
+		"[$random]",
+		"$auth.user_id",   // missing brackets
+		"[$auth.user_id", // missing closing bracket
+		"user_id",
+	}
+	for _, p := range unknown {
+		if IsKnownPlaceholder(p) {
+			t.Errorf("expected %q to NOT be a known placeholder", p)
+		}
+	}
+}

--- a/pkg/data-sources/sources/runtime/core-db/schema_catalog_tmpl.graphql
+++ b/pkg/data-sources/sources/runtime/core-db/schema_catalog_tmpl.graphql
@@ -184,6 +184,14 @@ type arguments @view(name: "_schema_arguments")
   is_list: Boolean!
   is_non_null: Boolean!
   default_value: String
+  "GraphQL directives applied to this argument, as a JSON array."
+  directives: JSON
+  """
+  True if this argument is server-injected via @arg_default — its value comes
+  from a context placeholder (like [$auth.user_id]) and clients cannot set it.
+  Hidden from MCP discovery and GraphQL introspection at the engine level.
+  """
+  is_arg_default: Boolean! @sql(exp: "{{ if .IsPostgres }}directives::TEXT LIKE '%\"name\":\"arg_default\"%'{{ else }}CAST(directives AS VARCHAR) LIKE '%\"name\":\"arg_default\"%'{{ end }}")
 }
 
 # --- Modules ---

--- a/pkg/mcp/discovery.go
+++ b/pkg/mcp/discovery.go
@@ -306,10 +306,9 @@ func (s *Server) searchModuleFunctions(ctx context.Context, req mcp.CallToolRequ
 		TypeName      string  `json:"type_name"`
 		Distance      float64 `json:"_distance_to_query"`
 		Arguments     []struct {
-			Name         string `json:"name"`
-			ArgType      string `json:"arg_type"`
-			Desc         string `json:"description"`
-			IsArgDefault bool   `json:"is_arg_default"`
+			Name    string `json:"name"`
+			ArgType string `json:"arg_type"`
+			Desc    string `json:"description"`
 		} `json:"arguments"`
 	}
 	err = s.queryScanAdmin(ctx, `query($filter: core_fields_filter, $limit: Int, $query: String!) {

--- a/pkg/mcp/discovery.go
+++ b/pkg/mcp/discovery.go
@@ -306,9 +306,10 @@ func (s *Server) searchModuleFunctions(ctx context.Context, req mcp.CallToolRequ
 		TypeName      string  `json:"type_name"`
 		Distance      float64 `json:"_distance_to_query"`
 		Arguments     []struct {
-			Name    string `json:"name"`
-			ArgType string `json:"arg_type"`
-			Desc    string `json:"description"`
+			Name         string `json:"name"`
+			ArgType      string `json:"arg_type"`
+			Desc         string `json:"description"`
+			IsArgDefault bool   `json:"is_arg_default"`
 		} `json:"arguments"`
 	}
 	err = s.queryScanAdmin(ctx, `query($filter: core_fields_filter, $limit: Int, $query: String!) {
@@ -325,7 +326,7 @@ func (s *Server) searchModuleFunctions(ctx context.Context, req mcp.CallToolRequ
 					field_type_name
 					type_name
 					_distance_to_query(query: $query)
-					arguments {
+					arguments(filter: { is_arg_default: { eq: false } }) {
 						name
 						arg_type
 						description

--- a/pkg/mcp/schema.go
+++ b/pkg/mcp/schema.go
@@ -94,7 +94,10 @@ func (s *Server) typeInfo(ctx context.Context, req mcp.CallToolRequest) (*mcp.Ca
 		argErr := s.queryScanAdmin(ctx, `query($filter: core_arguments_filter) {
 			core { catalog { arguments_aggregation(filter: $filter) { _rows_count } } }
 		}`, map[string]any{
-			"filter": map[string]any{"type_name": map[string]any{"eq": typeName}},
+			"filter": map[string]any{
+				"type_name":      map[string]any{"eq": typeName},
+				"is_arg_default": map[string]any{"eq": false},
+			},
 		}, "core.catalog.arguments_aggregation", &argsAgg)
 		if argErr == nil && argsAgg.Count > 0 {
 			hasArgs = true
@@ -162,7 +165,7 @@ func (s *Server) typeFields(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 	// Build field selection based on flags.
 	argSelection := ""
 	if includeArgs {
-		argSelection = `arguments { name arg_type description }`
+		argSelection = `arguments(filter: { is_arg_default: { eq: false } }) { name arg_type description }`
 	}
 
 	var fields []rawField
@@ -192,7 +195,7 @@ func (s *Server) typeFields(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 						description
 						hugr_type
 						_distance_to_query(query: $relevance_query)
-						arguments_aggregation { _rows_count }
+						arguments_aggregation(filter: { is_arg_default: { eq: false } }) { _rows_count }
 						%s
 					}
 					fields_aggregation(filter: $filter) { _rows_count }
@@ -230,7 +233,7 @@ func (s *Server) typeFields(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 						field_type_name
 						description
 						hugr_type
-						arguments_aggregation { _rows_count }
+						arguments_aggregation(filter: { is_arg_default: { eq: false } }) { _rows_count }
 						%s
 					}
 					fields_aggregation(filter: $filter) { _rows_count }

--- a/pkg/metadata/schema.go
+++ b/pkg/metadata/schema.go
@@ -248,6 +248,9 @@ func typeResolver(ctx context.Context, provider catalog.Provider, typeDef *ast.T
 			}
 			res := []map[string]any{}
 			for _, f := range def.Fields {
+				if isArgServerInjected(f.Directives) {
+					continue
+				}
 				data, err := inputValueResolver(ctx, provider, f, field.SelectionSet, maxDepth-1)
 				if err != nil {
 					return nil, err
@@ -358,6 +361,9 @@ func fieldResolver(ctx context.Context, provider catalog.Provider, def *ast.Fiel
 		"args": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
 			res := []map[string]any{}
 			for _, a := range def.Arguments {
+				if isArgServerInjected(a.Directives) {
+					continue
+				}
 				data, err := argumentResolver(ctx, provider, a, field.SelectionSet, maxDepth-1)
 				if err != nil {
 					return nil, err
@@ -537,6 +543,13 @@ func inputValueResolver(ctx context.Context, provider catalog.Provider, def *ast
 // parser placeholders in shared system types.
 func isPlaceholderField(name string) bool {
 	return name == "_stub" || name == "_placeholder"
+}
+
+// isArgServerInjected returns true if the argument or input field is marked
+// with @arg_default — meaning its value is injected from a server-side context
+// and should be hidden from client-facing schema introspection.
+func isArgServerInjected(directives ast.DirectiveList) bool {
+	return directives.ForName(base.ArgDefaultDirectiveName) != nil
 }
 
 

--- a/pkg/planner/node_function_call.go
+++ b/pkg/planner/node_function_call.go
@@ -272,7 +272,7 @@ func functionCallSQL(ctx context.Context, defs base.DefinitionsSource, e engines
 		authVars := perm.AuthVars(ctx)
 		for argName, placeholder := range info.ArgDefaults {
 			value, ok := authVars[placeholder]
-			if !ok || value == nil || value == "" {
+			if !ok || isEmptyContextValue(value) {
 				sql = strings.ReplaceAll(sql, "["+argName+"]", "NULL")
 				continue
 			}
@@ -302,7 +302,7 @@ func functionCallSQL(ctx context.Context, defs base.DefinitionsSource, e engines
 
 // substitutePlaceholders replaces known context placeholders ([$auth.*], [$catalog])
 // in the SQL string with parameterized values resolved from the request context.
-// Missing or nil/empty values are substituted as the literal "NULL".
+// Missing or empty values are substituted as the literal "NULL".
 func substitutePlaceholders(ctx context.Context, sql string, params []any) (string, []any) {
 	authVars := perm.AuthVars(ctx)
 	for placeholder := range sdl.KnownArgPlaceholders {
@@ -310,7 +310,7 @@ func substitutePlaceholders(ctx context.Context, sql string, params []any) (stri
 			continue
 		}
 		value, ok := authVars[placeholder]
-		if !ok || value == nil || value == "" {
+		if !ok || isEmptyContextValue(value) {
 			sql = strings.ReplaceAll(sql, placeholder, "NULL")
 			continue
 		}
@@ -318,4 +318,23 @@ func substitutePlaceholders(ctx context.Context, sql string, params []any) (stri
 		sql = strings.ReplaceAll(sql, placeholder, "$"+strconv.Itoa(len(params)))
 	}
 	return sql, params
+}
+
+// isEmptyContextValue reports whether a context placeholder value is "empty"
+// for the purpose of NULL substitution. Treats nil, empty string, and zero
+// integer as empty — covers the [$auth.user_id_int] case where strconv.Atoi
+// returns 0 for non-numeric/empty user IDs.
+func isEmptyContextValue(v any) bool {
+	if v == nil {
+		return true
+	}
+	switch val := v.(type) {
+	case string:
+		return val == ""
+	case int:
+		return val == 0
+	case int64:
+		return val == 0
+	}
+	return false
 }

--- a/pkg/planner/node_function_call.go
+++ b/pkg/planner/node_function_call.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
 	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
 	"github.com/hugr-lab/query-engine/pkg/engines"
+	"github.com/hugr-lab/query-engine/pkg/perm"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -257,6 +258,29 @@ func functionCallSQL(ctx context.Context, defs base.DefinitionsSource, e engines
 	for k, v := range call.ArgumentMap() {
 		sql = strings.ReplaceAll(sql, "["+k+"]", "["+v+"]")
 	}
+
+	// Substitute known context placeholders ([$auth.*], [$catalog]) embedded in the
+	// SQL template. The whitelist lives in pkg/catalog/sdl/placeholders.go. Missing
+	// or empty values become NULL — auth/perm middleware already handles unauthenticated
+	// requests; the function's own logic decides how to handle a NULL identity.
+	sql, params = substitutePlaceholders(ctx, sql, params)
+
+	// Resolve arguments declared with @arg_default before user-supplied args.
+	// Hidden args have a [arg_name] placeholder in the SQL template (auto-generated
+	// or user-written) which gets substituted with the resolved context value.
+	if len(info.ArgDefaults) > 0 {
+		authVars := perm.AuthVars(ctx)
+		for argName, placeholder := range info.ArgDefaults {
+			value, ok := authVars[placeholder]
+			if !ok || value == nil || value == "" {
+				sql = strings.ReplaceAll(sql, "["+argName+"]", "NULL")
+				continue
+			}
+			params = append(params, value)
+			sql = strings.ReplaceAll(sql, "["+argName+"]", "$"+strconv.Itoa(len(params)))
+		}
+	}
+
 	queryArg, err := call.ArgumentValues(ctx, defs, vars)
 	if err != nil {
 		return "", nil, err
@@ -274,4 +298,24 @@ func functionCallSQL(ctx context.Context, defs base.DefinitionsSource, e engines
 	}
 
 	return sql, params, nil
+}
+
+// substitutePlaceholders replaces known context placeholders ([$auth.*], [$catalog])
+// in the SQL string with parameterized values resolved from the request context.
+// Missing or nil/empty values are substituted as the literal "NULL".
+func substitutePlaceholders(ctx context.Context, sql string, params []any) (string, []any) {
+	authVars := perm.AuthVars(ctx)
+	for placeholder := range sdl.KnownArgPlaceholders {
+		if !strings.Contains(sql, placeholder) {
+			continue
+		}
+		value, ok := authVars[placeholder]
+		if !ok || value == nil || value == "" {
+			sql = strings.ReplaceAll(sql, placeholder, "NULL")
+			continue
+		}
+		params = append(params, value)
+		sql = strings.ReplaceAll(sql, placeholder, "$"+strconv.Itoa(len(params)))
+	}
+	return sql, params
 }

--- a/pkg/planner/node_function_call_placeholders_test.go
+++ b/pkg/planner/node_function_call_placeholders_test.go
@@ -1,0 +1,134 @@
+package planner
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/auth"
+)
+
+func TestSubstitutePlaceholders(t *testing.T) {
+	authInfo := &auth.AuthInfo{
+		Role:         "admin",
+		UserId:       "alice",
+		UserName:     "Alice",
+		AuthType:     "apiKey",
+		AuthProvider: "x-hugr-secret",
+	}
+	ctxAuth := auth.ContextWithAuthInfo(context.Background(), authInfo)
+	ctxAnon := context.Background()
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		sql      string
+		params   []any
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:     "no placeholders — unchanged",
+			ctx:      ctxAuth,
+			sql:      "func($1, $2)",
+			params:   []any{1, 2},
+			wantSQL:  "func($1, $2)",
+			wantArgs: []any{1, 2},
+		},
+		{
+			name:     "single auth placeholder",
+			ctx:      ctxAuth,
+			sql:      "func([$auth.user_id])",
+			params:   nil,
+			wantSQL:  "func($1)",
+			wantArgs: []any{"alice"},
+		},
+		{
+			name:     "multiple auth placeholders",
+			ctx:      ctxAuth,
+			sql:      "func([$auth.user_id], [$auth.role])",
+			params:   nil,
+			wantArgs: []any{"alice", "admin"},
+		},
+		{
+			name:     "placeholder appended to existing params",
+			ctx:      ctxAuth,
+			sql:      "func($1, [$auth.user_id])",
+			params:   []any{42},
+			wantSQL:  "func($1, $2)",
+			wantArgs: []any{42, "alice"},
+		},
+		{
+			name:     "anonymous request — substitute NULL",
+			ctx:      ctxAnon,
+			sql:      "func([$auth.user_id])",
+			params:   nil,
+			wantSQL:  "func(NULL)",
+			wantArgs: nil,
+		},
+		{
+			name:     "anonymous mixed with existing params",
+			ctx:      ctxAnon,
+			sql:      "func($1, [$auth.user_id])",
+			params:   []any{99},
+			wantSQL:  "func($1, NULL)",
+			wantArgs: []any{99},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSQL, gotParams := substitutePlaceholders(tt.ctx, tt.sql, tt.params)
+
+			// For multi-placeholder cases the iteration order over the placeholder map
+			// is non-deterministic, so verify the SQL doesn't contain any raw placeholder
+			// rather than asserting an exact string.
+			if strings.Contains(gotSQL, "[$auth.") || strings.Contains(gotSQL, "[$catalog]") {
+				t.Errorf("unsubstituted placeholder remains in SQL: %s", gotSQL)
+			}
+			if tt.wantSQL != "" && gotSQL != tt.wantSQL {
+				// only enforce when wantSQL is set (single-placeholder tests)
+				t.Errorf("SQL = %q, want %q", gotSQL, tt.wantSQL)
+			}
+			if !equalAnySliceUnordered(gotParams, tt.wantArgs) {
+				t.Errorf("params = %v, want %v", gotParams, tt.wantArgs)
+			}
+		})
+	}
+}
+
+// equalAnySliceUnordered compares two slices ignoring order (used for multi-placeholder
+// substitution where map iteration order is non-deterministic).
+func equalAnySliceUnordered(a, b []any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	used := make([]bool, len(b))
+outer:
+	for _, av := range a {
+		for j, bv := range b {
+			if !used[j] && av == bv {
+				used[j] = true
+				continue outer
+			}
+		}
+		return false
+	}
+	return true
+}
+
+func TestSubstitutePlaceholders_CatalogPreserved(t *testing.T) {
+	// [$catalog] is normally substituted upstream by Function.SQL() before reaching
+	// substitutePlaceholders. Verify our generic loop also handles it correctly if
+	// it does encounter the placeholder (e.g., via auth context catalog mechanism).
+	ctx := context.Background()
+	sql := "lookup([$catalog].x)"
+	got, params := substitutePlaceholders(ctx, sql, nil)
+	// No catalog in AuthVars by default → NULL substitution
+	if !strings.Contains(got, "NULL") {
+		t.Errorf("expected NULL substitution for unset catalog, got %q", got)
+	}
+	if len(params) != 0 {
+		t.Errorf("expected empty params, got %v", params)
+	}
+}

--- a/pkg/planner/node_function_call_placeholders_test.go
+++ b/pkg/planner/node_function_call_placeholders_test.go
@@ -117,16 +117,60 @@ outer:
 	return true
 }
 
-func TestSubstitutePlaceholders_CatalogPreserved(t *testing.T) {
-	// [$catalog] is normally substituted upstream by Function.SQL() before reaching
-	// substitutePlaceholders. Verify our generic loop also handles it correctly if
-	// it does encounter the placeholder (e.g., via auth context catalog mechanism).
+func TestSubstitutePlaceholders_UserIDIntZero(t *testing.T) {
+	// Regression: when user_id is non-numeric (e.g. "alice"), strconv.Atoi
+	// returns 0 in perm.AuthVars, and isEmptyContextValue(int(0)) must return
+	// true so the placeholder resolves to NULL instead of leaking 0 as a
+	// valid parameter.
+	authInfo := &auth.AuthInfo{
+		Role:     "admin",
+		UserId:   "alice", // non-numeric → user_id_int becomes 0
+		UserName: "Alice",
+	}
+	ctx := auth.ContextWithAuthInfo(context.Background(), authInfo)
+
+	sql := "lookup([$auth.user_id_int])"
+	got, params := substitutePlaceholders(ctx, sql, nil)
+	if got != "lookup(NULL)" {
+		t.Errorf("expected NULL substitution for zero user_id_int, got %q", got)
+	}
+	if len(params) != 0 {
+		t.Errorf("expected empty params, got %v", params)
+	}
+}
+
+func TestIsEmptyContextValue(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		empty bool
+	}{
+		{"nil", nil, true},
+		{"empty string", "", true},
+		{"int zero", 0, true},
+		{"int64 zero", int64(0), true},
+		{"non-empty string", "alice", false},
+		{"int positive", 42, false},
+		{"int64 positive", int64(42), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isEmptyContextValue(tc.value); got != tc.empty {
+				t.Errorf("isEmptyContextValue(%v) = %v, want %v", tc.value, got, tc.empty)
+			}
+		})
+	}
+}
+
+func TestSubstitutePlaceholders_CatalogNotInWhitelist(t *testing.T) {
+	// [$catalog] is intentionally NOT in KnownArgPlaceholders. It is resolved
+	// upstream by Function.SQL() before substitutePlaceholders runs, so the
+	// generic loop must leave it alone if it ever appears here.
 	ctx := context.Background()
 	sql := "lookup([$catalog].x)"
 	got, params := substitutePlaceholders(ctx, sql, nil)
-	// No catalog in AuthVars by default → NULL substitution
-	if !strings.Contains(got, "NULL") {
-		t.Errorf("expected NULL substitution for unset catalog, got %q", got)
+	if got != sql {
+		t.Errorf("[$catalog] should be left unchanged by substitutePlaceholders, got %q", got)
 	}
 	if len(params) != 0 {
 		t.Errorf("expected empty params, got %v", params)

--- a/pkg/planner/node_select.go
+++ b/pkg/planner/node_select.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
 	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
 	"github.com/hugr-lab/query-engine/pkg/engines"
+	"github.com/hugr-lab/query-engine/pkg/perm"
 	"github.com/hugr-lab/query-engine/pkg/catalog"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -296,7 +297,10 @@ func selectDataObjectNode(ctx context.Context, defs base.DefinitionsSource, plan
 		if !ok {
 			am = map[string]any{}
 		}
-		err = info.ApplyArguments(ctx, defs, am, e)
+		// perm.AuthVars(ctx) provides [$auth.*] and similar context placeholders
+		// for resolving @arg_default input fields and embedded placeholders in
+		// @view(sql:) templates.
+		err = info.ApplyArguments(ctx, defs, am, e, perm.AuthVars(ctx))
 		if err != nil {
 			return nil, false, err
 		}


### PR DESCRIPTION
## Summary

Two complementary mechanisms for binding context variables to function call SQL — eliminating boilerplate when injecting auth context into function arguments.

### 1. Direct `[$auth.*]` substitution in `sql:` templates

The planner now substitutes known context placeholders embedded in `@function(sql: "...")` templates:

```graphql
extend type Function {
  audit_call(action: String!): Boolean
    @function(name: "audit", sql: "audit_log([action], [\$auth.user_id], [\$auth.role])")
}
```

Backward compatible — no schema changes, no breaking behavior.

### 2. New `@arg_default` directive

Declarative way to bind a function/view argument to a server-side context value. The argument is hidden from clients and the planner injects the resolved value at request time:

```graphql
extend type Function {
  list_my_orders(
    limit: Int = 50,
    user_id: String @arg_default(value: "[\$auth.user_id]")
  ): [Order] @function(name: "list_user_orders")
}
```

Clients see only `list_my_orders(limit: Int = 50)` — `user_id` is injected by the engine. Attempts to set it client-side are rejected.

Works for **scalar functions, table functions, parameterized views, `@function_call`, `@table_function_call_join`** — all paths share the same `functionCallSQL` helper.

### 3. hugr-app SDK: `app.ArgFromContext()`

Typed `ContextPlaceholder` constants for compile-time safety:

```go
mux.HandleFunc("default", "my_orders", handler,
    app.Arg("limit", app.Int64),
    app.ArgFromContext("user_id", app.String, app.AuthUserID),
    app.Return(app.String),
)
```

Available constants: `AuthUserID`, `AuthUserIDInt`, `AuthUserName`, `AuthRole`, `AuthType`, `AuthProvider`, `AuthImpersonatedByRole`, `AuthImpersonatedByUserID`, `AuthImpersonatedByUserName`, `Catalog`.

## Implementation Highlights

- **Filtering**: `@arg_default` args are hidden from GraphQL introspection (`pkg/metadata/schema.go`), MCP discovery (`pkg/mcp/discovery.go`), MCP schema export (`pkg/mcp/schema.go`), and `arguments_aggregation` counts.
- **MCP filtering** uses a new computed `is_arg_default: Boolean!` field on the catalog `arguments` view via `@sql(exp:)` — works on both DuckDB and PostgreSQL.
- **No DB migration**: `_schema_arguments.directives` JSON column already exists.
- **Validation**: Compile-time whitelist check + runtime client-override rejection.
- **NULL fallback** when auth context is unavailable (anonymous requests).
- **No circular imports**: planner imports perm (existing direction); sdl receives context vars via parameter, not context.

## Test plan

- [x] Unit tests: `pkg/catalog/sdl/placeholders_test.go`, `pkg/planner/node_function_call_placeholders_test.go`, `client/app/sdl_gen_test.go` (4 new tests), `client/app/mux_test.go` (3 new tests)
- [x] Compile-time validation tests via existing rule infrastructure
- [x] Catalog DB integration tests pass (21s, includes `_schema_arguments` round-trip)
- [x] Full e2e-hugrapp suite: **34 passed, 0 failed** (4 new tests for `ArgFromContext`)
- [x] Main e2e suite: **209 passed, 0 failed** (covers PostgreSQL `is_arg_default` path)
- [x] Manual E2E scenarios: client-supplied override rejection, introspection hiding, named-schema `@module` + `@arg_default` together

## Docs

Documentation updated in [hugr-lab.github.io](https://github.com/hugr-lab/hugr-lab.github.io):
- `docs/12-hugr-apps/3-catalog-mux.md` — `ArgFromContext` example
- `docs/8-references/1-directives.md` — full `@arg_default` reference
- `docs/4-engine-configuration/3-schema-definition/2-function.md` — placeholder substitution feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)