### PR TITLE
fix: error handling, streaming token counts, and context propagation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -144,7 +144,7 @@
                 "--secret", "secret-key",
                 "--secret-header", "x-hugr-secret-key",
                 "--provider", "custom",
-                "--model", "openai/gpt-oss-20b",
+                "--model", "google/gemma-4-26b-a4b",
                 "--base-url", "http://127.0.0.1:1234/v1",
                 "--api-key", "lm-studio",
                 "--llm-timeout", "5m",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,15 @@ Auto-generated from all feature plans. Last updated: 2026-02-21
 - Go 1.26 + `duckdb-go/v2` (CGo, `duckdb_arrow`), `gqlparser/v2`, `apache/arrow-go/v18` + DuckDB embedded, existing `Source`/`RuntimeSource` interfaces, `ScalarFunctionWithArgs` UDF pattern (001-ai-model-sources)
 - DuckDB (embedded), PostgreSQL (CoreDB for metadata) (001-ai-model-sources)
 - Redis 6.0+ (key-value), DuckDB (embedded), PostgreSQL (CoreDB) (001-redis-store-ratelimit)
+- Go 1.26 with `iter.Seq`, range-over-func + `duckdb-go/v2` (CGo, build tag `duckdb_arrow`), `gqlparser/v2` (GraphQL AST), `apache/arrow-go/v18`, `gorilla/websocket` (existing dep), `redis/go-redis/v9` (existing dep for store) (001-graphql-subscriptions)
+- DuckDB embedded (primary query engine), PostgreSQL CoreDB (schema metadata), Redis (store source) (001-graphql-subscriptions)
+- Go 1.26 (with `iter.Seq`, range-over-func) + `duckdb-go/v2` (CGo, `duckdb_arrow`), `gqlparser/v2`, `gorilla/websocket`, `apache/arrow-go/v18` (001-client-impersonation)
+- N/A (reads from existing permission system via `core.roles_by_pk`) (001-client-impersonation)
+- DuckDB embedded + PostgreSQL CoreDB (roles table migration in hugr repo) (001-perm-impersonation)
+- Go 1.26 (with `iter.Seq`, range-over-func) + `gqlparser/v2` (GraphQL AST + directive parsing), `duckdb-go/v2` (CGo, `duckdb_arrow`), `apache/arrow-go/v18` (001-function-arg-placeholders)
+- DuckDB embedded + PostgreSQL CoreDB (no migration needed — `_schema_arguments.directives` JSON column already exists) (001-function-arg-placeholders)
+- Go 1.26 (with `iter.Seq`, range-over-func) + `gqlparser/v2` (GraphQL AST + directive parsing), `duckdb-go/v2` (CGo, `duckdb_arrow`), `apache/arrow-go/v18`, `airport-go` (Arrow Flight protocol for hugr-app catalog) (001-hugrapp-struct-args)
+- DuckDB embedded; no schema changes (001-hugrapp-struct-args)
 
 ## Project Structure
 
@@ -35,6 +44,6 @@ Go 1.26: Follow standard conventions
 <!-- MANUAL ADDITIONS END -->
 
 ## Recent Changes
-- 001-redis-store-ratelimit: Added Go 1.26 + `duckdb-go/v2` (CGo, `duckdb_arrow`), `gqlparser/v2`, `apache/arrow-go/v18`
-- 001-ai-model-sources: Added Go 1.26 + `duckdb-go/v2` (CGo, `duckdb_arrow`), `gqlparser/v2`, `apache/arrow-go/v18` + DuckDB embedded, existing `Source`/`RuntimeSource` interfaces, `ScalarFunctionWithArgs` UDF pattern
-- 001-hugr-apps: Added Go 1.26 (with `iter.Seq`, range-over-func) + `duckdb-go/v2` (CGo, `duckdb_arrow`), `hugr-lab/airport-go` v0.2.1 (Arrow Flight gRPC), `gqlparser/v2` (GraphQL AST), `apache/arrow-go/v18`
+- 001-hugrapp-struct-args: Added Go 1.26 (with `iter.Seq`, range-over-func) + `gqlparser/v2` (GraphQL AST + directive parsing), `duckdb-go/v2` (CGo, `duckdb_arrow`), `apache/arrow-go/v18`, `airport-go` (Arrow Flight protocol for hugr-app catalog)
+- 001-function-arg-placeholders: Added Go 1.26 (with `iter.Seq`, range-over-func) + `gqlparser/v2` (GraphQL AST + directive parsing), `duckdb-go/v2` (CGo, `duckdb_arrow`), `apache/arrow-go/v18`
+- 001-perm-impersonation: Added Go 1.26 (with `iter.Seq`, range-over-func) + `duckdb-go/v2` (CGo, `duckdb_arrow`), `gqlparser/v2`, `gorilla/websocket`, `apache/arrow-go/v18`

--- a/client/subscribe.go
+++ b/client/subscribe.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -165,7 +166,7 @@ func (sc *SubscriptionConn) readLoop() {
 					log.Printf("subscription %s error: %s", msg.SubscriptionID, msg.Error)
 					sc.subsMu.Lock()
 					if as := sc.subs[msg.SubscriptionID]; as != nil && as.sub != nil {
-						as.sub.SetErr(fmt.Errorf("%s", msg.Error))
+						as.sub.SetErr(errors.New(msg.Error))
 					}
 					sc.subsMu.Unlock()
 				}

--- a/client/subscribe.go
+++ b/client/subscribe.go
@@ -77,6 +77,7 @@ type activeSub struct {
 	eventCh chan types.SubscriptionEvent
 	pipes   map[string]*batchPipe // one pipe per path, persists across ticks
 	done    bool
+	sub     *types.Subscription // back-pointer to set Err on subscription_error
 }
 
 // Subscribe creates a subscription on this connection.
@@ -86,10 +87,21 @@ func (sc *SubscriptionConn) Subscribe(ctx context.Context, query string, vars ma
 	}
 
 	subID := uuid.NewString()
-	sub := &activeSub{eventCh: make(chan types.SubscriptionEvent, 16)}
+	as := &activeSub{eventCh: make(chan types.SubscriptionEvent, 16)}
+
+	result := &types.Subscription{
+		Events: as.eventCh,
+		Cancel: func() {
+			sc.mu.Lock()
+			_ = sc.conn.WriteJSON(ipcSubMsg{Type: "unsubscribe", SubscriptionID: subID})
+			sc.mu.Unlock()
+			sc.removeSub(subID)
+		},
+	}
+	as.sub = result
 
 	sc.subsMu.Lock()
-	sc.subs[subID] = sub
+	sc.subs[subID] = as
 	sc.subsMu.Unlock()
 
 	msg := ipcSubMsg{
@@ -110,15 +122,7 @@ func (sc *SubscriptionConn) Subscribe(ctx context.Context, query string, vars ma
 		return nil, fmt.Errorf("send subscribe: %w", err)
 	}
 
-	return &types.Subscription{
-		Events: sub.eventCh,
-		Cancel: func() {
-			sc.mu.Lock()
-			_ = sc.conn.WriteJSON(ipcSubMsg{Type: "unsubscribe", SubscriptionID: subID})
-			sc.mu.Unlock()
-			sc.removeSub(subID)
-		},
-	}, nil
+	return result, nil
 }
 
 // Count returns the number of active subscriptions.
@@ -159,6 +163,11 @@ func (sc *SubscriptionConn) readLoop() {
 			case "subscription_complete", "subscription_error":
 				if msg.Type == "subscription_error" {
 					log.Printf("subscription %s error: %s", msg.SubscriptionID, msg.Error)
+					sc.subsMu.Lock()
+					if as := sc.subs[msg.SubscriptionID]; as != nil && as.sub != nil {
+						as.sub.SetErr(fmt.Errorf("%s", msg.Error))
+					}
+					sc.subsMu.Unlock()
 				}
 				sc.completeSub(msg.SubscriptionID)
 			}

--- a/pkg/data-sources/sources/llm/openai.go
+++ b/pkg/data-sources/sources/llm/openai.go
@@ -52,11 +52,11 @@ func NewOpenAI(ds types.DataSource, attached bool) (*OpenAISource, error) {
 	}, nil
 }
 
-func (s *OpenAISource) Name() string             { return s.ds.Name }
+func (s *OpenAISource) Name() string                 { return s.ds.Name }
 func (s *OpenAISource) Definition() types.DataSource { return s.ds }
-func (s *OpenAISource) Engine() engines.Engine   { return s.engine }
-func (s *OpenAISource) IsAttached() bool         { return s.isAttached }
-func (s *OpenAISource) ReadOnly() bool           { return true }
+func (s *OpenAISource) Engine() engines.Engine       { return s.engine }
+func (s *OpenAISource) IsAttached() bool             { return s.isAttached }
+func (s *OpenAISource) ReadOnly() bool               { return true }
 
 func (s *OpenAISource) ModelInfo() sources.ModelInfo {
 	return sources.ModelInfo{
@@ -162,7 +162,7 @@ func (s *OpenAISource) CreateChatCompletion(ctx context.Context, messages []sour
 
 	// Build request body
 	reqBody := map[string]any{
-		"model":      s.config.Model,
+		"model":      strings.Trim(s.config.Model, "\""),
 		"messages":   convertMessagesOpenAI(messages),
 		"max_tokens": maxTokens,
 	}
@@ -358,10 +358,17 @@ func (s *OpenAISource) CreateChatCompletionStream(ctx context.Context, messages 
 	}
 
 	reqBody := map[string]any{
-		"model":      s.config.Model,
+		"model":      strings.Trim(s.config.Model, "\""), // some providers (e.g. Ollama) require unquoted model names
 		"messages":   convertMessagesOpenAI(messages),
 		"max_tokens": maxTokens,
 		"stream":     true,
+		// Ask the OpenAI-compatible endpoint to send token usage on the
+		// final SSE chunk. Without this, the streaming response carries
+		// no `usage` block (LM Studio, vLLM, llama.cpp and the official
+		// OpenAI API all gate it on this option), so the LLMStreamEvent
+		// `finish` event ends up with PromptTokens=0 / CompletionTokens=0
+		// and downstream consumers can't display per-message cost.
+		"stream_options": map[string]any{"include_usage": true},
 	}
 	if opts.Temperature > 0 {
 		reqBody["temperature"] = opts.Temperature
@@ -411,6 +418,12 @@ func (s *OpenAISource) CreateChatCompletionStream(ctx context.Context, messages 
 
 	var totalPromptTokens, totalCompletionTokens int
 	var toolCallParts []string
+	// finishEvent is captured when the model emits a finish_reason, but
+	// emitted only AFTER the SSE stream ends. With `stream_options.include_usage`
+	// the OpenAI-compatible server sends a trailing chunk with `choices: []`
+	// and a `usage` block — that arrives strictly after the finish chunk, so
+	// emitting the finish event eagerly would always lose the token counts.
+	var finishEvent *sources.LLMStreamEvent
 
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
@@ -486,19 +499,30 @@ func (s *OpenAISource) CreateChatCompletionStream(ctx context.Context, messages 
 		}
 
 		if choice.FinishReason != nil {
-			ev := &sources.LLMStreamEvent{
-				Type:             "finish",
-				Model:            chunk.Model,
-				FinishReason:     normalizeFinishReasonOpenAI(*choice.FinishReason),
-				PromptTokens:     totalPromptTokens,
-				CompletionTokens: totalCompletionTokens,
+			// Capture the finish event but defer emitting it. The trailing
+			// usage-only chunk that follows (when include_usage is set) will
+			// update totalPromptTokens / totalCompletionTokens before we
+			// flush below.
+			finishEvent = &sources.LLMStreamEvent{
+				Type:         "finish",
+				Model:        chunk.Model,
+				FinishReason: normalizeFinishReasonOpenAI(*choice.FinishReason),
 			}
 			if len(toolCallParts) > 0 {
-				ev.ToolCalls = strings.Join(toolCallParts, "")
+				finishEvent.ToolCalls = strings.Join(toolCallParts, "")
 			}
-			if err := onEvent(ev); err != nil {
-				return err
-			}
+		}
+	}
+
+	// Flush the finish event with the final accumulated token counts
+	// (populated either from the finish chunk itself for providers that
+	// inline `usage`, or from the trailing usage-only chunk for those that
+	// honor `stream_options.include_usage`).
+	if finishEvent != nil {
+		finishEvent.PromptTokens = totalPromptTokens
+		finishEvent.CompletionTokens = totalCompletionTokens
+		if err := onEvent(finishEvent); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/data-sources/sources/runtime/auth/functions.go
+++ b/pkg/data-sources/sources/runtime/auth/functions.go
@@ -22,14 +22,14 @@ func registerFunctions(ctx context.Context, pool *db.Pool) error {
 				return nil, nil
 			}
 			result := map[string]any{
-				"user_id":                    info.UserId,
-				"user_name":                  info.UserName,
-				"role":                       info.Role,
-				"auth_type":                  info.AuthType,
-				"auth_provider":              info.AuthProvider,
-				"impersonated_by_user_id":    "",
-				"impersonated_by_user_name":  "",
-				"impersonated_by_user_role":  "",
+				"user_id":                   info.UserId,
+				"user_name":                 info.UserName,
+				"role":                      info.Role,
+				"auth_type":                 info.AuthType,
+				"auth_provider":             info.AuthProvider,
+				"impersonated_by_user_id":   "",
+				"impersonated_by_user_name": "",
+				"impersonated_by_user_role": "",
 			}
 			if impBy := auth.ImpersonatedByFromContext(ctx); impBy != nil {
 				result["impersonated_by_user_id"] = impBy.UserId
@@ -197,14 +197,14 @@ func marshalJSONField(v map[string]any) (string, error) {
 
 func meOutputType() duckdb.TypeInfo {
 	return runtime.DuckDBStructTypeFromSchemaMust(map[string]any{
-		"user_id":                    "VARCHAR",
-		"user_name":                  "VARCHAR",
-		"role":                       "VARCHAR",
-		"auth_type":                  "VARCHAR",
-		"auth_provider":              "VARCHAR",
-		"impersonated_by_user_id":    "VARCHAR",
-		"impersonated_by_user_name":  "VARCHAR",
-		"impersonated_by_user_role":  "VARCHAR",
+		"user_id":                   "VARCHAR",
+		"user_name":                 "VARCHAR",
+		"role":                      "VARCHAR",
+		"auth_type":                 "VARCHAR",
+		"auth_provider":             "VARCHAR",
+		"impersonated_by_user_id":   "VARCHAR",
+		"impersonated_by_user_name": "VARCHAR",
+		"impersonated_by_user_role": "VARCHAR",
 	})
 }
 

--- a/pkg/db/table_udf.go
+++ b/pkg/db/table_udf.go
@@ -12,12 +12,12 @@ func RegisterTableRowFunction(ctx context.Context, db *Pool, function TableRowFu
 		return err
 	}
 	defer c.Close()
-	return duckdb.RegisterTableUDF(c.DBConn(), function.FuncName(), function.Bind(ctx))
+	return duckdb.RegisterTableUDF(c.DBConn(), function.FuncName(), function.Bind())
 }
 
 type TableRowFunction interface {
 	FuncName() string
-	Bind(ctx context.Context) duckdb.RowTableFunction
+	Bind() duckdb.RowTableFunction
 }
 
 type TableRowFunctionWithArgs[I any, O any] struct {
@@ -34,13 +34,13 @@ func (f *TableRowFunctionWithArgs[I, O]) FuncName() string {
 	return f.Name
 }
 
-func (f *TableRowFunctionWithArgs[I, O]) Bind(ctx context.Context) duckdb.RowTableFunction {
+func (f *TableRowFunctionWithArgs[I, O]) Bind() duckdb.RowTableFunction {
 	return duckdb.RowTableFunction{
 		Config: duckdb.TableFunctionConfig{
 			Arguments:      f.Arguments,
 			NamedArguments: f.NamedArguments,
 		},
-		BindArguments: func(named map[string]any, args ...any) (duckdb.RowTableSource, error) {
+		BindArgumentsContext: func(ctx context.Context, named map[string]any, args ...any) (duckdb.RowTableSource, error) {
 			input, err := f.ConvertArgs(named, args...)
 			if err != nil {
 				return nil, err
@@ -118,11 +118,10 @@ func (f *TableRowFunctionNoArgs[O]) FuncName() string {
 	return f.Name
 }
 
-func (f *TableRowFunctionNoArgs[O]) Bind(ctx context.Context) duckdb.RowTableFunction {
+func (f *TableRowFunctionNoArgs[O]) Bind() duckdb.RowTableFunction {
 	return duckdb.RowTableFunction{
 		Config: duckdb.TableFunctionConfig{},
-		BindArguments: func(named map[string]any, args ...any) (duckdb.RowTableSource, error) {
-
+		BindArgumentsContext: func(ctx context.Context, named map[string]any, args ...any) (duckdb.RowTableSource, error) {
 			return &tableRowUDFSource[any, O]{
 				ctx:      ctx,
 				colInfos: f.ColumnInfos,

--- a/pkg/planner/node_select.go
+++ b/pkg/planner/node_select.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hugr-lab/query-engine/pkg/catalog"
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
 	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
 	"github.com/hugr-lab/query-engine/pkg/engines"
 	"github.com/hugr-lab/query-engine/pkg/perm"
-	"github.com/hugr-lab/query-engine/pkg/catalog"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -153,7 +153,7 @@ func selectDataObjectNode(ctx context.Context, defs base.DefinitionsSource, plan
 			if isInner {
 				innerGeneral = append(innerGeneral, joinNode.Name+"._selection IS NOT NULL")
 			}
-			ff, err := sourceFields(ctx, defs,dataObject, sq)
+			ff, err := sourceFields(ctx, defs, dataObject, sq)
 			if err != nil {
 				return nil, false, err
 			}
@@ -252,7 +252,7 @@ func selectDataObjectNode(ctx context.Context, defs base.DefinitionsSource, plan
 		}
 		if len(generalFields) != 0 {
 			qJoinsGeneralFields[qj.Alias] = generalFields
-			ff, err := sourceFields(ctx, defs,dataObject, qj)
+			ff, err := sourceFields(ctx, defs, dataObject, qj)
 			if err != nil {
 				return nil, false, err
 			}
@@ -293,8 +293,11 @@ func selectDataObjectNode(ctx context.Context, defs base.DefinitionsSource, plan
 	}
 	if info.HasArguments() {
 		arg := queryArg.ForName("args")
-		am, ok := arg.Value.(map[string]any)
-		if !ok {
+		var am map[string]any
+		if arg != nil {
+			am = arg.Value.(map[string]any)
+		}
+		if am == nil {
 			am = map[string]any{}
 		}
 		// perm.AuthVars(ctx) provides [$auth.*] and similar context placeholders
@@ -1471,7 +1474,7 @@ func splitByQueryParts(ctx context.Context, defs base.DefinitionsSource, query *
 	}
 	// add source fields for subqueries and function calls
 	for _, f := range append(qp.subQueries, append(queryTimeJoins, queryTimeSpatial...)...) {
-		sff, err := sourceFields(ctx, defs,f.ObjectDefinition, f)
+		sff, err := sourceFields(ctx, defs, f.ObjectDefinition, f)
 		if err != nil {
 			return nil, err
 		}
@@ -1942,7 +1945,7 @@ func sourceFields(ctx context.Context, defs base.DefinitionsSource, def *ast.Def
 		if aggregated == nil {
 			return nil, errors.New("aggregated field not found")
 		}
-		return sourceFields(ctx, defs,def, &ast.Field{
+		return sourceFields(ctx, defs, def, &ast.Field{
 			Alias:            query.Alias,
 			Name:             aggregated.Name,
 			Definition:       aggregated,

--- a/types/engine.go
+++ b/types/engine.go
@@ -32,11 +32,20 @@ type SubscriptionEvent struct {
 
 // Subscription is the result of Querier.Subscribe.
 // Events channel produces SubscriptionEvents until closed.
-// Errors are reported via Reader.Err() after Reader.Next() returns false.
+// Errors are reported via Reader.Err() after Reader.Next() returns false,
+// or via Err() after Events is closed (for subscription-level errors).
 type Subscription struct {
 	Events <-chan SubscriptionEvent
 	Cancel func()
+	err    error
 }
+
+// Err returns the subscription-level error (e.g. from subscription_error frame).
+// Call after Events channel is closed.
+func (s *Subscription) Err() error { return s.err }
+
+// SetErr sets the subscription-level error. Called by the transport layer.
+func (s *Subscription) SetErr(err error) { s.err = err }
 
 type UnloadOpt func(*UnloadOpts)
 


### PR DESCRIPTION
## Summary

- **Subscription error propagation**: `types.Subscription` gains `Err()`/`SetErr()` so callers can inspect subscription-level errors (e.g. `subscription_error` frame) after the `Events` channel closes. `client/subscribe.go` sets the error before completing the subscription.
- **OpenAI streaming**: send `stream_options: {include_usage: true}` to get token counts in streaming mode; defer `finish` event emission until the trailing usage-only SSE chunk is consumed. Also trim quoted model names in both stream and non-stream POST bodies.
- **Table UDF context**: replace `Bind(ctx context.Context)` with `Bind()` using `BindArgumentsContext` — DuckDB now provides the actual query-time context instead of the stale registration-time context.
- **Planner nil args fix**: handle `nil` arg when `HasArguments()` is true but the query omits `args` — prevents nil pointer panic.
- **Formatting**: align struct literals in `auth/functions.go` and `openai.go`.

## Test plan

- [ ] Run integration tests: `go test -tags=duckdb_arrow ./integration-test/models/...`
- [ ] Verify streaming token counts are non-zero for OpenAI provider
- [ ] Verify subscription errors are surfaced via `sub.Err()` after channel close
- [ ] Run E2E: `cd integration-test/e2e && bash run.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)