### PR TITLE
feat: Anthropic thinking round-trip + OpenAI Responses API

### DIFF
--- a/integration-test/models/models_test.go
+++ b/integration-test/models/models_test.go
@@ -115,6 +115,18 @@ func registerDS(ctx context.Context, s *hugr.Service) {
 			},
 		})
 		mustQuery(ctx, s, `mutation { function { core { load_data_source(name: "test_openai_remote") { success } } } }`, nil)
+
+		// OpenAI Responses API DS (same key, Responses API endpoint)
+		responsesPath := "https://api.openai.com/v1/responses?model=\"gpt-5.4-mini-2026-03-17\"&api_key=" + key + "&max_tokens=4096&timeout=120s&reasoning_summary=auto"
+		mustQuery(ctx, s, `mutation($data: core_data_sources_mut_input_data!) {
+			core { insert_data_sources(data: $data) { name } }
+		}`, map[string]any{
+			"data": map[string]any{
+				"name": "test_openai_responses", "type": "llm-openai",
+				"prefix": "test_openai_responses", "as_module": false, "path": responsesPath,
+			},
+		})
+		mustQuery(ctx, s, `mutation { function { core { load_data_source(name: "test_openai_responses") { success } } } }`, nil)
 	}
 }
 
@@ -1286,4 +1298,91 @@ func TestModels_StreamThinkingToolCallRoundTrip_Anthropic(t *testing.T) {
 
 	t.Logf("Step 3 stream — %d content events, content=%q, finish=%v",
 		contentEvents, truncateStr(allContent, 200), finishEvent2["finish_reason"])
+}
+
+// --- OpenAI Responses API Tests ---
+
+func TestModels_OpenAIResponses_Completion(t *testing.T) {
+	if os.Getenv("OPENAI_KEY") == "" {
+		t.Skip("OPENAI_KEY not set")
+	}
+	res := query(t, `{ function { core { models { completion(model: "test_openai_responses", prompt: "What is 2+2? Answer with just the number.", max_tokens: 50) {
+		content model finish_reason prompt_tokens completion_tokens total_tokens provider latency_ms thinking
+	} } } } }`, nil)
+	defer res.Close()
+
+	var result struct {
+		Content      string `json:"content"`
+		Model        string `json:"model"`
+		FinishReason string `json:"finish_reason"`
+		Provider     string `json:"provider"`
+		LatencyMs    int    `json:"latency_ms"`
+		Thinking     string `json:"thinking"`
+	}
+	err := res.ScanData("function.core.models.completion", &result)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.Content)
+	assert.Equal(t, "openai", result.Provider)
+	assert.NotEmpty(t, result.FinishReason)
+	t.Logf("responses api completion: %q, model=%s, finish=%s, thinking=%q",
+		result.Content, result.Model, result.FinishReason, truncateStr(result.Thinking, 80))
+}
+
+func TestModels_OpenAIResponses_ChatWithTools(t *testing.T) {
+	if os.Getenv("OPENAI_KEY") == "" {
+		t.Skip("OPENAI_KEY not set")
+	}
+	res := query(t, `query($messages: [String!]!, $tools: [String!]) {
+		function { core { models { chat_completion(
+			model: "test_openai_responses", messages: $messages, tools: $tools,
+			tool_choice: "auto", max_tokens: 200
+		) { content finish_reason tool_calls provider } } } } }`, map[string]any{
+		"messages": []string{`{"role":"user","content":"What is the weather in Paris?"}`},
+		"tools":    []string{roundTripToolDef},
+	})
+	defer res.Close()
+
+	var result struct {
+		Content      string `json:"content"`
+		FinishReason string `json:"finish_reason"`
+		ToolCalls    string `json:"tool_calls"`
+		Provider     string `json:"provider"`
+	}
+	err := res.ScanData("function.core.models.chat_completion", &result)
+	require.NoError(t, err)
+	assert.Equal(t, "openai", result.Provider)
+	assert.NotEmpty(t, result.FinishReason)
+	if result.FinishReason == "tool_use" {
+		assert.NotEmpty(t, result.ToolCalls)
+		assert.Contains(t, result.ToolCalls, "get_weather")
+	}
+	t.Logf("responses api chat+tools: content=%q, finish=%s, tool_calls=%s",
+		result.Content, result.FinishReason, result.ToolCalls)
+}
+
+func TestModels_OpenAIResponses_ToolCallRoundTrip(t *testing.T) {
+	if os.Getenv("OPENAI_KEY") == "" {
+		t.Skip("OPENAI_KEY not set")
+	}
+	testToolCallRoundTrip(t, "test_openai_responses", "openai", 200)
+}
+
+func TestModels_OpenAIResponses_StreamCompletion(t *testing.T) {
+	if os.Getenv("OPENAI_KEY") == "" {
+		t.Skip("OPENAI_KEY not set")
+	}
+	events := collectStreamEventsWithTimeout(t,
+		`subscription { core { models { completion(model: "test_openai_responses", prompt: "Say hello in one word.", max_tokens: 50) {
+			type content model finish_reason tool_calls prompt_tokens completion_tokens thinking
+		} } } }`, 120*time.Second)
+
+	require.NotEmpty(t, events, "should receive streaming events")
+	assertStreamEvents(t, "OpenAI Responses", events)
+}
+
+func TestModels_OpenAIResponses_StreamToolCallRoundTrip(t *testing.T) {
+	if os.Getenv("OPENAI_KEY") == "" {
+		t.Skip("OPENAI_KEY not set")
+	}
+	testStreamToolCallRoundTrip(t, "test_openai_responses", "openai", 200, 120*time.Second)
 }

--- a/integration-test/models/models_test.go
+++ b/integration-test/models/models_test.go
@@ -1081,3 +1081,209 @@ func TestModels_StreamToolCallRoundTrip_OpenAIRemote(t *testing.T) {
 	}
 	testStreamToolCallRoundTrip(t, "test_openai_remote", "openai", 200, 120*time.Second)
 }
+
+// --- Anthropic Thinking Round-trip Tests ---
+// Verify that thinking content (thinking text + thought_signature) survives
+// the full tool call round-trip with extended thinking enabled.
+
+func TestModels_Anthropic_ThinkingToolCallRoundTrip(t *testing.T) {
+	if os.Getenv("ANTHROPIC_KEY") == "" {
+		t.Skip("ANTHROPIC_KEY not set")
+	}
+
+	userMsg := `{"role":"user","content":"What is the weather in Tokyo? You must use the get_weather tool."}`
+
+	// Step 1: chat_completion with thinking_budget + tools
+	step1Q := `query($messages: [String!]!, $tools: [String!]) {
+		function { core { models { chat_completion(
+			model: "test_anthropic", messages: $messages, tools: $tools,
+			tool_choice: "auto", max_tokens: 4096
+		) { content finish_reason tool_calls provider thought_signature thinking } } } } }`
+
+	res := query(t, step1Q, map[string]any{
+		"messages": []string{userMsg},
+		"tools":    []string{roundTripToolDef},
+	})
+	defer res.Close()
+
+	var result struct {
+		Content          string `json:"content"`
+		FinishReason     string `json:"finish_reason"`
+		ToolCalls        string `json:"tool_calls"`
+		Provider         string `json:"provider"`
+		ThoughtSignature string `json:"thought_signature"`
+		Thinking         string `json:"thinking"`
+	}
+	err := res.ScanData("function.core.models.chat_completion", &result)
+	require.NoError(t, err)
+	assert.Equal(t, "anthropic", result.Provider)
+	require.NotEmpty(t, result.ToolCalls, "anthropic: should call tools")
+
+	var toolCalls []types.LLMToolCall
+	err = json.Unmarshal([]byte(result.ToolCalls), &toolCalls)
+	require.NoError(t, err)
+	require.NotEmpty(t, toolCalls)
+
+	// Anthropic with thinking_budget should return thinking content
+	assert.NotEmpty(t, result.Thinking, "anthropic: should return thinking content with thinking_budget")
+	assert.NotEmpty(t, result.ThoughtSignature, "anthropic: should return thought_signature (thinking signature)")
+
+	t.Logf("Step 1 — thinking=%q (len=%d), thought_sig=%q",
+		truncateStr(result.Thinking, 80), len(result.Thinking), truncateStr(result.ThoughtSignature, 40))
+	for i, tc := range toolCalls {
+		t.Logf("Step 1 — tool_call[%d]: id=%s name=%s", i, tc.ID, tc.Name)
+	}
+
+	// Step 2: Build assistant message WITH thinking fields for round-trip
+	assistantMsg := types.LLMMessage{
+		Role:             "assistant",
+		Content:          result.Content,
+		ToolCalls:        toolCalls,
+		ThoughtSignature: result.ThoughtSignature,
+		Thinking:         result.Thinking,
+	}
+	assistantJSON, err := json.Marshal(assistantMsg)
+	require.NoError(t, err)
+
+	messages := []string{userMsg, string(assistantJSON)}
+	for _, tc := range toolCalls {
+		toolID := tc.ID
+		if toolID == "" {
+			toolID = tc.Name
+		}
+		toolResult := types.LLMMessage{
+			Role:       "tool",
+			Content:    `{"temperature": 22, "condition": "sunny", "humidity": 65}`,
+			ToolCallID: toolID,
+		}
+		toolJSON, _ := json.Marshal(toolResult)
+		messages = append(messages, string(toolJSON))
+	}
+
+	t.Logf("Step 2 — sending %d messages with thinking back to anthropic", len(messages))
+
+	// Step 3: Second request with tool results + thinking in history
+	step2Q := `query($messages: [String!]!, $tools: [String!]) {
+		function { core { models { chat_completion(
+			model: "test_anthropic", messages: $messages, tools: $tools, max_tokens: 4096
+		) { content finish_reason provider } } } } }`
+
+	res2 := query(t, step2Q, map[string]any{
+		"messages": messages,
+		"tools":    []string{roundTripToolDef},
+	})
+	defer res2.Close()
+
+	var result2 struct {
+		Content      string `json:"content"`
+		FinishReason string `json:"finish_reason"`
+		Provider     string `json:"provider"`
+	}
+	err = res2.ScanData("function.core.models.chat_completion", &result2)
+	require.NoError(t, err)
+	assert.Equal(t, "anthropic", result2.Provider)
+	assert.NotEmpty(t, result2.Content, "anthropic: should respond with content after thinking + tool results")
+
+	t.Logf("Step 3 — response: %q (finish=%s)", truncateStr(result2.Content, 200), result2.FinishReason)
+}
+
+func TestModels_StreamThinkingToolCallRoundTrip_Anthropic(t *testing.T) {
+	if os.Getenv("ANTHROPIC_KEY") == "" {
+		t.Skip("ANTHROPIC_KEY not set")
+	}
+
+	userMsg := `{"role":"user","content":"What is the weather in Tokyo? You must use the get_weather tool."}`
+
+	// Step 1: Stream with thinking
+	step1Q := buildInlineStreamQuery("test_anthropic", []string{userMsg}, []string{roundTripToolDef}, 4096, "auto")
+	events := collectStreamEventsWithTimeout(t, step1Q, 120*time.Second)
+	require.NotEmpty(t, events)
+
+	var finishEvent map[string]any
+	var reasoningEvents int
+	for _, e := range events {
+		switch fmt.Sprintf("%v", e["type"]) {
+		case "reasoning":
+			reasoningEvents++
+		case "finish":
+			finishEvent = e
+		}
+	}
+	require.NotNil(t, finishEvent, "should have finish event")
+
+	toolCallsRaw := finishEvent["tool_calls"]
+	require.NotNil(t, toolCallsRaw, "finish should have tool_calls")
+	var toolCalls []types.LLMToolCall
+	err := json.Unmarshal([]byte(fmt.Sprintf("%v", toolCallsRaw)), &toolCalls)
+	require.NoError(t, err)
+	require.NotEmpty(t, toolCalls)
+
+	// Check thinking in finish event
+	thinking := ""
+	if v := finishEvent["thinking"]; v != nil {
+		thinking = fmt.Sprintf("%v", v)
+	}
+	thoughtSig := ""
+	if v := finishEvent["thought_signature"]; v != nil {
+		thoughtSig = fmt.Sprintf("%v", v)
+	}
+
+	assert.NotEmpty(t, thinking, "anthropic stream: finish should have thinking")
+	assert.NotEmpty(t, thoughtSig, "anthropic stream: finish should have thought_signature")
+	assert.Greater(t, reasoningEvents, 0, "anthropic stream: should have reasoning events")
+
+	t.Logf("Step 1 stream — %d reasoning events, thinking len=%d, thought_sig=%q",
+		reasoningEvents, len(thinking), truncateStr(thoughtSig, 40))
+
+	// Step 2: Build messages with thinking for round-trip
+	assistantMsg := types.LLMMessage{
+		Role:             "assistant",
+		ToolCalls:        toolCalls,
+		ThoughtSignature: thoughtSig,
+		Thinking:         thinking,
+	}
+	assistantJSON, _ := json.Marshal(assistantMsg)
+	messages := []string{userMsg, string(assistantJSON)}
+	for _, tc := range toolCalls {
+		toolID := tc.ID
+		if toolID == "" {
+			toolID = tc.Name
+		}
+		toolResult := types.LLMMessage{
+			Role:       "tool",
+			Content:    `{"temperature": 22, "condition": "sunny", "humidity": 65}`,
+			ToolCallID: toolID,
+		}
+		toolJSON, _ := json.Marshal(toolResult)
+		messages = append(messages, string(toolJSON))
+	}
+
+	t.Logf("Step 2 stream — sending %d messages with thinking back to anthropic", len(messages))
+
+	// Step 3: Stream second request
+	step2Q := buildInlineStreamQuery("test_anthropic", messages, []string{roundTripToolDef}, 4096, "")
+	events2 := collectStreamEventsWithTimeout(t, step2Q, 120*time.Second)
+	require.NotEmpty(t, events2)
+
+	var contentEvents int
+	var allContent string
+	var finishEvent2 map[string]any
+	for _, e := range events2 {
+		switch fmt.Sprintf("%v", e["type"]) {
+		case "content_delta":
+			contentEvents++
+			if c := e["content"]; c != nil {
+				allContent += fmt.Sprintf("%v", c)
+			}
+		case "finish":
+			finishEvent2 = e
+		}
+	}
+
+	require.NotNil(t, finishEvent2, "should have finish event in step 2")
+	assert.Greater(t, contentEvents, 0, "should have content after thinking + tool results")
+	assert.NotEmpty(t, allContent, "should have content text")
+
+	t.Logf("Step 3 stream — %d content events, content=%q, finish=%v",
+		contentEvents, truncateStr(allContent, 200), finishEvent2["finish_reason"])
+}

--- a/pkg/data-sources/sources/llm/anthropic.go
+++ b/pkg/data-sources/sources/llm/anthropic.go
@@ -156,9 +156,16 @@ func (s *AnthropicSource) CreateChatCompletion(ctx context.Context, messages []s
 			})
 			continue
 		}
-		if m.Role == "assistant" && len(m.ToolCalls) > 0 {
-			// Anthropic requires tool_use content blocks for assistant tool calls
+		if m.Role == "assistant" && (len(m.ToolCalls) > 0 || m.Thinking != "") {
 			content := []map[string]any{}
+			// Thinking block must come first (Anthropic requires unmodified thinking blocks)
+			if m.Thinking != "" {
+				thinkingBlock := map[string]any{"type": "thinking", "thinking": m.Thinking}
+				if m.ThoughtSignature != "" {
+					thinkingBlock["signature"] = m.ThoughtSignature
+				}
+				content = append(content, thinkingBlock)
+			}
 			if m.Content != "" {
 				content = append(content, map[string]any{"type": "text", "text": m.Content})
 			}
@@ -176,10 +183,27 @@ func (s *AnthropicSource) CreateChatCompletion(ctx context.Context, messages []s
 		apiMessages = append(apiMessages, map[string]any{"role": m.Role, "content": m.Content})
 	}
 
+	// Resolve effective thinking budget
+	effectiveBudget := opts.ThinkingBudget
+	if s.config.ThinkingBudget > 0 && (effectiveBudget == 0 || effectiveBudget > s.config.ThinkingBudget) {
+		effectiveBudget = s.config.ThinkingBudget
+	}
+
+	// Anthropic requires max_tokens > thinking budget
+	if effectiveBudget > 0 && maxTokens <= effectiveBudget {
+		maxTokens = effectiveBudget + 1024
+	}
+
 	reqBody := map[string]any{
 		"model":      s.config.Model,
 		"messages":   apiMessages,
 		"max_tokens": maxTokens,
+	}
+	if effectiveBudget > 0 {
+		reqBody["thinking"] = map[string]any{
+			"type":          "enabled",
+			"budget_tokens": effectiveBudget,
+		}
 	}
 	if system != "" {
 		reqBody["system"] = system
@@ -252,11 +276,13 @@ func (s *AnthropicSource) CreateChatCompletion(ctx context.Context, messages []s
 func parseAnthropicResponse(body []byte) (*sources.LLMResult, error) {
 	var resp struct {
 		Content []struct {
-			Type  string `json:"type"`
-			Text  string `json:"text"`
-			ID    string `json:"id"`
-			Name  string `json:"name"`
-			Input any    `json:"input"`
+			Type      string `json:"type"`
+			Text      string `json:"text"`
+			ID        string `json:"id"`
+			Name      string `json:"name"`
+			Input     any    `json:"input"`
+			Thinking  string `json:"thinking"`  // type: "thinking"
+			Signature string `json:"signature"` // type: "thinking"
 		} `json:"content"`
 		Model      string `json:"model"`
 		StopReason string `json:"stop_reason"`
@@ -290,6 +316,9 @@ func parseAnthropicResponse(body []byte) (*sources.LLMResult, error) {
 
 	for _, block := range resp.Content {
 		switch block.Type {
+		case "thinking":
+			result.Thinking = block.Thinking
+			result.ThoughtSignature = block.Signature
 		case "text":
 			result.Content += block.Text
 		case "tool_use":
@@ -341,8 +370,15 @@ func (s *AnthropicSource) CreateChatCompletionStream(ctx context.Context, messag
 			})
 			continue
 		}
-		if m.Role == "assistant" && len(m.ToolCalls) > 0 {
+		if m.Role == "assistant" && (len(m.ToolCalls) > 0 || m.Thinking != "") {
 			content := []map[string]any{}
+			if m.Thinking != "" {
+				thinkingBlock := map[string]any{"type": "thinking", "thinking": m.Thinking}
+				if m.ThoughtSignature != "" {
+					thinkingBlock["signature"] = m.ThoughtSignature
+				}
+				content = append(content, thinkingBlock)
+			}
 			if m.Content != "" {
 				content = append(content, map[string]any{"type": "text", "text": m.Content})
 			}
@@ -432,6 +468,8 @@ func (s *AnthropicSource) CreateChatCompletionStream(ctx context.Context, messag
 
 	var model string
 	var promptTokens, completionTokens int
+	var accThinking strings.Builder
+	var accThoughtSig string
 
 	// pendingToolCalls accumulates tool call data from content_block_start
 	// (id, name) and content_block_delta (input_json_delta fragments).
@@ -475,18 +513,24 @@ func (s *AnthropicSource) CreateChatCompletionStream(ctx context.Context, messag
 			var cbs struct {
 				Index        int `json:"index"`
 				ContentBlock struct {
-					Type string `json:"type"`
-					ID   string `json:"id"`
-					Name string `json:"name"`
+					Type      string `json:"type"`
+					ID        string `json:"id"`
+					Name      string `json:"name"`
+					Signature string `json:"signature"` // thinking block signature
 				} `json:"content_block"`
 			}
 			if err := json.Unmarshal([]byte(data), &cbs); err != nil {
 				continue
 			}
-			if cbs.ContentBlock.Type == "tool_use" {
+			switch cbs.ContentBlock.Type {
+			case "tool_use":
 				pendingToolCallsByIndex[cbs.Index] = &pendingToolCall{
 					ID:   cbs.ContentBlock.ID,
 					Name: cbs.ContentBlock.Name,
+				}
+			case "thinking":
+				if cbs.ContentBlock.Signature != "" {
+					accThoughtSig = cbs.ContentBlock.Signature
 				}
 			}
 
@@ -497,6 +541,7 @@ func (s *AnthropicSource) CreateChatCompletionStream(ctx context.Context, messag
 					Type        string `json:"type"`
 					Text        string `json:"text"`
 					Thinking    string `json:"thinking"`
+					Signature   string `json:"signature"`
 					PartialJSON string `json:"partial_json"`
 				} `json:"delta"`
 			}
@@ -513,6 +558,7 @@ func (s *AnthropicSource) CreateChatCompletionStream(ctx context.Context, messag
 					return err
 				}
 			case "thinking_delta":
+				accThinking.WriteString(delta.Delta.Thinking)
 				if err := onEvent(&sources.LLMStreamEvent{
 					Type:    "reasoning",
 					Content: delta.Delta.Thinking,
@@ -520,6 +566,8 @@ func (s *AnthropicSource) CreateChatCompletionStream(ctx context.Context, messag
 				}); err != nil {
 					return err
 				}
+			case "signature_delta":
+				accThoughtSig = delta.Delta.Signature
 			case "input_json_delta":
 				if ptc := pendingToolCallsByIndex[delta.Index]; ptc != nil {
 					ptc.ArgsJSON.WriteString(delta.Delta.PartialJSON)
@@ -556,6 +604,8 @@ func (s *AnthropicSource) CreateChatCompletionStream(ctx context.Context, messag
 					FinishReason:     finishReason,
 					PromptTokens:     promptTokens,
 					CompletionTokens: completionTokens,
+					ThoughtSignature: accThoughtSig,
+					Thinking:         accThinking.String(),
 				}
 				if len(pendingToolCallsByIndex) > 0 {
 					var calls []sources.LLMToolCall

--- a/pkg/data-sources/sources/llm/openai.go
+++ b/pkg/data-sources/sources/llm/openai.go
@@ -32,16 +32,19 @@ type OpenAISource struct {
 }
 
 type openAIConfig struct {
-	BaseURL        string
-	Model          string
-	ApiKey         string
-	ApiKeyHeader   string
-	MaxTokens      int
-	ThinkingBudget int // max thinking/reasoning tokens (0 = disabled)
-	Timeout        time.Duration
-	RPM            int    // max requests per minute (0 = unlimited)
-	TPM            int    // max tokens per minute (0 = unlimited)
-	RateStore      string // name of StoreSource for shared counters (empty = in-memory)
+	BaseURL          string
+	Model            string
+	ApiKey           string
+	ApiKeyHeader     string
+	MaxTokens        int
+	ThinkingBudget   int // max thinking/reasoning tokens (0 = disabled)
+	Timeout          time.Duration
+	RPM              int    // max requests per minute (0 = unlimited)
+	TPM              int    // max tokens per minute (0 = unlimited)
+	RateStore        string // name of StoreSource for shared counters (empty = in-memory)
+	UseResponsesAPI  bool   // use OpenAI Responses API instead of Chat Completions
+	ReasoningSummary string // "auto", "concise", "detailed" (Responses API only)
+	ReasoningEffort  string // "low", "medium", "high" (Responses API only)
 }
 
 func NewOpenAI(ds types.DataSource, attached bool) (*OpenAISource, error) {
@@ -119,6 +122,15 @@ func (s *OpenAISource) Attach(_ context.Context, _ *db.Pool) error {
 	}
 	s.config.RateStore = u.Query().Get("rate_store")
 
+	// Responses API detection
+	if u.Query().Get("use_responses_api") == "true" {
+		s.config.UseResponsesAPI = true
+	} else if strings.Contains(u.Path, "/responses") {
+		s.config.UseResponsesAPI = true
+	}
+	s.config.ReasoningSummary = u.Query().Get("reasoning_summary")
+	s.config.ReasoningEffort = u.Query().Get("reasoning_effort")
+
 	// Strip query params to get base URL
 	q := u.Query()
 	q.Del("model")
@@ -130,6 +142,9 @@ func (s *OpenAISource) Attach(_ context.Context, _ *db.Pool) error {
 	q.Del("rpm")
 	q.Del("tpm")
 	q.Del("rate_store")
+	q.Del("use_responses_api")
+	q.Del("reasoning_summary")
+	q.Del("reasoning_effort")
 	u.RawQuery = q.Encode()
 	s.config.BaseURL = u.String()
 
@@ -150,6 +165,9 @@ func (s *OpenAISource) CreateCompletion(ctx context.Context, prompt string, opts
 }
 
 func (s *OpenAISource) CreateChatCompletion(ctx context.Context, messages []sources.LLMMessage, opts sources.LLMOptions) (*sources.LLMResult, error) {
+	if s.config.UseResponsesAPI {
+		return s.createResponsesCompletion(ctx, messages, opts)
+	}
 	if !s.isAttached {
 		return nil, sources.ErrDataSourceNotAttached
 	}
@@ -355,6 +373,9 @@ func normalizeFinishReasonOpenAI(reason string) string {
 
 func (s *OpenAISource) CreateChatCompletionStream(ctx context.Context, messages []sources.LLMMessage, opts sources.LLMOptions,
 	onEvent func(event *sources.LLMStreamEvent) error) error {
+	if s.config.UseResponsesAPI {
+		return s.createResponsesStream(ctx, messages, opts, onEvent)
+	}
 	if !s.isAttached {
 		return sources.ErrDataSourceNotAttached
 	}

--- a/pkg/data-sources/sources/llm/openai_responses.go
+++ b/pkg/data-sources/sources/llm/openai_responses.go
@@ -1,0 +1,430 @@
+package llm
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/hugr-lab/query-engine/pkg/data-sources/sources"
+)
+
+// createResponsesCompletion implements CreateChatCompletion using the OpenAI Responses API.
+func (s *OpenAISource) createResponsesCompletion(ctx context.Context, messages []sources.LLMMessage, opts sources.LLMOptions) (*sources.LLMResult, error) {
+	reqBody := buildResponsesRequest(s.config, messages, opts, false)
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(ctx, s.config.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", s.config.BaseURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	setOpenAIHeaders(req, s.config)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("OpenAI Responses API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return parseResponsesResponse(respBody)
+}
+
+// createResponsesStream implements CreateChatCompletionStream using the OpenAI Responses API.
+func (s *OpenAISource) createResponsesStream(ctx context.Context, messages []sources.LLMMessage, opts sources.LLMOptions,
+	onEvent func(event *sources.LLMStreamEvent) error) error {
+
+	reqBody := buildResponsesRequest(s.config, messages, opts, true)
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(ctx, s.config.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", s.config.BaseURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	setOpenAIHeaders(req, s.config)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("OpenAI Responses API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return parseResponsesStream(resp.Body, onEvent)
+}
+
+// buildResponsesRequest builds a Responses API request body from normalized messages.
+func buildResponsesRequest(config openAIConfig, messages []sources.LLMMessage, opts sources.LLMOptions, stream bool) map[string]any {
+	maxTokens := opts.MaxTokens
+	if maxTokens == 0 {
+		maxTokens = config.MaxTokens
+	}
+
+	reqBody := map[string]any{
+		"model":            config.Model,
+		"max_output_tokens": maxTokens,
+	}
+
+	if stream {
+		reqBody["stream"] = true
+	}
+
+	// Convert messages to input
+	input := convertMessagesResponses(messages)
+	reqBody["input"] = input
+
+	// Temperature
+	if opts.Temperature > 0 {
+		reqBody["temperature"] = opts.Temperature
+	}
+
+	// Reasoning config
+	reasoning := map[string]any{}
+	effort := config.ReasoningEffort
+	if effort == "" {
+		effort = "medium"
+	}
+	reasoning["effort"] = effort
+	if config.ReasoningSummary != "" {
+		reasoning["summary"] = config.ReasoningSummary
+	}
+	reqBody["reasoning"] = reasoning
+
+	// Tools
+	if len(opts.Tools) > 0 {
+		tools := make([]map[string]any, len(opts.Tools))
+		for i, t := range opts.Tools {
+			tool := map[string]any{
+				"type": "function",
+				"name": t.Name,
+			}
+			if t.Description != "" {
+				tool["description"] = t.Description
+			}
+			if t.Parameters != nil {
+				tool["parameters"] = t.Parameters
+			}
+			tools[i] = tool
+		}
+		reqBody["tools"] = tools
+	}
+
+	return reqBody
+}
+
+// convertMessagesResponses converts normalized LLMMessages to Responses API input items.
+func convertMessagesResponses(messages []sources.LLMMessage) []map[string]any {
+	var input []map[string]any
+
+	for _, m := range messages {
+		switch m.Role {
+		case "system":
+			input = append(input, map[string]any{
+				"type": "message",
+				"role": "developer",
+				"content": []map[string]any{
+					{"type": "input_text", "text": m.Content},
+				},
+			})
+
+		case "user":
+			input = append(input, map[string]any{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]any{
+					{"type": "input_text", "text": m.Content},
+				},
+			})
+
+		case "assistant":
+			// Assistant message with possible tool calls
+			var content []map[string]any
+			if m.Content != "" {
+				content = append(content, map[string]any{
+					"type": "output_text", "text": m.Content,
+				})
+			}
+			if len(content) > 0 {
+				input = append(input, map[string]any{
+					"type": "message", "role": "assistant", "content": content,
+				})
+			}
+			// Tool calls as separate function_call items
+			for _, tc := range m.ToolCalls {
+				argsStr := ""
+				if tc.Arguments != nil {
+					b, _ := json.Marshal(tc.Arguments)
+					argsStr = string(b)
+				}
+				input = append(input, map[string]any{
+					"type":      "function_call",
+					"call_id":   tc.ID,
+					"name":      tc.Name,
+					"arguments": argsStr,
+				})
+			}
+
+		case "tool":
+			// Tool result → function_call_output
+			input = append(input, map[string]any{
+				"type":    "function_call_output",
+				"call_id": m.ToolCallID,
+				"output":  m.Content,
+			})
+		}
+	}
+
+	return input
+}
+
+// setOpenAIHeaders sets auth headers for OpenAI API requests.
+func setOpenAIHeaders(req *http.Request, config openAIConfig) {
+	req.Header.Set("Content-Type", "application/json")
+	if config.ApiKey != "" {
+		if config.ApiKeyHeader != "" {
+			req.Header.Set(config.ApiKeyHeader, config.ApiKey)
+		} else {
+			req.Header.Set("Authorization", "Bearer "+config.ApiKey)
+		}
+	}
+}
+
+// parseResponsesResponse parses a non-streaming Responses API response.
+func parseResponsesResponse(body []byte) (*sources.LLMResult, error) {
+	var resp struct {
+		ID     string `json:"id"`
+		Model  string `json:"model"`
+		Output []struct {
+			Type    string `json:"type"`
+			ID      string `json:"id"`
+			Status  string `json:"status"`
+			Role    string `json:"role"`
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+			// reasoning type
+			Summary []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"summary"`
+			// function_call type
+			CallID    string `json:"call_id"`
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		} `json:"output"`
+		Usage struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+			TotalTokens  int `json:"total_tokens"`
+		} `json:"usage"`
+		Status string `json:"status"`
+		Error  *struct {
+			Message string `json:"message"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse responses API: %w", err)
+	}
+
+	if resp.Error != nil {
+		return nil, fmt.Errorf("OpenAI Responses API error: %s (%s)", resp.Error.Message, resp.Error.Code)
+	}
+
+	result := &sources.LLMResult{
+		Model:            resp.Model,
+		PromptTokens:     resp.Usage.InputTokens,
+		CompletionTokens: resp.Usage.OutputTokens,
+		TotalTokens:      resp.Usage.TotalTokens,
+		Provider:         "openai",
+		FinishReason:     "stop",
+	}
+
+	for _, item := range resp.Output {
+		switch item.Type {
+		case "message":
+			for _, c := range item.Content {
+				if c.Type == "output_text" {
+					result.Content += c.Text
+				}
+			}
+		case "reasoning":
+			for _, s := range item.Summary {
+				if s.Type == "summary_text" {
+					result.Thinking += s.Text
+				}
+			}
+		case "function_call":
+			var args any
+			if item.Arguments != "" {
+				_ = json.Unmarshal([]byte(item.Arguments), &args)
+			}
+			result.ToolCalls = append(result.ToolCalls, sources.LLMToolCall{
+				ID:        item.CallID,
+				Name:      item.Name,
+				Arguments: args,
+			})
+			result.FinishReason = "tool_use"
+		}
+	}
+
+	return result, nil
+}
+
+// parseResponsesStream parses SSE events from a streaming Responses API response.
+func parseResponsesStream(body io.Reader, onEvent func(event *sources.LLMStreamEvent) error) error {
+	type pendingFunctionCall struct {
+		CallID string
+		Name   string
+		Args   strings.Builder
+	}
+
+	var (
+		accThinking      strings.Builder
+		pendingCalls     = map[string]*pendingFunctionCall{} // by call_id
+		promptTokens     int
+		completionTokens int
+		model            string
+	)
+
+	scanner := bufio.NewScanner(body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var event struct {
+			Type string `json:"type"`
+
+			// response.output_text.delta
+			Delta string `json:"delta"`
+
+			// response.function_call_arguments.delta
+			CallID string `json:"call_id"`
+
+			// response.output_item.added — function_call start
+			Item struct {
+				Type   string `json:"type"`
+				CallID string `json:"call_id"`
+				Name   string `json:"name"`
+			} `json:"item"`
+
+			// response.completed
+			Response struct {
+				Model string `json:"model"`
+				Usage struct {
+					InputTokens  int `json:"input_tokens"`
+					OutputTokens int `json:"output_tokens"`
+				} `json:"usage"`
+			} `json:"response"`
+
+			// summary_text
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			continue
+		}
+
+		switch event.Type {
+		case "response.output_text.delta":
+			if err := onEvent(&sources.LLMStreamEvent{
+				Type:    "content_delta",
+				Content: event.Delta,
+			}); err != nil {
+				return err
+			}
+
+		case "response.reasoning_summary_text.delta":
+			accThinking.WriteString(event.Delta)
+			if err := onEvent(&sources.LLMStreamEvent{
+				Type:    "reasoning",
+				Content: event.Delta,
+			}); err != nil {
+				return err
+			}
+
+		case "response.output_item.added":
+			if event.Item.Type == "function_call" {
+				pendingCalls[event.Item.CallID] = &pendingFunctionCall{
+					CallID: event.Item.CallID,
+					Name:   event.Item.Name,
+				}
+			}
+
+		case "response.function_call_arguments.delta":
+			if pc := pendingCalls[event.CallID]; pc != nil {
+				pc.Args.WriteString(event.Delta)
+			}
+
+		case "response.completed":
+			model = event.Response.Model
+			promptTokens = event.Response.Usage.InputTokens
+			completionTokens = event.Response.Usage.OutputTokens
+
+			ev := &sources.LLMStreamEvent{
+				Type:             "finish",
+				Model:            model,
+				FinishReason:     "stop",
+				PromptTokens:     promptTokens,
+				CompletionTokens: completionTokens,
+				Thinking:         accThinking.String(),
+			}
+
+			if len(pendingCalls) > 0 {
+				var calls []sources.LLMToolCall
+				for _, pc := range pendingCalls {
+					var args any
+					if s := pc.Args.String(); s != "" {
+						_ = json.Unmarshal([]byte(s), &args)
+					}
+					calls = append(calls, sources.LLMToolCall{
+						ID:        pc.CallID,
+						Name:      pc.Name,
+						Arguments: args,
+					})
+				}
+				b, _ := json.Marshal(calls)
+				ev.ToolCalls = string(b)
+				ev.FinishReason = "tool_use"
+			}
+
+			if err := onEvent(ev); err != nil {
+				return err
+			}
+		}
+	}
+
+	return scanner.Err()
+}

--- a/pkg/data-sources/sources/runtime/models/schema.graphql
+++ b/pkg/data-sources/sources/runtime/models/schema.graphql
@@ -101,8 +101,10 @@ type llm_result {
   Empty string when no tools were called.
   """
   tool_calls: String
-  "Gemini 2.5+ thought signature for function call verification. Include in assistant message for tool result round-trip."
+  "Gemini 2.5+ / Anthropic thought signature for function call verification. Include in assistant message for tool result round-trip."
   thought_signature: String
+  "Thinking/reasoning content (Anthropic extended thinking text, OpenAI reasoning summary)"
+  thinking: String
 }
 
 "Registered AI model data source info"
@@ -169,6 +171,8 @@ type llm_stream_event {
   prompt_tokens: Int
   "Number of generated tokens (for finish events)"
   completion_tokens: Int
-  "Gemini 2.5+ thought signature (for finish events with tool calls)"
+  "Gemini 2.5+ / Anthropic thought signature (for finish events with tool calls)"
   thought_signature: String
+  "Accumulated thinking content (for finish events)"
+  thinking: String
 }

--- a/pkg/data-sources/sources/runtime/models/source.go
+++ b/pkg/data-sources/sources/runtime/models/source.go
@@ -378,6 +378,7 @@ func llmResultToMap(r *sources.LLMResult) map[string]any {
 		"latency_ms":        int32(r.LatencyMs),
 		"tool_calls":        toolCallsJSON,
 		"thought_signature": r.ThoughtSignature,
+		"thinking":          r.Thinking,
 	}
 }
 
@@ -394,6 +395,7 @@ var llmResultDuckDBType = runtime.DuckDBStructTypeFromSchemaMust(map[string]any{
 	"latency_ms":        duckdb.TYPE_INTEGER,
 	"tool_calls":        duckdb.TYPE_VARCHAR,
 	"thought_signature": duckdb.TYPE_VARCHAR,
+	"thinking":          duckdb.TYPE_VARCHAR,
 })
 
 var _ sources.RuntimeSourceDataSourceUser = (*Source)(nil)

--- a/pkg/data-sources/sources/runtime/models/subscribe.go
+++ b/pkg/data-sources/sources/runtime/models/subscribe.go
@@ -22,6 +22,7 @@ var streamEventSchema = arrow.NewSchema([]arrow.Field{
 	{Name: "prompt_tokens", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "completion_tokens", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "thought_signature", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "thinking", Type: arrow.BinaryTypes.String, Nullable: true},
 }, nil)
 
 var _ sources.SubscriptionSource = (*Source)(nil)
@@ -171,6 +172,7 @@ func buildEventRecord(event *sources.LLMStreamEvent) arrow.RecordBatch {
 	b.Field(5).(*array.Int32Builder).Append(int32(event.PromptTokens))
 	b.Field(6).(*array.Int32Builder).Append(int32(event.CompletionTokens))
 	b.Field(7).(*array.StringBuilder).Append(event.ThoughtSignature)
+	b.Field(8).(*array.StringBuilder).Append(event.Thinking)
 
 	return b.NewRecord()
 }

--- a/types/models.go
+++ b/types/models.go
@@ -28,7 +28,8 @@ type LLMMessage struct {
 	Content          string        `json:"content"`
 	ToolCalls        []LLMToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string        `json:"tool_call_id,omitempty"`
-	ThoughtSignature string        `json:"thought_signature,omitempty"` // Gemini 2.5+: Part-level signature for the first functionCall
+	ThoughtSignature string        `json:"thought_signature,omitempty"` // Gemini 2.5+ / Anthropic: encrypted signature for multi-turn continuity
+	Thinking         string        `json:"thinking,omitempty"`          // Anthropic thinking text / OpenAI reasoning summary
 }
 
 // LLMTool is a tool definition provided to the model.
@@ -65,7 +66,8 @@ type LLMStreamEvent struct {
 	ToolCalls        string `json:"tool_calls"`        // JSON-encoded tool calls (tool_use only)
 	PromptTokens     int    `json:"prompt_tokens"`     // Input token count (finish only)
 	CompletionTokens int    `json:"completion_tokens"` // Output token count (finish only)
-	ThoughtSignature string `json:"thought_signature"` // Gemini 2.5+: Part-level signature (finish only)
+	ThoughtSignature string `json:"thought_signature"` // Gemini 2.5+ / Anthropic: encrypted signature (finish only)
+	Thinking         string `json:"thinking"`          // Anthropic thinking text / OpenAI reasoning summary (finish only)
 }
 
 // LLMResult is the normalized response from any LLM provider.
@@ -79,5 +81,6 @@ type LLMResult struct {
 	Provider         string        `json:"provider"`
 	LatencyMs        int           `json:"latency_ms"`
 	ToolCalls        []LLMToolCall `json:"tool_calls"`
-	ThoughtSignature string        `json:"thought_signature,omitempty"` // Gemini 2.5+: Part-level signature
+	ThoughtSignature string        `json:"thought_signature,omitempty"` // Gemini 2.5+ / Anthropic: encrypted signature
+	Thinking         string        `json:"thinking,omitempty"`          // Anthropic thinking text / OpenAI reasoning summary
 }


### PR DESCRIPTION
## Summary

- **Anthropic extended thinking**: `thinking` field on LLMMessage/LLMResult/LLMStreamEvent carries thinking text, existing `thought_signature` reused for Anthropic `signature` (same concept as Gemini). Non-streaming + streaming: parse thinking blocks, echo back in tool use round-trips, accumulate `signature_delta` in streaming.
- **OpenAI Responses API**: transparent support via `llm-openai` provider. Auto-detected from URL path (`/v1/responses`) or `use_responses_api=true` flag. Converts to/from existing `CreateChatCompletion`/`CreateChatCompletionStream` interface — `core.models` module works unchanged.
- **39 integration tests pass** across all 4 providers (OpenAI Chat Completions, OpenAI Responses API, Anthropic, Gemini) in both streaming and non-streaming modes including multi-turn tool call round-trips.

## Files changed

- `types/models.go` — `Thinking` field on LLMMessage, LLMResult, LLMStreamEvent
- `anthropic.go` — thinking budget in non-streaming, parse/emit thinking blocks, `signature_delta` in streaming, auto-adjust max_tokens
- `openai.go` — Responses API config detection + routing
- `openai_responses.go` — **NEW**: request builder, response parser, streaming SSE parser, tool call conversion
- `schema.graphql` — `thinking` field on llm_result + llm_stream_event
- `source.go` / `subscribe.go` — DuckDB type + Arrow schema
- `models_test.go` — 7 new tests (thinking round-trip × 2, Responses API × 5)

## Test plan

- [x] Anthropic non-streaming thinking tool call round-trip
- [x] Anthropic streaming thinking tool call round-trip
- [x] OpenAI Responses API: completion, chat+tools, tool call round-trip
- [x] OpenAI Responses API: streaming completion, streaming tool call round-trip
- [x] All 32 existing tests pass (no regression)
- [ ] Verify with hugen agent in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)