### PR TITLE
Fix/repack geometry geojson once

### DIFF
--- a/pkg/catalog/sdl/fields.go
+++ b/pkg/catalog/sdl/fields.go
@@ -134,21 +134,6 @@ func (f *Field) SQLFieldFunc(prefix string, fn func(string) string) string {
 	return sql
 }
 
-func (f *Field) IsTransformed() bool {
-	if f.sql == "" {
-		return false
-	}
-	fields := f.UsingFields()
-	return len(fields) == 1 && fields[0] == f.Name
-}
-
-func (f *Field) TransformSQL(sql string) string {
-	if f.sql == "" {
-		return sql
-	}
-	return strings.ReplaceAll(f.sql, "["+f.Name+"]", sql)
-}
-
 func (f *Field) UsingFields() []string {
 	return ExtractFieldsFromSQL(f.sql)
 }

--- a/pkg/engines/duckdb.go
+++ b/pkg/engines/duckdb.go
@@ -905,9 +905,10 @@ func repackStructRecursive(sql string, field *ast.Field, path string) string {
 		if fi.IsCalcField() {
 			extractValue = fi.SQLFieldFunc("", func(s string) string { return sql + extractStructFieldByPath(s) })
 		}
-		if fi.IsTransformed() {
-			extractValue = fi.TransformSQL(extractValue)
-		}
+		// Do not call TransformSQL here: for calc fields, SQLFieldFunc already substitutes
+		// all [field] placeholders (including when the only placeholder matches this field name).
+		// Applying TransformSQL again would re-wrap the expression (e.g. double ST_GeomFromGeoJSON),
+		// and DuckDB would coerce the inner geometry to WKT for the outer parse, causing errors.
 		if f.Field.Definition.Type.NamedType == "" && f.Field.Definition.Type.Elem == nil {
 			continue
 		}

--- a/pkg/engines/duckdb_geojson_http_integration_test.go
+++ b/pkg/engines/duckdb_geojson_http_integration_test.go
@@ -1,0 +1,150 @@
+//go:build duckdb_arrow
+
+package engines
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
+	"github.com/duckdb/duckdb-go/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// mkudLineStringGeoJSON matches MKUD /GetTrafficLightById directions[].coordinates
+// (GeoJSON serialized as a JSON string value).
+const mkudLineStringGeoJSON = `{"type":"LineString","coordinates":[[66.52748007,66.630207063],[66.52747884,66.630249448],[66.527478439,66.630289574],[66.527479052,66.630334744],[66.527480859,66.630376662],[66.527483277,66.630409109],[66.527486523,66.630439297],[66.5274906,66.630467227],[66.527495505,66.630492899],[66.527501239,66.630516312],[66.527507802,66.630537466],[66.527516773,66.63055987],[66.52752516,66.630576056],[66.527534377,66.630589983],[66.527546531,66.630603714],[66.527557572,66.630612673],[66.527571915,66.630620442],[66.52758478,66.630624431],[66.527598474,66.630626162],[66.527612996,66.630625635]]}`
+
+// trafficLightLightFieldForHTTPIntegration matches GraphQL
+// light { directions { coordinates } } with OpenAPI StringAsGeoJson → ST_GeomFromGeoJSON([coordinates]).
+func trafficLightLightFieldForHTTPIntegration() *ast.Field {
+	coordsDef := &ast.FieldDefinition{
+		Name: "coordinates",
+		Type: ast.NamedType("Geometry", nil),
+		Directives: ast.DirectiveList{
+			base.FieldSqlDirective("ST_GeomFromGeoJSON([coordinates])"),
+		},
+	}
+	dirType := &ast.Definition{
+		Name:   "Direction",
+		Fields: []*ast.FieldDefinition{coordsDef},
+	}
+	return &ast.Field{
+		Alias: "light",
+		Name:  "light",
+		SelectionSet: ast.SelectionSet{
+			&ast.Field{
+				Alias: "directionsOut",
+				Name:  "directions",
+				SelectionSet: ast.SelectionSet{
+					&ast.Field{
+						Alias:            "coords",
+						Name:             "coordinates",
+						Definition:       coordsDef,
+						ObjectDefinition: dirType,
+					},
+				},
+				ObjectDefinition: dirType,
+				Definition: &ast.FieldDefinition{
+					Name: "directions",
+					Type: &ast.Type{NamedType: "", Elem: ast.NamedType("Direction", nil)},
+				},
+			},
+		},
+		Definition: &ast.FieldDefinition{
+			Name: "light", Type: ast.NamedType("Object", nil),
+		},
+		ObjectDefinition: &ast.Definition{Fields: []*ast.FieldDefinition{
+			{Name: "light", Type: ast.NamedType("Object", nil)},
+		}},
+	}
+}
+
+// TestDuckDB_HTTPResponseTrafficLightDirectionsCoordinates runs json_transform + RepackObject
+// against a JSON document shaped like the MKUD HTTP body fragment (directions[].coordinates
+// as a GeoJSON string). This is the DuckDB path used for HTTP scalar JSON function results
+// with nested OpenAPI Geometry fields.
+func TestDuckDB_HTTPResponseTrafficLightDirectionsCoordinates(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{
+		"directions": []map[string]any{
+			{
+				"conflictDirections": []string{},
+				"coordinates":        mkudLineStringGeoJSON,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lightField := trafficLightLightFieldForHTTPIntegration()
+	e := NewDuckDB()
+
+	jsonTransform := JsonToStruct(lightField, "", true, true)
+	repackExpr := e.RepackObject("_value", lightField)
+
+	// Column alias "light" holds the raw JSON; json_transform(light, …) matches functionCallSQL JsonCast.
+	query := `SELECT CAST(to_json(` + repackExpr + `) AS VARCHAR) AS out FROM (
+		SELECT (` + jsonTransform + `) AS _value
+		FROM (SELECT $1::JSON AS light)
+	) sub`
+
+	connector, err := duckdb.NewConnector("", nil)
+	if err != nil {
+		t.Fatalf("duckdb connector: %v", err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	_, err = db.ExecContext(context.Background(), `INSTALL spatial; LOAD spatial;`)
+	if err != nil {
+		t.Fatalf("load spatial: %v", err)
+	}
+
+	var out string
+	err = db.QueryRowContext(context.Background(), query, string(payload)).Scan(&out)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal([]byte(out), &root); err != nil {
+		t.Fatalf("unmarshal result: %v\n%s", err, out)
+	}
+	dirAny, ok := root["directionsOut"]
+	if !ok {
+		t.Fatalf("missing directionsOut in %s", out)
+	}
+	dirs, ok := dirAny.([]any)
+	if !ok || len(dirs) == 0 {
+		t.Fatalf("directionsOut not a non-empty array: %#v", dirAny)
+	}
+	row0, ok := dirs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("direction row type %T", dirs[0])
+	}
+	coordsStr := coordsToStringForAssert(t, row0["coords"])
+	if !strings.Contains(coordsStr, `"type":"LineString"`) && !strings.Contains(coordsStr, `"type": "LineString"`) {
+		t.Fatalf("expected LineString GeoJSON in coords, got: %s", coordsStr)
+	}
+}
+
+func coordsToStringForAssert(t *testing.T, v any) string {
+	t.Helper()
+	switch x := v.(type) {
+	case string:
+		return x
+	case map[string]any:
+		b, err := json.Marshal(x)
+		if err != nil {
+			t.Fatalf("marshal coords: %v", err)
+		}
+		return string(b)
+	default:
+		t.Fatalf("coords type %T", v)
+		return ""
+	}
+}

--- a/pkg/engines/duckdb_test.go
+++ b/pkg/engines/duckdb_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
 	"github.com/paulmach/orb"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -282,6 +283,87 @@ func Test_repackStructRecursive(t *testing.T) {
 				}},
 			},
 			expected: "{subfield1A: list_transform(field1['subfield1'],lambda _value: {subsubfield1: _value['subsubfield1']})}",
+		},
+		{
+			name: "nested geometry from GeoJSON string (OpenAPI StringAsGeoJson)",
+			field: func() *ast.Field {
+				coordsDef := &ast.FieldDefinition{
+					Name: "coordinates",
+					Type: ast.NamedType("Geometry", nil),
+					Directives: ast.DirectiveList{
+						base.FieldSqlDirective("ST_GeomFromGeoJSON([coordinates])"),
+					},
+				}
+				dirType := &ast.Definition{
+					Name:   "Direction",
+					Fields: []*ast.FieldDefinition{coordsDef},
+				}
+				return &ast.Field{
+					Alias: "row",
+					Name:  "row",
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Alias:            "coords",
+							Name:             "coordinates",
+							Definition:       coordsDef,
+							ObjectDefinition: dirType,
+						},
+					},
+					Definition: &ast.FieldDefinition{
+						Name: "row", Type: ast.NamedType("Object", nil),
+					},
+					ObjectDefinition: &ast.Definition{Fields: []*ast.FieldDefinition{
+						{Name: "row", Type: ast.NamedType("Object", nil)},
+					}},
+				}
+			}(),
+			expected: "{coords: ST_AsGeoJSON(ST_GeomFromGeoJSON(row['coordinates']))}",
+		},
+		{
+			name: "list of objects with geometry from GeoJSON string",
+			field: func() *ast.Field {
+				coordsDef := &ast.FieldDefinition{
+					Name: "coordinates",
+					Type: ast.NamedType("Geometry", nil),
+					Directives: ast.DirectiveList{
+						base.FieldSqlDirective("ST_GeomFromGeoJSON([coordinates])"),
+					},
+				}
+				dirType := &ast.Definition{
+					Name:   "Direction",
+					Fields: []*ast.FieldDefinition{coordsDef},
+				}
+				return &ast.Field{
+					Alias: "light",
+					Name:  "light",
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Alias: "directionsOut",
+							Name:  "directions",
+							SelectionSet: ast.SelectionSet{
+								&ast.Field{
+									Alias:            "coords",
+									Name:             "coordinates",
+									Definition:       coordsDef,
+									ObjectDefinition: dirType,
+								},
+							},
+							ObjectDefinition: dirType,
+							Definition: &ast.FieldDefinition{
+								Name: "directions",
+								Type: &ast.Type{NamedType: "", Elem: ast.NamedType("Direction", nil)},
+							},
+						},
+					},
+					Definition: &ast.FieldDefinition{
+						Name: "light", Type: ast.NamedType("Object", nil),
+					},
+					ObjectDefinition: &ast.Definition{Fields: []*ast.FieldDefinition{
+						{Name: "light", Type: ast.NamedType("Object", nil)},
+					}},
+				}
+			}(),
+			expected: "{directionsOut: list_transform(light['directions'],lambda _value: {coords: ST_AsGeoJSON(ST_GeomFromGeoJSON(_value['coordinates']))})}",
 		},
 	}
 


### PR DESCRIPTION
Problem
OpenAPI fields with StringAsGeoJson get @sql(exp: "ST_GeomFromGeoJSON([coordinates])"). In repackStructRecursive, placeholders are already expanded via SQLFieldFunc. An extra TransformSQL pass applied the same template again, producing ST_GeomFromGeoJSON(ST_GeomFromGeoJSON(...)). The inner call returns a geometry value; the outer ST_GeomFromGeoJSON then receives a non–GeoJSON string (geometry coerced to WKT), so DuckDB fails with errors like Could not parse GeoJSON … LINESTRING (...). The upstream API can still return a valid GeoJSON string.

Change
Remove the redundant TransformSQL step after SQLFieldFunc in repackStructRecursive. Drop unused Field.IsTransformed and Field.TransformSQL. Add regression tests for nested Geometry with the same @sql pattern as OpenAPI, and for a list of objects containing such a field.