### PR TITLE
feat: unified streaming tool calls across all LLM providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-21
 - DuckDB embedded + PostgreSQL CoreDB (no migration needed — `_schema_arguments.directives` JSON column already exists) (001-function-arg-placeholders)
 - Go 1.26 (with `iter.Seq`, range-over-func) + `gqlparser/v2` (GraphQL AST + directive parsing), `duckdb-go/v2` (CGo, `duckdb_arrow`), `apache/arrow-go/v18`, `airport-go` (Arrow Flight protocol for hugr-app catalog) (001-hugrapp-struct-args)
 - DuckDB embedded; no schema changes (001-hugrapp-struct-args)
+- Go 1.26 with `duckdb_arrow` build tag + `duckdb-go/v2`, `gqlparser/v2`, `apache/arrow-go/v18` (001-streaming-tool-calls)
+- N/A (no storage changes) (001-streaming-tool-calls)
 
 ## Project Structure
 
@@ -44,6 +46,6 @@ Go 1.26: Follow standard conventions
 <!-- MANUAL ADDITIONS END -->
 
 ## Recent Changes
+- 001-streaming-tool-calls: Added Go 1.26 with `duckdb_arrow` build tag + `duckdb-go/v2`, `gqlparser/v2`, `apache/arrow-go/v18`
 - 001-hugrapp-struct-args: Added Go 1.26 (with `iter.Seq`, range-over-func) + `gqlparser/v2` (GraphQL AST + directive parsing), `duckdb-go/v2` (CGo, `duckdb_arrow`), `apache/arrow-go/v18`, `airport-go` (Arrow Flight protocol for hugr-app catalog)
 - 001-function-arg-placeholders: Added Go 1.26 (with `iter.Seq`, range-over-func) + `gqlparser/v2` (GraphQL AST + directive parsing), `duckdb-go/v2` (CGo, `duckdb_arrow`), `apache/arrow-go/v18`
-- 001-perm-impersonation: Added Go 1.26 (with `iter.Seq`, range-over-func) + `duckdb-go/v2` (CGo, `duckdb_arrow`), `gqlparser/v2`, `gorilla/websocket`, `apache/arrow-go/v18`

--- a/integration-test/models/models_test.go
+++ b/integration-test/models/models_test.go
@@ -4,6 +4,7 @@ package models_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -604,4 +605,86 @@ func TestModels_Sources_AllProviders(t *testing.T) {
 		t.Logf("source: name=%s type=%s provider=%s model=%s", s["name"], s["type"], s["provider"], s["model"])
 	}
 	t.Logf("total sources: %d, providers: %v", len(srcs), providers)
+}
+
+// --- US4: Streaming Tool Call Format Tests ---
+
+const streamToolCallQuery = `subscription { core { models { chat_completion(
+	model: "%s",
+	messages: ["{\"role\":\"user\",\"content\":\"What is the weather in London?\"}"],
+	tools: ["{\"name\":\"get_weather\",\"description\":\"Get weather for a city\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}"],
+	tool_choice: "auto",
+	max_tokens: 200
+) {
+	type content finish_reason tool_calls prompt_tokens completion_tokens
+} } } }`
+
+// assertStreamToolCalls validates that the finish event tool_calls field
+// contains a valid []LLMToolCall JSON array with id, name, and arguments.
+func assertStreamToolCalls(t *testing.T, provider string, events []map[string]any) {
+	t.Helper()
+
+	var finishEvent map[string]any
+	for _, e := range events {
+		if fmt.Sprintf("%v", e["type"]) == "finish" {
+			finishEvent = e
+		}
+	}
+	require.NotNil(t, finishEvent, "%s: should have a finish event", provider)
+
+	toolCallsRaw := finishEvent["tool_calls"]
+	require.NotNil(t, toolCallsRaw, "%s: finish event should have tool_calls", provider)
+
+	toolCallsStr := fmt.Sprintf("%v", toolCallsRaw)
+	require.NotEmpty(t, toolCallsStr, "%s: tool_calls should not be empty", provider)
+
+	var calls []types.LLMToolCall
+	err := json.Unmarshal([]byte(toolCallsStr), &calls)
+	require.NoError(t, err, "%s: tool_calls should parse as []LLMToolCall, got: %s", provider, toolCallsStr)
+	require.NotEmpty(t, calls, "%s: should have at least one tool call", provider)
+
+	for i, tc := range calls {
+		assert.NotEmpty(t, tc.Name, "%s: tool call[%d] should have a name", provider, i)
+		assert.NotNil(t, tc.Arguments, "%s: tool call[%d] should have arguments", provider, i)
+		t.Logf("%s stream tool call[%d]: id=%s name=%s args=%v", provider, i, tc.ID, tc.Name, tc.Arguments)
+	}
+
+	t.Logf("%s stream finish: finish_reason=%v, tool_calls=%d items", provider, finishEvent["finish_reason"], len(calls))
+}
+
+func TestModels_StreamChatCompletionWithTools_OpenAI(t *testing.T) {
+	if os.Getenv("LLM_URL") == "" {
+		t.Skip("LLM_URL not set")
+	}
+	events := collectStreamEvents(t, fmt.Sprintf(streamToolCallQuery, "test_llm"))
+	require.NotEmpty(t, events, "should receive streaming events")
+	assertStreamToolCalls(t, "OpenAI", events)
+}
+
+func TestModels_StreamChatCompletionWithTools_Anthropic(t *testing.T) {
+	if os.Getenv("ANTHROPIC_KEY") == "" {
+		t.Skip("ANTHROPIC_KEY not set")
+	}
+	// Anthropic with thinking requires max_tokens > thinking_budget (configured at 2048).
+	q := `subscription { core { models { chat_completion(
+		model: "test_anthropic",
+		messages: ["{\"role\":\"user\",\"content\":\"What is the weather in London?\"}"],
+		tools: ["{\"name\":\"get_weather\",\"description\":\"Get weather for a city\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}"],
+		tool_choice: "auto",
+		max_tokens: 4096
+	) {
+		type content finish_reason tool_calls prompt_tokens completion_tokens
+	} } } }`
+	events := collectStreamEvents(t, q)
+	require.NotEmpty(t, events, "should receive streaming events")
+	assertStreamToolCalls(t, "Anthropic", events)
+}
+
+func TestModels_StreamChatCompletionWithTools_Gemini(t *testing.T) {
+	if os.Getenv("GEMINI_KEY") == "" {
+		t.Skip("GEMINI_KEY not set")
+	}
+	events := collectStreamEvents(t, fmt.Sprintf(streamToolCallQuery, "test_gemini"))
+	require.NotEmpty(t, events, "should receive streaming events")
+	assertStreamToolCalls(t, "Gemini", events)
 }

--- a/pkg/data-sources/sources/llm/anthropic.go
+++ b/pkg/data-sources/sources/llm/anthropic.go
@@ -427,6 +427,15 @@ func (s *AnthropicSource) CreateChatCompletionStream(ctx context.Context, messag
 	var model string
 	var promptTokens, completionTokens int
 
+	// pendingToolCalls accumulates tool call data from content_block_start
+	// (id, name) and content_block_delta (input_json_delta fragments).
+	type pendingToolCall struct {
+		ID       string
+		Name     string
+		ArgsJSON strings.Builder
+	}
+	pendingToolCallsByIndex := make(map[int]*pendingToolCall)
+
 	scanner := bufio.NewScanner(resp.Body)
 	var currentEventType string
 	for scanner.Scan() {
@@ -456,12 +465,33 @@ func (s *AnthropicSource) CreateChatCompletionStream(ctx context.Context, messag
 				promptTokens = msg.Message.Usage.InputTokens
 			}
 
+		case "content_block_start":
+			var cbs struct {
+				Index        int `json:"index"`
+				ContentBlock struct {
+					Type string `json:"type"`
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"content_block"`
+			}
+			if err := json.Unmarshal([]byte(data), &cbs); err != nil {
+				continue
+			}
+			if cbs.ContentBlock.Type == "tool_use" {
+				pendingToolCallsByIndex[cbs.Index] = &pendingToolCall{
+					ID:   cbs.ContentBlock.ID,
+					Name: cbs.ContentBlock.Name,
+				}
+			}
+
 		case "content_block_delta":
 			var delta struct {
+				Index int `json:"index"`
 				Delta struct {
-					Type     string `json:"type"`
-					Text     string `json:"text"`
-					Thinking string `json:"thinking"`
+					Type        string `json:"type"`
+					Text        string `json:"text"`
+					Thinking    string `json:"thinking"`
+					PartialJSON string `json:"partial_json"`
 				} `json:"delta"`
 			}
 			if err := json.Unmarshal([]byte(data), &delta); err != nil {
@@ -483,6 +513,10 @@ func (s *AnthropicSource) CreateChatCompletionStream(ctx context.Context, messag
 					Model:   model,
 				}); err != nil {
 					return err
+				}
+			case "input_json_delta":
+				if ptc := pendingToolCallsByIndex[delta.Index]; ptc != nil {
+					ptc.ArgsJSON.WriteString(delta.Delta.PartialJSON)
 				}
 			}
 
@@ -510,13 +544,30 @@ func (s *AnthropicSource) CreateChatCompletionStream(ctx context.Context, messag
 						finishReason = md.Delta.StopReason
 					}
 				}
-				if err := onEvent(&sources.LLMStreamEvent{
+				ev := &sources.LLMStreamEvent{
 					Type:             "finish",
 					Model:            model,
 					FinishReason:     finishReason,
 					PromptTokens:     promptTokens,
 					CompletionTokens: completionTokens,
-				}); err != nil {
+				}
+				if len(pendingToolCallsByIndex) > 0 {
+					var calls []sources.LLMToolCall
+					for _, ptc := range pendingToolCallsByIndex {
+						var args any
+						if s := ptc.ArgsJSON.String(); s != "" {
+							_ = json.Unmarshal([]byte(s), &args)
+						}
+						calls = append(calls, sources.LLMToolCall{
+							ID:        ptc.ID,
+							Name:      ptc.Name,
+							Arguments: args,
+						})
+					}
+					b, _ := json.Marshal(calls)
+					ev.ToolCalls = string(b)
+				}
+				if err := onEvent(ev); err != nil {
 					return err
 				}
 			}

--- a/pkg/data-sources/sources/llm/gemini.go
+++ b/pkg/data-sources/sources/llm/gemini.go
@@ -239,6 +239,7 @@ func parseGeminiResponse(body []byte) (*sources.LLMResult, error) {
 				Parts []struct {
 					Text         string `json:"text"`
 					FunctionCall *struct {
+						ID   string `json:"id"`
 						Name string `json:"name"`
 						Args any    `json:"args"`
 					} `json:"functionCall"`
@@ -279,6 +280,7 @@ func parseGeminiResponse(body []byte) (*sources.LLMResult, error) {
 			}
 			if part.FunctionCall != nil {
 				result.ToolCalls = append(result.ToolCalls, sources.LLMToolCall{
+					ID:        part.FunctionCall.ID,
 					Name:      part.FunctionCall.Name,
 					Arguments: part.FunctionCall.Args,
 				})
@@ -411,6 +413,7 @@ func (s *GeminiSource) CreateChatCompletionStream(ctx context.Context, messages 
 	}
 
 	var totalPromptTokens, totalCompletionTokens int
+	var accToolCalls []sources.LLMToolCall
 
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
@@ -427,6 +430,7 @@ func (s *GeminiSource) CreateChatCompletionStream(ctx context.Context, messages 
 						Text         string `json:"text"`
 						Thought      bool   `json:"thought,omitempty"`
 						FunctionCall *struct {
+							ID   string `json:"id"`
 							Name string `json:"name"`
 							Args any    `json:"args"`
 						} `json:"functionCall"`
@@ -467,15 +471,11 @@ func (s *GeminiSource) CreateChatCompletionStream(ctx context.Context, messages 
 				}
 			}
 			if part.FunctionCall != nil {
-				b, _ := json.Marshal([]map[string]any{
-					{"name": part.FunctionCall.Name, "args": part.FunctionCall.Args},
+				accToolCalls = append(accToolCalls, sources.LLMToolCall{
+					ID:        part.FunctionCall.ID,
+					Name:      part.FunctionCall.Name,
+					Arguments: part.FunctionCall.Args,
 				})
-				if err := onEvent(&sources.LLMStreamEvent{
-					Type:      "content_delta",
-					ToolCalls: string(b),
-				}); err != nil {
-					return err
-				}
 			}
 		}
 
@@ -487,12 +487,20 @@ func (s *GeminiSource) CreateChatCompletionStream(ctx context.Context, messages 
 			case "MAX_TOKENS":
 				finishReason = "length"
 			}
-			if err := onEvent(&sources.LLMStreamEvent{
+			ev := &sources.LLMStreamEvent{
 				Type:             "finish",
 				FinishReason:     finishReason,
 				PromptTokens:     totalPromptTokens,
 				CompletionTokens: totalCompletionTokens,
-			}); err != nil {
+			}
+			if len(accToolCalls) > 0 {
+				b, _ := json.Marshal(accToolCalls)
+				ev.ToolCalls = string(b)
+				if finishReason == "stop" {
+					ev.FinishReason = "tool_use"
+				}
+			}
+			if err := onEvent(ev); err != nil {
 				return err
 			}
 		}

--- a/pkg/data-sources/sources/llm/openai.go
+++ b/pkg/data-sources/sources/llm/openai.go
@@ -417,7 +417,15 @@ func (s *OpenAISource) CreateChatCompletionStream(ctx context.Context, messages 
 	}
 
 	var totalPromptTokens, totalCompletionTokens int
-	var toolCallParts []string
+	// pendingToolCalls accumulates tool call fragments keyed by delta index.
+	// Each entry captures id/name from the first delta and concatenates
+	// argument JSON fragments across subsequent deltas.
+	type pendingToolCall struct {
+		ID       string
+		Name     string
+		ArgsJSON strings.Builder
+	}
+	var pendingToolCalls []*pendingToolCall
 	// finishEvent is captured when the model emits a finish_reason, but
 	// emitted only AFTER the SSE stream ends. With `stream_options.include_usage`
 	// the OpenAI-compatible server sends a trailing chunk with `choices: []`
@@ -442,6 +450,7 @@ func (s *OpenAISource) CreateChatCompletionStream(ctx context.Context, messages 
 					Content          string `json:"content"`
 					ReasoningContent string `json:"reasoning_content"`
 					ToolCalls        []struct {
+						Index    int    `json:"index"`
 						ID       string `json:"id"`
 						Function struct {
 							Name      string `json:"name"`
@@ -471,11 +480,21 @@ func (s *OpenAISource) CreateChatCompletionStream(ctx context.Context, messages 
 		}
 		choice := chunk.Choices[0]
 
-		// Accumulate tool call argument fragments
+		// Accumulate tool call fragments per-index.
+		// The first delta for each index carries id and function.name;
+		// subsequent deltas carry only argument fragments.
 		for _, tc := range choice.Delta.ToolCalls {
-			if tc.Function.Arguments != "" {
-				toolCallParts = append(toolCallParts, tc.Function.Arguments)
+			for tc.Index >= len(pendingToolCalls) {
+				pendingToolCalls = append(pendingToolCalls, &pendingToolCall{})
 			}
+			ptc := pendingToolCalls[tc.Index]
+			if tc.ID != "" {
+				ptc.ID = tc.ID
+			}
+			if tc.Function.Name != "" {
+				ptc.Name = tc.Function.Name
+			}
+			ptc.ArgsJSON.WriteString(tc.Function.Arguments)
 		}
 
 		if choice.Delta.ReasoningContent != "" {
@@ -508,8 +527,21 @@ func (s *OpenAISource) CreateChatCompletionStream(ctx context.Context, messages 
 				Model:        chunk.Model,
 				FinishReason: normalizeFinishReasonOpenAI(*choice.FinishReason),
 			}
-			if len(toolCallParts) > 0 {
-				finishEvent.ToolCalls = strings.Join(toolCallParts, "")
+			if len(pendingToolCalls) > 0 {
+				var calls []sources.LLMToolCall
+				for _, ptc := range pendingToolCalls {
+					var args any
+					if s := ptc.ArgsJSON.String(); s != "" {
+						_ = json.Unmarshal([]byte(s), &args)
+					}
+					calls = append(calls, sources.LLMToolCall{
+						ID:        ptc.ID,
+						Name:      ptc.Name,
+						Arguments: args,
+					})
+				}
+				b, _ := json.Marshal(calls)
+				finishEvent.ToolCalls = string(b)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- **OpenAI**: accumulate tool call `id`/`name` from first delta chunk per-index + argument fragments; `json.Marshal([]LLMToolCall)` on finish event
- **Anthropic**: handle `content_block_start` (`tool_use`) and `content_block_delta` (`input_json_delta`) SSE events; include accumulated tool calls in finish event (was empty before)
- **Gemini**: accumulate `functionCall` parts into finish event instead of emitting as `content_delta`; capture `id` field (Gemini 3+) in both streaming and non-streaming paths
- **Tests**: 3 new streaming-with-tools tests + `assertStreamToolCalls` helper validating `[]LLMToolCall` format

All three providers now produce identical tool call format in streaming finish events:
```json
[{"id":"...","name":"get_weather","arguments":{"city":"London"}}]
```

## Test plan

- [x] `TestModels_StreamChatCompletionWithTools_OpenAI` — pass
- [x] `TestModels_StreamChatCompletionWithTools_Anthropic` — pass
- [x] `TestModels_StreamChatCompletionWithTools_Gemini` — pass
- [x] All 21 models integration tests pass (no regressions)
- [x] Build clean: `go build -tags=duckdb_arrow ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)