### PR TITLE
feat: provider URL scheme shortcuts for LLM/embedding sources

### DIFF
--- a/pkg/data-sources/sources/embedding/source.go
+++ b/pkg/data-sources/sources/embedding/source.go
@@ -71,6 +71,11 @@ func (s *Source) Attach(ctx context.Context, db *db.Pool) (err error) {
 		return err
 	}
 
+	s.ds.Path, err = sources.ResolveProviderScheme(s.ds.Path)
+	if err != nil {
+		return err
+	}
+
 	u, err := url.Parse(s.ds.Path)
 	if err != nil {
 		return err

--- a/pkg/data-sources/sources/llm/anthropic.go
+++ b/pkg/data-sources/sources/llm/anthropic.go
@@ -60,6 +60,10 @@ func (s *AnthropicSource) Attach(_ context.Context, _ *db.Pool) error {
 	if err != nil {
 		return err
 	}
+	path, err = sources.ResolveProviderScheme(path)
+	if err != nil {
+		return err
+	}
 	u, err := url.Parse(path)
 	if err != nil {
 		return err

--- a/pkg/data-sources/sources/llm/gemini.go
+++ b/pkg/data-sources/sources/llm/gemini.go
@@ -60,6 +60,10 @@ func (s *GeminiSource) Attach(_ context.Context, _ *db.Pool) error {
 	if err != nil {
 		return err
 	}
+	path, err = sources.ResolveProviderScheme(path)
+	if err != nil {
+		return err
+	}
 	u, err := url.Parse(path)
 	if err != nil {
 		return err

--- a/pkg/data-sources/sources/llm/openai.go
+++ b/pkg/data-sources/sources/llm/openai.go
@@ -80,6 +80,11 @@ func (s *OpenAISource) Attach(_ context.Context, _ *db.Pool) error {
 		return err
 	}
 
+	path, err = sources.ResolveProviderScheme(path)
+	if err != nil {
+		return err
+	}
+
 	u, err := url.Parse(path)
 	if err != nil {
 		return err

--- a/pkg/data-sources/sources/resolve.go
+++ b/pkg/data-sources/sources/resolve.go
@@ -1,0 +1,43 @@
+package sources
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// providerSchemes maps provider://service shortcuts to real API endpoint URLs.
+var providerSchemes = map[string]string{
+	"openai://llm":       "https://api.openai.com/v1/chat/completions",
+	"openai://embedding": "https://api.openai.com/v1/embeddings",
+	"anthropic://llm":    "https://api.anthropic.com/v1/messages",
+	"gemini://llm":       "https://generativelanguage.googleapis.com/v1beta",
+}
+
+// ResolveProviderScheme checks if path uses a provider:// scheme and resolves
+// it to the real API endpoint URL. Returns the path unchanged if it uses
+// http:// or https://. Returns an error for unrecognized schemes.
+func ResolveProviderScheme(path string) (string, error) {
+	u, err := url.Parse(path)
+	if err != nil {
+		return path, nil
+	}
+
+	switch u.Scheme {
+	case "http", "https", "":
+		return path, nil
+	}
+
+	// Build the scheme://host key to look up in the mapping.
+	key := u.Scheme + "://" + u.Host
+
+	baseURL, ok := providerSchemes[key]
+	if !ok {
+		return "", fmt.Errorf("unsupported provider URL scheme %q; supported schemes: openai://llm, openai://embedding, anthropic://llm, gemini://llm", key)
+	}
+
+	// Rebuild with the resolved base URL and the original query parameters.
+	if u.RawQuery != "" {
+		return baseURL + "?" + u.RawQuery, nil
+	}
+	return baseURL, nil
+}

--- a/pkg/data-sources/sources/resolve_test.go
+++ b/pkg/data-sources/sources/resolve_test.go
@@ -1,0 +1,83 @@
+package sources
+
+import (
+	"testing"
+)
+
+func TestResolveProviderScheme(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "openai llm",
+			path: "openai://llm?model=gpt-4o&api_key=sk-test",
+			want: "https://api.openai.com/v1/chat/completions?model=gpt-4o&api_key=sk-test",
+		},
+		{
+			name: "openai embedding",
+			path: "openai://embedding?model=text-embedding-3-small&api_key=sk-test",
+			want: "https://api.openai.com/v1/embeddings?model=text-embedding-3-small&api_key=sk-test",
+		},
+		{
+			name: "anthropic llm",
+			path: "anthropic://llm?model=claude-sonnet-4-20250514&api_key=sk-ant-test",
+			want: "https://api.anthropic.com/v1/messages?model=claude-sonnet-4-20250514&api_key=sk-ant-test",
+		},
+		{
+			name: "gemini llm",
+			path: "gemini://llm?model=gemini-2.5-flash&api_key=AIza-test",
+			want: "https://generativelanguage.googleapis.com/v1beta?model=gemini-2.5-flash&api_key=AIza-test",
+		},
+		{
+			name: "openai llm no query params",
+			path: "openai://llm",
+			want: "https://api.openai.com/v1/chat/completions",
+		},
+		{
+			name: "http passthrough",
+			path: "http://localhost:11434/v1/chat/completions?model=llama3",
+			want: "http://localhost:11434/v1/chat/completions?model=llama3",
+		},
+		{
+			name: "https passthrough",
+			path: "https://api.openai.com/v1/chat/completions?model=gpt-4&api_key=sk-test",
+			want: "https://api.openai.com/v1/chat/completions?model=gpt-4&api_key=sk-test",
+		},
+		{
+			name:    "unsupported scheme",
+			path:    "mistral://llm?model=mistral-large",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported service for known provider",
+			path:    "anthropic://embedding?model=test",
+			wantErr: true,
+		},
+		{
+			name: "empty path",
+			path: "",
+			want: "",
+		},
+		{
+			name: "preserves multiple query params",
+			path: "openai://llm?model=gpt-4o&api_key=sk-test&max_tokens=4096&timeout=30s&rpm=60",
+			want: "https://api.openai.com/v1/chat/completions?model=gpt-4o&api_key=sk-test&max_tokens=4096&timeout=30s&rpm=60",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveProviderScheme(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveProviderScheme() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ResolveProviderScheme() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `openai://llm`, `openai://embedding`, `anthropic://llm`, `gemini://llm` as shorthand URL schemes for data source paths
- Schemes auto-resolve to real API endpoints during `Attach()`, preserving all query parameters
- Full backward compatibility — existing `http://`/`https://` URLs work unchanged

## Examples

```
# Before
path: "https://api.openai.com/v1/chat/completions?model=gpt-4o&api_key=[$OPENAI_API_KEY]"

# After
path: "openai://llm?model=gpt-4o&api_key=[$OPENAI_API_KEY]"
```

## Changes

- **New**: `pkg/data-sources/sources/resolve.go` — `ResolveProviderScheme()` with static provider→URL mapping
- **New**: `pkg/data-sources/sources/resolve_test.go` — 11 unit tests (all schemes, passthrough, errors)
- **Modified**: `llm/openai.go`, `llm/anthropic.go`, `llm/gemini.go`, `embedding/source.go` — call `ResolveProviderScheme()` in `Attach()` after `ApplyEnvVars()`

## Test plan

- [x] Unit tests for `ResolveProviderScheme()` — 11 cases all pass
- [x] `go test ./pkg/data-sources/...` — zero regressions
- [x] `go build ./...` — compiles cleanly
- [ ] Manual test with real API keys (openai, anthropic, gemini)

🤖 Generated with [Claude Code](https://claude.com/claude-code)