### PR TITLE
fix: view args validation, interval parsing, cache TTL, and MCP discovery

### DIFF
--- a/integration-test/compiler/cross_compiler_test.go
+++ b/integration-test/compiler/cross_compiler_test.go
@@ -1142,13 +1142,16 @@ type SearchResults
 }
 
 func TestValidate_ViewArgs_SQLWithUnknownRef(t *testing.T) {
+	// [$unknown_field] (with $ prefix) is an argument reference — must be
+	// declared in the args input type. [table_name] (without $) is a database
+	// table reference and is NOT validated at compile time.
 	sdl := `
 input SearchArgs {
   search_term: String!
 }
 
 type SearchResults
-  @view(name: "search_results", sql: "SELECT * FROM search WHERE x = [unknown_field]")
+  @view(name: "search_results", sql: "SELECT * FROM [search] WHERE x = [$unknown_field]")
   @args(name: "SearchArgs") {
   id: Int! @pk
   title: String!
@@ -1156,7 +1159,7 @@ type SearchResults
 `
 	err := compileNewOnly(t, sdl)
 	if err == nil {
-		t.Fatal("expected error for unknown SQL ref in view, got nil")
+		t.Fatal("expected error for unknown SQL arg ref in view, got nil")
 	}
 	if !strings.Contains(err.Error(), "unknown_field") {
 		t.Fatalf("expected error to mention 'unknown_field', got: %v", err)

--- a/integration-test/compiler/testdata/07_view_parameterized/expected/schema.graphql
+++ b/integration-test/compiler/testdata/07_view_parameterized/expected/schema.graphql
@@ -571,6 +571,111 @@ type Query @system {
     """
     args: SalesReportArgs!
   product_id: Int!): SalesReport @query(name: "SalesReport", type: SELECT_ONE) @catalog(name: "reports", engine: "duckdb")
+  UserOrders(
+    """
+    Arguments for the view
+    """
+    args: UserOrdersArgs
+
+    """
+    Filter
+    """
+    filter: UserOrders_filter
+
+    """
+    Sort options for the result set
+    """
+    order_by: [OrderByField]
+
+    """
+    Limit the number of returned objects
+    """
+    limit: Int = 2000
+
+    """
+    Skip the first n objects
+    """
+    offset: Int = 0
+
+    """
+    Distinct on the given fields
+    """
+    distinct_on: [String]
+  ): [UserOrders] @query(name: "UserOrders", type: SELECT) @catalog(name: "reports", engine: "duckdb")
+  """
+  The aggregation for UserOrders
+  """
+  UserOrders_aggregation(
+    """
+    Arguments for the view
+    """
+    args: UserOrdersArgs
+
+    """
+    Filter
+    """
+    filter: UserOrders_filter
+
+    """
+    Sort options for the result set
+    """
+    order_by: [OrderByField]
+
+    """
+    Limit the number of returned objects
+    """
+    limit: Int = 2000
+
+    """
+    Skip the first n objects
+    """
+    offset: Int = 0
+
+    """
+    Distinct on the given fields
+    """
+    distinct_on: [String]
+  ): _UserOrders_aggregation @aggregation_query(name: "UserOrders", is_bucket: false) @catalog(name: "reports", engine: "duckdb")
+  """
+  The aggregation for UserOrders
+  """
+  UserOrders_bucket_aggregation(
+    """
+    Arguments for the view
+    """
+    args: UserOrdersArgs
+
+    """
+    Filter
+    """
+    filter: UserOrders_filter
+
+    """
+    Sort options for the result set
+    """
+    order_by: [OrderByField]
+
+    """
+    Limit the number of returned objects
+    """
+    limit: Int = 2000
+
+    """
+    Skip the first n objects
+    """
+    offset: Int = 0
+
+    """
+    Distinct on the given fields
+    """
+    distinct_on: [String]
+  ): [_UserOrders_aggregation_bucket] @aggregation_query(name: "UserOrders", is_bucket: true) @catalog(name: "reports", engine: "duckdb")
+  UserOrders_by_pk(
+    """
+    Arguments for the view
+    """
+    args: UserOrdersArgs
+  order_id: Int!): UserOrders @query(name: "UserOrders", type: SELECT_ONE) @catalog(name: "reports", engine: "duckdb")
   function: Function @system
   """
   H3 aggregation query
@@ -797,6 +902,28 @@ enum UniqueRuleType @system {
   EQUALS
   INTERSECTS
 }
+type UserOrders @view(name: "user_orders_view", sql: "SELECT * FROM [orders] WHERE user_id = [$auth.user_id] AND status = [$status]") @args(name: "UserOrdersArgs") @catalog(name: "reports", engine: "duckdb") @filter_input(name: "UserOrders_filter") @query(name: "UserOrders", type: SELECT) @query(name: "UserOrders_by_pk", type: SELECT_ONE) @query(name: "UserOrders_aggregation", type: AGGREGATE) @query(name: "UserOrders_bucket_aggregation", type: AGGREGATE_BUCKET) {
+  _join(fields: [String!]!): _join
+  order_id: Int! @pk
+  status: String
+  total: Float
+  user_id: Int
+}
+input UserOrdersArgs @catalog(name: "reports", engine: "duckdb") {
+  status: String @field_source(field: "status")
+}
+"""
+Filter for UserOrders objects
+"""
+input UserOrders_filter @filter_input(name: "UserOrders") @catalog(name: "reports", engine: "duckdb") {
+  _and: [UserOrders_filter]
+  _not: UserOrders_filter
+  _or: [UserOrders_filter]
+  order_id: IntFilter @pk
+  status: StringFilter
+  total: FloatFilter
+  user_id: IntFilter
+}
 """
 The `Vector` scalar type represents a fixed-length array of floating-point numbers, used for embeddings and similarity search.
 Filter operators: is_null
@@ -873,6 +1000,44 @@ type _SalesReport_aggregation_sub_aggregation @aggregation(name: "_SalesReport_a
   order_count: BigIntSubAggregation @field_aggregation(name: "order_count")
   product_id: IntSubAggregation @field_aggregation(name: "product_id")
   total_sales: FloatSubAggregation @field_aggregation(name: "total_sales")
+}
+type _UserOrders_aggregation @aggregation(name: "UserOrders", is_bucket: false, level: 1) @catalog(name: "reports", engine: "duckdb") {
+  _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
+  _rows_count: BigInt
+  order_id: IntAggregation @field_aggregation(name: "order_id")
+  status: StringAggregation @field_aggregation(name: "status")
+  total: FloatAggregation @field_aggregation(name: "total")
+  user_id: IntAggregation @field_aggregation(name: "user_id")
+}
+"""
+Bucket aggregation for UserOrders
+"""
+type _UserOrders_aggregation_bucket @aggregation(name: "UserOrders", is_bucket: true, level: 1) @catalog(name: "reports", engine: "duckdb") {
+  """
+  The aggregations of the bucket
+  """
+  aggregations(
+    """
+    Filter
+    """
+    filter: UserOrders_filter
+
+    """
+    Sort options for the result set
+    """
+    order_by: [OrderByField]
+  ): _UserOrders_aggregation
+  """
+  The key of the bucket
+  """
+  key: UserOrders
+}
+type _UserOrders_aggregation_sub_aggregation @aggregation(name: "_UserOrders_aggregation", is_bucket: false, level: 2) @catalog(name: "reports", engine: "duckdb") {
+  _rows_count: BigIntAggregation @field_aggregation(name: "aggregation_field")
+  order_id: IntSubAggregation @field_aggregation(name: "order_id")
+  status: StringSubAggregation @field_aggregation(name: "status")
+  total: FloatSubAggregation @field_aggregation(name: "total")
+  user_id: IntSubAggregation @field_aggregation(name: "user_id")
 }
 """
 Value distribution data type
@@ -1129,6 +1294,159 @@ type _join @system {
     """
     nested_offset: Int
   ): [_SalesReport_aggregation_bucket] @aggregation_query(is_bucket: true, name: "SalesReport") @catalog(name: "reports", engine: "duckdb")
+  UserOrders(
+    """
+    Arguments for the view
+    """
+    args: UserOrdersArgs
+  fields: [String!]!,
+    """
+    Filter
+    """
+    filter: UserOrders_filter
+
+    """
+    Sort options for the result set
+    """
+    order_by: [OrderByField]
+
+    """
+    Limit the number of returned objects
+    """
+    limit: Int = 2000
+
+    """
+    Skip the first n objects
+    """
+    offset: Int = 0
+
+    """
+    Distinct on the given fields
+    """
+    distinct_on: [String]
+
+    """
+    Apply inner join to the result set
+    """
+    inner: Boolean = false
+
+    """
+    Sort options for the nested result set
+    """
+    nested_order_by: [OrderByField]
+
+    """
+    Limit the number of returned nested objects
+    """
+    nested_limit: Int
+
+    """
+    Skip the first n nested objects
+    """
+    nested_offset: Int
+  ): [UserOrders] @query(name: "UserOrders", type: SELECT) @catalog(name: "reports", engine: "duckdb")
+  UserOrders_aggregation(
+    """
+    Arguments for the view
+    """
+    args: UserOrdersArgs
+  fields: [String!]!,
+    """
+    Filter
+    """
+    filter: UserOrders_filter
+
+    """
+    Sort options for the result set
+    """
+    order_by: [OrderByField]
+
+    """
+    Limit the number of returned objects
+    """
+    limit: Int = 2000
+
+    """
+    Skip the first n objects
+    """
+    offset: Int = 0
+
+    """
+    Distinct on the given fields
+    """
+    distinct_on: [String]
+
+    """
+    Apply inner join to the result set
+    """
+    inner: Boolean = false
+
+    """
+    Sort options for the nested result set
+    """
+    nested_order_by: [OrderByField]
+
+    """
+    Limit the number of returned nested objects
+    """
+    nested_limit: Int
+
+    """
+    Skip the first n nested objects
+    """
+    nested_offset: Int
+  ): _UserOrders_aggregation @aggregation_query(is_bucket: false, name: "UserOrders") @catalog(name: "reports", engine: "duckdb")
+  UserOrders_bucket_aggregation(
+    """
+    Arguments for the view
+    """
+    args: UserOrdersArgs
+  fields: [String!]!,
+    """
+    Filter
+    """
+    filter: UserOrders_filter
+
+    """
+    Sort options for the result set
+    """
+    order_by: [OrderByField]
+
+    """
+    Limit the number of returned objects
+    """
+    limit: Int = 2000
+
+    """
+    Skip the first n objects
+    """
+    offset: Int = 0
+
+    """
+    Distinct on the given fields
+    """
+    distinct_on: [String]
+
+    """
+    Apply inner join to the result set
+    """
+    inner: Boolean = false
+
+    """
+    Sort options for the nested result set
+    """
+    nested_order_by: [OrderByField]
+
+    """
+    Limit the number of returned nested objects
+    """
+    nested_limit: Int
+
+    """
+    Skip the first n nested objects
+    """
+    nested_offset: Int
+  ): [_UserOrders_aggregation_bucket] @aggregation_query(is_bucket: true, name: "UserOrders") @catalog(name: "reports", engine: "duckdb")
 }
 type _join_aggregation @aggregation(name: "_join", is_bucket: false, level: 1) {
   SalesReport(
@@ -1172,6 +1490,47 @@ type _join_aggregation @aggregation(name: "_join", is_bucket: false, level: 1) {
     """
     nested_offset: Int
   ): _SalesReport_aggregation @aggregation_query(is_bucket: false, name: "SalesReport") @catalog(name: "reports", engine: "duckdb") @field_aggregation(name: "SalesReport")
+  UserOrders(
+    """
+    Arguments for the view
+    """
+    args: UserOrdersArgs
+  fields: [String!]!,
+    """
+    Filter
+    """
+    filter: UserOrders_filter
+
+    """
+    Sort options for the result set
+    """
+    order_by: [OrderByField]
+
+    """
+    Distinct on the given fields
+    """
+    distinct_on: [String]
+
+    """
+    Apply inner join to the result set
+    """
+    inner: Boolean = false
+
+    """
+    Sort options for the nested result set
+    """
+    nested_order_by: [OrderByField]
+
+    """
+    Limit the number of returned nested objects
+    """
+    nested_limit: Int
+
+    """
+    Skip the first n nested objects
+    """
+    nested_offset: Int
+  ): _UserOrders_aggregation @aggregation_query(is_bucket: false, name: "UserOrders") @catalog(name: "reports", engine: "duckdb") @field_aggregation(name: "UserOrders")
 }
 type _spatial @system
 type _spatial_aggregation @aggregation(name: "_spatial", is_bucket: false, level: 1)

--- a/integration-test/compiler/testdata/07_view_parameterized/schemes/01_schema.graphql
+++ b/integration-test/compiler/testdata/07_view_parameterized/schemes/01_schema.graphql
@@ -10,3 +10,20 @@ type SalesReport @view(name: "sales_report_view", sql: "SELECT * FROM sales WHER
   total_sales: Float
   order_count: BigInt
 }
+
+# Parameterized view with [table] reference and [$auth.*] context placeholder.
+# [orders] is a database table resolved at runtime with source prefix.
+# [$auth.user_id] is a known context placeholder resolved from auth context.
+input UserOrdersArgs {
+  status: String @field_source(field: "status")
+}
+
+type UserOrders @view(
+  name: "user_orders_view",
+  sql: "SELECT * FROM [orders] WHERE user_id = [$auth.user_id] AND status = [$status]"
+) @args(name: "UserOrdersArgs") {
+  order_id: Int! @pk
+  user_id: Int
+  status: String
+  total: Float
+}

--- a/pkg/cache/query.go
+++ b/pkg/cache/query.go
@@ -2,11 +2,11 @@ package cache
 
 import (
 	"bytes"
-	"strconv"
 	"time"
 
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
 	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
+	"github.com/hugr-lab/query-engine/pkg/catalog/types"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/formatter"
 )
@@ -70,8 +70,8 @@ func cacheDirectiveInfo(d *ast.Directive, vars map[string]any) Info {
 	if d == nil {
 		return Info{}
 	}
-
-	ttl, _ := strconv.Atoi(sdl.DirectiveArgValue(d, "ttl", vars))
+	ttlStr := sdl.DirectiveArgValue(d, "ttl", vars)
+	ttl, _ := types.ParseIntervalValue(ttlStr)
 
 	return Info{
 		Key:  sdl.DirectiveArgValue(d, "key", vars),

--- a/pkg/catalog/compiler/base/base.graphql
+++ b/pkg/catalog/compiler/base/base.graphql
@@ -212,7 +212,8 @@ enum UniqueRuleType @system {
 }
 
 directive @cache(
-	ttl: Int
+	"Time to live for the cache entry"
+	ttl: Interval
 	"""
 	Cache key for the query
 	"""

--- a/pkg/catalog/compiler/rules/validate_definitions.go
+++ b/pkg/catalog/compiler/rules/validate_definitions.go
@@ -453,8 +453,10 @@ func validateFunctionSQL(def *ast.Definition) error {
 
 // validateViewArgs validates @view + @args consistency:
 // - The @args input type must exist and be INPUT_OBJECT
-// - If @view has sql: argument, [paramName] references must be either
-//   view fields, $-prefixed system vars, or input args fields
+// - If @view has sql: argument, [$paramName] references must be either
+//   args input fields, known context placeholders ([$auth.*]), or [$catalog].
+//   Non-$-prefixed references like [table_name] are database table/view names
+//   resolved at runtime by Object.SQL() and are not validated here.
 func validateViewArgs(ctx base.CompilationContext, def *ast.Definition) error {
 	argsDir := def.Directives.ForName(base.ViewArgsDirectiveName)
 	argInputName := base.DirectiveArgString(argsDir, base.ArgName)
@@ -485,19 +487,28 @@ func validateViewArgs(ctx base.CompilationContext, def *ast.Definition) error {
 
 	refs := extractFieldsFromSQL(sql)
 	for _, ref := range refs {
-		if strings.HasPrefix(ref, "$") {
+		if !strings.HasPrefix(ref, "$") {
+			// No $ prefix → database table/view reference (e.g. [sales]).
+			// Resolved at runtime by Object.SQL() with source prefix.
 			continue
 		}
-		// Check if ref is a field of the view itself
-		if hasField(def, ref) {
+		// $ prefix → argument or context placeholder.
+		argName := ref[1:] // strip leading "$"
+
+		// [$catalog] — system variable resolved by Object.SQL()
+		if ref == base.CatalogSystemVariableName {
 			continue
 		}
-		// Check if ref is a field of the args input type
-		if inputDef.Fields.ForName(ref) != nil {
+		// [$auth.*] — known context placeholders resolved by ApplyArguments()
+		if sdl.IsKnownPlaceholder("[" + ref + "]") {
+			continue
+		}
+		// Must be an args input field: [$field_name]
+		if inputDef.Fields.ForName(argName) != nil {
 			continue
 		}
 		return gqlerror.ErrorPosf(viewDir.Position,
-			"@view on %q: sql references unknown field or argument %q", def.Name, ref)
+			"@view on %q: sql references unknown argument \"[$%s]\"", def.Name, argName)
 	}
 	return nil
 }

--- a/pkg/catalog/types/scalar_interval.go
+++ b/pkg/catalog/types/scalar_interval.go
@@ -99,7 +99,7 @@ func (i *Interval) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	*i = Interval(time.Duration(d))
+	*i = Interval(time.Duration(d) * time.Second)
 	return nil
 }
 
@@ -109,6 +109,9 @@ func ParseIntervalValue(v any) (time.Duration, error) {
 	}
 	switch v := v.(type) {
 	case string:
+		if v == "" {
+			return 0, nil
+		}
 		d, err := ParseSQLInterval(v)
 		if err != nil {
 			return 0, err
@@ -117,6 +120,8 @@ func ParseIntervalValue(v any) (time.Duration, error) {
 	case int:
 		return time.Duration(v) * time.Second, nil
 	case int64:
+		return time.Duration(v) * time.Second, nil
+	case float64:
 		return time.Duration(v) * time.Second, nil
 	case time.Duration:
 		return v, nil
@@ -130,34 +135,43 @@ func ParseIntervalValue(v any) (time.Duration, error) {
 var intervalRegex = regexp.MustCompile(`(?i)(\d+)\s*(day|hour|minute|second)s?`)
 
 func ParseSQLInterval(s string) (time.Duration, error) {
+	// Try Go duration format first: "10m", "1h30m", "5s", "10m2s"
+	if d, err := time.ParseDuration(s); err == nil {
+		return d, nil
+	}
+
+	// Try SQL interval format: "10 minutes", "1 hour 30 seconds"
 	matches := intervalRegex.FindAllStringSubmatch(s, -1)
-	if matches == nil {
-		return 0, fmt.Errorf("invalid interval format: %s", s)
+	if matches != nil {
+		var totalDuration time.Duration
+		for _, match := range matches {
+			value, err := strconv.Atoi(match[1])
+			if err != nil {
+				return 0, fmt.Errorf("invalid number in interval: %s", match[1])
+			}
+			unit := strings.ToLower(match[2])
+			switch unit {
+			case "day", "days", "d":
+				totalDuration += time.Duration(value) * 24 * time.Hour
+			case "hour", "hours", "h":
+				totalDuration += time.Duration(value) * time.Hour
+			case "minute", "minutes", "m":
+				totalDuration += time.Duration(value) * time.Minute
+			case "second", "seconds", "s":
+				totalDuration += time.Duration(value) * time.Second
+			default:
+				return 0, fmt.Errorf("invalid time unit in interval: %s", unit)
+			}
+		}
+		return totalDuration, nil
 	}
 
-	var totalDuration time.Duration
-	for _, match := range matches {
-		value, err := strconv.Atoi(match[1])
-		if err != nil {
-			return 0, fmt.Errorf("invalid number in interval: %s", match[1])
-		}
-
-		unit := strings.ToLower(match[2])
-		switch unit {
-		case "day", "days", "d":
-			totalDuration += time.Duration(value) * 24 * time.Hour
-		case "hour", "hours", "h":
-			totalDuration += time.Duration(value) * time.Hour
-		case "minute", "minutes", "m":
-			totalDuration += time.Duration(value) * time.Minute
-		case "second", "seconds", "s":
-			totalDuration += time.Duration(value) * time.Second
-		default:
-			return 0, fmt.Errorf("invalid time unit in interval: %s", unit)
-		}
+	// Try bare number: "2" → 2 seconds
+	if v, err := strconv.ParseFloat(s, 64); err == nil {
+		return time.Duration(v * float64(time.Second)), nil
 	}
 
-	return totalDuration, nil
+	return 0, fmt.Errorf("invalid interval format: %s", s)
 }
 
 func IntervalToSQLValue(v any) (string, error) {

--- a/pkg/mcp/discovery.go
+++ b/pkg/mcp/discovery.go
@@ -21,28 +21,32 @@ func (s *Server) searchModules(ctx context.Context, req mcp.CallToolRequest) (*m
 		Desc     string  `json:"description"`
 		Distance float64 `json:"_distance_to_query"`
 	}
-	err := s.queryScanAdmin(ctx, `query($query: String!, $limit: Int) {
+	err := s.queryScanAdmin(ctx, `query($query: String!) {
 		core {
 			catalog {
 				modules(
 					order_by: [{field: "_distance_to_query", direction: ASC}]
-					limit: $limit
-				) {
+				) @cache(ttl: "10m") {
 					name
 					description
 					_distance_to_query(query: $query)
 				}
 			}
 		}
-	}`, map[string]any{"query": query, "limit": topK}, "core.catalog.modules", &items)
+	}`, map[string]any{"query": query}, "core.catalog.modules", &items)
 	if err != nil {
 		return toolResultError(fmt.Sprintf("query failed: %v", err)), nil
 	}
 
 	filter := newMCPFilter(ctx)
 	var result []ModuleSearchItem
+	var total int
 	for _, item := range items {
 		if !filter.visibleModule(item.Name) {
+			continue
+		}
+		total++
+		if len(result) >= topK {
 			continue
 		}
 		score := distanceToScore(item.Distance)
@@ -57,7 +61,7 @@ func (s *Server) searchModules(ctx context.Context, req mcp.CallToolRequest) (*m
 	}
 
 	return toolResultJSON(SearchResult[ModuleSearchItem]{
-		Total:    len(items),
+		Total:    total,
 		Returned: len(result),
 		Items:    result,
 	}), nil
@@ -79,13 +83,12 @@ func (s *Server) searchDataSources(ctx context.Context, req mcp.CallToolRequest)
 		AsModule bool    `json:"as_module"`
 		Distance float64 `json:"_distance_to_query"`
 	}
-	err := s.queryScanAdmin(ctx, `query($query: String!, $limit: Int) {
+	err := s.queryScanAdmin(ctx, `query($query: String!) {
 		core {
 			catalog {
 				schema_catalogs(
 					order_by: [{field: "_distance_to_query", direction: ASC}]
-					limit: $limit
-				) {
+				) @cache(ttl: "10m") {
 					name
 					description
 					type
@@ -95,15 +98,20 @@ func (s *Server) searchDataSources(ctx context.Context, req mcp.CallToolRequest)
 				}
 			}
 		}
-	}`, map[string]any{"query": query, "limit": topK}, "core.catalog.schema_catalogs", &items)
+	}`, map[string]any{"query": query}, "core.catalog.schema_catalogs", &items)
 	if err != nil {
 		return toolResultError(fmt.Sprintf("query failed: %v", err)), nil
 	}
 
 	filter := newMCPFilter(ctx)
 	var result []DataSourceSearchItem
+	var total int
 	for _, item := range items {
 		if !filter.visibleDataSource(item.Name) {
+			continue
+		}
+		total++
+		if len(result) >= topK {
 			continue
 		}
 		score := distanceToScore(item.Distance)
@@ -121,7 +129,7 @@ func (s *Server) searchDataSources(ctx context.Context, req mcp.CallToolRequest)
 	}
 
 	return toolResultJSON(SearchResult[DataSourceSearchItem]{
-		Total:    len(items),
+		Total:    total,
 		Returned: len(result),
 		Items:    result,
 	}), nil
@@ -162,7 +170,7 @@ func (s *Server) searchModuleDataObjects(ctx context.Context, req mcp.CallToolRe
 					filter: $filter
 					order_by: [{field: "_distance_to_query", direction: ASC}]
 					limit: $limit
-				) {
+				) @cache(ttl: "10m") {
 					name
 					hugr_type
 					description
@@ -183,7 +191,7 @@ func (s *Server) searchModuleDataObjects(ctx context.Context, req mcp.CallToolRe
 			"hugr_type": map[string]any{"in": []string{"table", "view"}},
 			"module":    moduleFilter,
 		},
-		"limit": topK,
+		"limit": 100,
 		"query": query,
 	}, "core.catalog.types", &items)
 	if err != nil {
@@ -192,8 +200,13 @@ func (s *Server) searchModuleDataObjects(ctx context.Context, req mcp.CallToolRe
 
 	filter := newMCPFilter(ctx)
 	var result []DataObjectSearchItem
+	var total int
 	for _, item := range items {
 		if !filter.visibleType(item.Name) {
+			continue
+		}
+		total++
+		if len(result) >= topK {
 			continue
 		}
 		score := distanceToScore(item.Distance)
@@ -222,7 +235,7 @@ func (s *Server) searchModuleDataObjects(ctx context.Context, req mcp.CallToolRe
 	}
 
 	return toolResultJSON(SearchResult[DataObjectSearchItem]{
-		Total:    len(items),
+		Total:    total,
 		Returned: len(result),
 		Items:    result,
 	}), nil

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -29,12 +29,12 @@ type DataSourceSearchItem struct {
 // --- Discovery: Data Objects ---
 
 type DataObjectSearchItem struct {
-	Name        string               `json:"name"        jsonschema_description:"Full type name (e.g. prefix_tablename)"`
-	Module      string               `json:"module"      jsonschema_description:"Module path (e.g. sales.analytics)"`
-	Description string               `json:"description"`
-	ObjectType  string               `json:"object_type" jsonschema_description:"table or view"`
-	Score       float64              `json:"score"`
-	Queries     []DataObjectQuery    `json:"queries"     jsonschema_description:"Available query fields in module namespace"`
+	Name        string                 `json:"name"        jsonschema_description:"Full type name (e.g. prefix_tablename)"`
+	Module      string                 `json:"module"      jsonschema_description:"Module path (e.g. sales.analytics)"`
+	Description string                 `json:"description"`
+	ObjectType  string                 `json:"object_type" jsonschema_description:"table or view"`
+	Score       float64                `json:"score"`
+	Queries     []DataObjectQuery      `json:"queries"     jsonschema_description:"Available query fields in module namespace"`
 	Fields      []DataObjectFieldBrief `json:"fields,omitempty" jsonschema_description:"Top fields (scalars and relations)"`
 }
 
@@ -70,8 +70,8 @@ type FunctionArgument struct {
 }
 
 type FunctionReturnType struct {
-	TypeName string              `json:"type_name"`
-	IsList   bool               `json:"is_list"`
+	TypeName string                `json:"type_name"`
+	IsList   bool                  `json:"is_list"`
 	Fields   []FunctionReturnField `json:"fields,omitempty" jsonschema_description:"Top fields of return type (up to 10)"`
 }
 


### PR DESCRIPTION
## Summary

- **validateViewArgs**: `[table]` refs (no `$` prefix) are now skipped as runtime table references resolved by `Object.SQL()`; `[$arg]` refs are validated against the args input type; `[$auth.*]` and `[$catalog]` recognized as known context placeholders
- **ParseSQLInterval**: now supports Go duration format (`10m`, `1h30m`), SQL interval format (`10 minutes`), and bare numbers as seconds (`"2"` → 2s)
- **@cache directive**: `ttl` changed from `Int` to `Interval`, parsed via `ParseIntervalValue`
- **MCP discovery**: `@cache(ttl: "10m")` on search queries, visibility filter before topK limit, correct `total` count

## Test plan

- [x] Golden tests: 69/69 pass (including updated `07_view_parameterized` with `[table]` ref + `[$auth.*]`)
- [x] Compiler integration tests: all pass (including updated `TestValidate_ViewArgs_SQLWithUnknownRef`)
- [x] Catalog unit tests: 12/12 pass
- [x] Models integration tests: 18/18 pass
- [x] MCP integration tests: all pass
- [x] E2E main + cluster: 209/209 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)