### PR TITLE
fix(llm): OpenAI Responses streaming — populate function-call arguments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-21
 - Go 1.26 with `duckdb_arrow` build tag + `duckdb-go/v2` (CGo), `net/url` (stdlib) (001-provider-url-schemes)
 - N/A (no schema changes — resolution happens in-memory during Attach) (001-provider-url-schemes)
 - N/A — feature reads Arrow records already materialised in (001-arrow-scanner)
+- Go 1.26 (via `duckdb_arrow` build tag; same as rest of `pkg/data-sources/sources/llm/`) + standard library only for the fix (`encoding/json`, `bufio`, `strings`, `io`); test paths use `github.com/stretchr/testify/require`, `assert`, and the existing subscription harness in `integration-test/models`. (001-openai-responses-fc-args)
+- N/A — the fix is entirely in-memory stream parsing. No schema migrations, no persisted state. (001-openai-responses-fc-args)
 
 ## Project Structure
 
@@ -51,6 +53,6 @@ Go 1.26: Follow standard conventions
 <!-- MANUAL ADDITIONS END -->
 
 ## Recent Changes
+- 001-openai-responses-fc-args: Added Go 1.26 (via `duckdb_arrow` build tag; same as rest of `pkg/data-sources/sources/llm/`) + standard library only for the fix (`encoding/json`, `bufio`, `strings`, `io`); test paths use `github.com/stretchr/testify/require`, `assert`, and the existing subscription harness in `integration-test/models`.
 - 001-arrow-scanner: Added Go 1.26 (with `iter.Seq`, range-over-func)
 - 001-provider-url-schemes: Added Go 1.26 with `duckdb_arrow` build tag + `duckdb-go/v2` (CGo), `net/url` (stdlib)
-- 001-llm-thinking-roundtrip: Added Go 1.26 with `duckdb_arrow` build tag + `duckdb-go/v2` (CGo), `gqlparser/v2`, `apache/arrow-go/v18`

--- a/integration-test/models/models_test.go
+++ b/integration-test/models/models_test.go
@@ -1007,6 +1007,16 @@ func testStreamToolCallRoundTrip(t *testing.T, modelName, provider string, maxTo
 	for i, tc := range toolCalls {
 		t.Logf("Step 1 stream — %s tool_call[%d]: id=%s name=%s args=%v",
 			provider, i, tc.ID, tc.Name, tc.Arguments)
+		require.NotEmptyf(t, tc.ID, "%s stream: tool_call[%d] id empty", provider, i)
+		require.NotEmptyf(t, tc.Name, "%s stream: tool_call[%d] name empty", provider, i)
+		require.NotNilf(t, tc.Arguments,
+			"%s stream: tool_call[%d] arguments nil (id=%s name=%s) — streaming accumulator likely dropped deltas",
+			provider, i, tc.ID, tc.Name)
+		argsMap, ok := tc.Arguments.(map[string]any)
+		require.Truef(t, ok, "%s stream: tool_call[%d] arguments not an object: %T", provider, i, tc.Arguments)
+		require.NotEmptyf(t, argsMap, "%s stream: tool_call[%d] arguments empty map", provider, i)
+		require.Containsf(t, argsMap, "city",
+			"%s stream: tool_call[%d] missing 'city' in arguments: %v", provider, i, argsMap)
 	}
 	// thought_signature at finish event level, not per tool call
 	thoughtSig := ""
@@ -1385,4 +1395,64 @@ func TestModels_OpenAIResponses_StreamToolCallRoundTrip(t *testing.T) {
 		t.Skip("OPENAI_KEY not set")
 	}
 	testStreamToolCallRoundTrip(t, "test_openai_responses", "openai", 200, 120*time.Second)
+}
+
+// TestModels_OpenAIResponses_StreamMultiToolCall verifies that the Responses API
+// streaming parser correctly attributes streamed arguments to each of multiple
+// parallel function calls in a single response — exercising the item_id-keyed
+// accumulator with two concurrent in-flight calls.
+func TestModels_OpenAIResponses_StreamMultiToolCall(t *testing.T) {
+	if os.Getenv("OPENAI_KEY") == "" {
+		t.Skip("OPENAI_KEY not set")
+	}
+
+	userMsg := `{"role":"user","content":"Get the current weather in Paris and in London. You must call the get_weather tool twice — once for Paris and once for London. Do not combine both cities into a single call."}`
+
+	q := buildInlineStreamQuery("test_openai_responses", []string{userMsg}, []string{roundTripToolDef}, 500, "auto")
+	events := collectStreamEventsWithTimeout(t, q, 180*time.Second)
+	require.NotEmpty(t, events, "should receive streaming events")
+
+	var finishEvent map[string]any
+	for _, e := range events {
+		if fmt.Sprintf("%v", e["type"]) == "finish" {
+			finishEvent = e
+		}
+	}
+	require.NotNil(t, finishEvent, "should have finish event")
+
+	toolCallsRaw := finishEvent["tool_calls"]
+	require.NotNil(t, toolCallsRaw, "finish event should have tool_calls")
+	toolCallsStr := fmt.Sprintf("%v", toolCallsRaw)
+
+	var toolCalls []types.LLMToolCall
+	err := json.Unmarshal([]byte(toolCallsStr), &toolCalls)
+	require.NoError(t, err, "tool_calls parse failed: %s", toolCallsStr)
+
+	for i, tc := range toolCalls {
+		t.Logf("multi tool_call[%d]: id=%s name=%s args=%v", i, tc.ID, tc.Name, tc.Arguments)
+	}
+
+	require.GreaterOrEqualf(t, len(toolCalls), 2,
+		"expected at least 2 parallel tool calls, got %d: %s", len(toolCalls), toolCallsStr)
+
+	seenIDs := make(map[string]bool, len(toolCalls))
+	seenCities := make(map[string]bool, len(toolCalls))
+	for i, tc := range toolCalls {
+		require.NotEmptyf(t, tc.ID, "tool_call[%d] id empty", i)
+		require.Falsef(t, seenIDs[tc.ID], "duplicate tool_call id %q at index %d", tc.ID, i)
+		seenIDs[tc.ID] = true
+
+		require.Equalf(t, "get_weather", tc.Name, "tool_call[%d] unexpected name", i)
+
+		argsMap, ok := tc.Arguments.(map[string]any)
+		require.Truef(t, ok, "tool_call[%d] arguments not an object: %T", i, tc.Arguments)
+		require.NotEmptyf(t, argsMap, "tool_call[%d] arguments empty map", i)
+
+		city, _ := argsMap["city"].(string)
+		require.NotEmptyf(t, city, "tool_call[%d] missing 'city' in arguments: %v", i, argsMap)
+		seenCities[strings.ToLower(city)] = true
+	}
+
+	require.Truef(t, seenCities["paris"], "expected a tool call with city=Paris, got cities=%v", seenCities)
+	require.Truef(t, seenCities["london"], "expected a tool call with city=London, got cities=%v", seenCities)
 }

--- a/integration-test/models/models_test.go
+++ b/integration-test/models/models_test.go
@@ -1004,6 +1004,9 @@ func testStreamToolCallRoundTrip(t *testing.T, modelName, provider string, maxTo
 	require.NoError(t, err, "%s stream: tool_calls parse failed: %s", provider, toolCallsStr)
 	require.NotEmpty(t, toolCalls)
 
+	// Per-call shape assertions. Coupled to `roundTripToolDef` — all call
+	// sites pass that tool, whose single required parameter is `city`.
+	// If a caller ever passes a different tool, update the key here.
 	for i, tc := range toolCalls {
 		t.Logf("Step 1 stream — %s tool_call[%d]: id=%s name=%s args=%v",
 			provider, i, tc.ID, tc.Name, tc.Arguments)

--- a/integration-test/models/models_test.go
+++ b/integration-test/models/models_test.go
@@ -572,7 +572,7 @@ func TestModels_StreamChatCompletion_OpenAI(t *testing.T) {
 	defer sub.Cancel()
 
 	var eventCount int
-	var content string
+	var content strings.Builder
 	for event := range sub.Events {
 		for event.Reader.Next() {
 			batch := event.Reader.RecordBatch()
@@ -584,7 +584,7 @@ func TestModels_StreamChatCompletion_OpenAI(t *testing.T) {
 				eventType := batch.Column(typeIdx).GetOneForMarshal(i)
 				eventContent := batch.Column(contentIdx).GetOneForMarshal(i)
 				if eventType == "content_delta" && eventContent != nil {
-					content += fmt.Sprintf("%v", eventContent)
+					fmt.Fprintf(&content, "%v", eventContent)
 				}
 			}
 		}
@@ -593,7 +593,7 @@ func TestModels_StreamChatCompletion_OpenAI(t *testing.T) {
 
 	assert.Greater(t, eventCount, 0, "should receive events")
 	// Note: some OpenAI-compatible servers may return content in finish event only
-	t.Logf("OpenAI chat stream: %d events, content=%q", eventCount, content)
+	t.Logf("OpenAI chat stream: %d events, content=%q", eventCount, content.String())
 }
 
 func TestModels_StreamCompletion_Anthropic(t *testing.T) {
@@ -1239,7 +1239,7 @@ func TestModels_StreamThinkingToolCallRoundTrip_Anthropic(t *testing.T) {
 	toolCallsRaw := finishEvent["tool_calls"]
 	require.NotNil(t, toolCallsRaw, "finish should have tool_calls")
 	var toolCalls []types.LLMToolCall
-	err := json.Unmarshal([]byte(fmt.Sprintf("%v", toolCallsRaw)), &toolCalls)
+	err := json.Unmarshal(fmt.Appendf(nil, "%v", toolCallsRaw), &toolCalls)
 	require.NoError(t, err)
 	require.NotEmpty(t, toolCalls)
 

--- a/pkg/data-sources/sources/llm/openai_responses.go
+++ b/pkg/data-sources/sources/llm/openai_responses.go
@@ -333,21 +333,30 @@ func parseResponsesStream(body io.Reader, onEvent func(event *sources.LLMStreamE
 			break
 		}
 
+		// Fields are unioned across event types; absent fields parse as
+		// zero values. Comments note which events populate each field.
 		var event struct {
 			Type string `json:"type"`
 
-			// response.output_text.delta / function_call_arguments.delta
+			// output_text.delta, reasoning_summary_text.delta,
+			// function_call_arguments.delta
 			Delta string `json:"delta"`
 
-			// function_call_arguments.delta / .done correlate by item_id.
-			ItemID      string `json:"item_id"`
-			OutputIndex int    `json:"output_index"`
+			// function_call_arguments.delta, function_call_arguments.done,
+			// output_text.delta, reasoning_summary_text.delta — item
+			// correlation handle.
+			ItemID string `json:"item_id"`
 
-			// response.function_call_arguments.done — authoritative final args.
+			// output_item.added, function_call_arguments.delta/done —
+			// stable index within the response, used for ordered flush.
+			OutputIndex int `json:"output_index"`
+
+			// function_call_arguments.done — authoritative final args
+			// string for a single function_call item.
 			Arguments string `json:"arguments"`
 
-			// response.output_item.added — item.id is the stable handle used
-			// as the map key; item.call_id is the external id surfaced later.
+			// output_item.added — item.id is the map key; item.call_id
+			// is the external id surfaced later as LLMToolCall.ID.
 			Item struct {
 				ID     string `json:"id"`
 				Type   string `json:"type"`
@@ -355,7 +364,7 @@ func parseResponsesStream(body io.Reader, onEvent func(event *sources.LLMStreamE
 				Name   string `json:"name"`
 			} `json:"item"`
 
-			// response.completed
+			// response.completed — terminal usage + model metadata.
 			Response struct {
 				Model string `json:"model"`
 				Usage struct {
@@ -364,7 +373,8 @@ func parseResponsesStream(body io.Reader, onEvent func(event *sources.LLMStreamE
 				} `json:"usage"`
 			} `json:"response"`
 
-			// summary_text
+			// reasoning_summary_text.* — unused today; parsed for
+			// forward compatibility with richer reasoning events.
 			Text string `json:"text"`
 		}
 		if err := json.Unmarshal([]byte(data), &event); err != nil {
@@ -426,9 +436,11 @@ func parseResponsesStream(body io.Reader, onEvent func(event *sources.LLMStreamE
 			if len(pendingOrder) > 0 {
 				calls := make([]sources.LLMToolCall, 0, len(pendingOrder))
 				for _, pc := range pendingOrder {
-					raw := pc.FinalArgs
-					if raw == "" {
-						raw = pc.Args.String()
+					// Prefer the authoritative final args from the .done
+					// event; fall back to the accumulated delta stream.
+					raw := pc.Args.String()
+					if pc.Done {
+						raw = pc.FinalArgs
 					}
 					var args any
 					if raw != "" {

--- a/pkg/data-sources/sources/llm/openai_responses.go
+++ b/pkg/data-sources/sources/llm/openai_responses.go
@@ -299,19 +299,27 @@ func parseResponsesResponse(body []byte) (*sources.LLMResult, error) {
 }
 
 // parseResponsesStream parses SSE events from a streaming Responses API response.
+//
+// Pending function calls are keyed by item_id (the stable handle OpenAI uses on
+// function_call_arguments.delta / .done events). The external call_id — which
+// the provider expects echoed back on the tool-result follow-up message — is
+// captured once on response.output_item.added and emitted upward as
+// LLMToolCall.ID.
 func parseResponsesStream(body io.Reader, onEvent func(event *sources.LLMStreamEvent) error) error {
 	type pendingFunctionCall struct {
-		CallID string
-		Name   string
-		Args   strings.Builder
+		ItemID      string
+		CallID      string
+		Name        string
+		OutputIndex int
+		Args        strings.Builder
+		FinalArgs   string
+		Done        bool
 	}
 
 	var (
-		accThinking      strings.Builder
-		pendingCalls     = map[string]*pendingFunctionCall{} // by call_id
-		promptTokens     int
-		completionTokens int
-		model            string
+		accThinking     strings.Builder
+		pendingByItemID = map[string]*pendingFunctionCall{}
+		pendingOrder    []*pendingFunctionCall
 	)
 
 	scanner := bufio.NewScanner(body)
@@ -328,14 +336,20 @@ func parseResponsesStream(body io.Reader, onEvent func(event *sources.LLMStreamE
 		var event struct {
 			Type string `json:"type"`
 
-			// response.output_text.delta
+			// response.output_text.delta / function_call_arguments.delta
 			Delta string `json:"delta"`
 
-			// response.function_call_arguments.delta
-			CallID string `json:"call_id"`
+			// function_call_arguments.delta / .done correlate by item_id.
+			ItemID      string `json:"item_id"`
+			OutputIndex int    `json:"output_index"`
 
-			// response.output_item.added — function_call start
+			// response.function_call_arguments.done — authoritative final args.
+			Arguments string `json:"arguments"`
+
+			// response.output_item.added — item.id is the stable handle used
+			// as the map key; item.call_id is the external id surfaced later.
 			Item struct {
+				ID     string `json:"id"`
 				Type   string `json:"type"`
 				CallID string `json:"call_id"`
 				Name   string `json:"name"`
@@ -376,38 +390,49 @@ func parseResponsesStream(body io.Reader, onEvent func(event *sources.LLMStreamE
 			}
 
 		case "response.output_item.added":
-			if event.Item.Type == "function_call" {
-				pendingCalls[event.Item.CallID] = &pendingFunctionCall{
-					CallID: event.Item.CallID,
-					Name:   event.Item.Name,
-				}
+			if event.Item.Type != "function_call" || event.Item.ID == "" {
+				break
 			}
+			pc := &pendingFunctionCall{
+				ItemID:      event.Item.ID,
+				CallID:      event.Item.CallID,
+				Name:        event.Item.Name,
+				OutputIndex: event.OutputIndex,
+			}
+			pendingByItemID[event.Item.ID] = pc
+			pendingOrder = append(pendingOrder, pc)
 
 		case "response.function_call_arguments.delta":
-			if pc := pendingCalls[event.CallID]; pc != nil {
+			if pc := pendingByItemID[event.ItemID]; pc != nil {
 				pc.Args.WriteString(event.Delta)
 			}
 
-		case "response.completed":
-			model = event.Response.Model
-			promptTokens = event.Response.Usage.InputTokens
-			completionTokens = event.Response.Usage.OutputTokens
+		case "response.function_call_arguments.done":
+			if pc := pendingByItemID[event.ItemID]; pc != nil {
+				pc.FinalArgs = event.Arguments
+				pc.Done = true
+			}
 
+		case "response.completed":
 			ev := &sources.LLMStreamEvent{
 				Type:             "finish",
-				Model:            model,
+				Model:            event.Response.Model,
 				FinishReason:     "stop",
-				PromptTokens:     promptTokens,
-				CompletionTokens: completionTokens,
+				PromptTokens:     event.Response.Usage.InputTokens,
+				CompletionTokens: event.Response.Usage.OutputTokens,
 				Thinking:         accThinking.String(),
 			}
 
-			if len(pendingCalls) > 0 {
-				var calls []sources.LLMToolCall
-				for _, pc := range pendingCalls {
+			if len(pendingOrder) > 0 {
+				calls := make([]sources.LLMToolCall, 0, len(pendingOrder))
+				for _, pc := range pendingOrder {
+					raw := pc.FinalArgs
+					if raw == "" {
+						raw = pc.Args.String()
+					}
 					var args any
-					if s := pc.Args.String(); s != "" {
-						_ = json.Unmarshal([]byte(s), &args)
+					if raw != "" {
+						_ = json.Unmarshal([]byte(raw), &args)
 					}
 					calls = append(calls, sources.LLMToolCall{
 						ID:        pc.CallID,

--- a/pkg/mcp/data.go
+++ b/pkg/mcp/data.go
@@ -81,7 +81,8 @@ func (s *Server) inlineGraphQLResult(ctx context.Context, req mcp.CallToolReques
 	}
 	if isTruncated {
 		result["data"] = fmt.Sprintf("[truncated: result is %d bytes, max is %d. Increase max_result_size or use jq_transform to reduce output]", originalSize, maxResultSize)
-		result["preview"] = string(b[:2000])
+		// Raw byte-window preview; may split a UTF-8 rune at the boundary.
+		result["preview"] = string(b[:min(originalSize, 2000)])
 	} else {
 		result["data"] = json.RawMessage(b)
 	}

--- a/pkg/mcp/data.go
+++ b/pkg/mcp/data.go
@@ -81,6 +81,7 @@ func (s *Server) inlineGraphQLResult(ctx context.Context, req mcp.CallToolReques
 	}
 	if isTruncated {
 		result["data"] = fmt.Sprintf("[truncated: result is %d bytes, max is %d. Increase max_result_size or use jq_transform to reduce output]", originalSize, maxResultSize)
+		result["preview"] = string(b[:2000])
 	} else {
 		result["data"] = json.RawMessage(b)
 	}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -138,7 +138,7 @@ Common enums: OrderDirection (ASC, DESC), TimeExtract (year, month, day, hour, .
 	// Data tools.
 	mcpServer.AddTool(mcp.NewTool("data-inline_graphql_result",
 		mcp.WithDescription(`Execute a GraphQL query and return JSON result with optional jq transform.
-If result is truncated (is_truncated=true), increase max_result_size (up to 5000) or use jq_transform to reduce output.
+If result is truncated (is_truncated=true), increase max_result_size (up to 10000) or use jq_transform to reduce output.
 Query rules:
 - Modules are nested fields: query { module { submodule { table(limit:10) { fields } } } }
 - order_by: [{field: "name", direction: ASC}] — direction is UPPERCASE (ASC/DESC), fields MUST be in selection set
@@ -149,7 +149,7 @@ Query rules:
 		mcp.WithString("query", mcp.Required(), mcp.Description("GraphQL query")),
 		mcp.WithObject("variables", mcp.Description("Query variables")),
 		mcp.WithString("jq_transform", mcp.Description("JQ expression to apply to result")),
-		mcp.WithNumber("max_result_size", mcp.Description("Max result bytes (100-5000). Increase if result is truncated."), mcp.DefaultNumber(1000)),
+		mcp.WithNumber("max_result_size", mcp.Description("Max result bytes (100-10000). Increase if result is truncated."), mcp.DefaultNumber(1000)),
 	), s.inlineGraphQLResult)
 
 	mcpServer.AddTool(mcp.NewTool("data-validate_graphql_query",


### PR DESCRIPTION
## Summary

- Streaming subscriptions against OpenAI Responses-API-backed models delivered `tool_calls` with empty `arguments` — the stream accumulator keyed pending calls by `call_id`, but `response.function_call_arguments.delta` events carry only `item_id`. Every delta was silently dropped.
- Rewrite `parseResponsesStream` to key by `item_id`, flush in `output_index` order, and accept `response.function_call_arguments.done` as the authoritative final arguments payload. `LLMToolCall.ID` keeps being the external `call_id` used for tool-result round-trips.
- Non-streaming path, Chat Completions, Anthropic, and Gemini are untouched — only the Responses streaming accumulator changes.
- Also bundles two small MCP tweaks (separate commit): a 2KB `preview` in truncated inline-GraphQL responses and raising `max_result_size` cap from 5000 to 10000, so agents aren't flying blind on truncated results.

## Test plan

- [x] `TestModels_OpenAIResponses_StreamToolCallRoundTrip` — now asserts per-call `Arguments` is a non-empty map containing `city`; passes live.
- [x] `TestModels_OpenAIResponses_StreamMultiToolCall` (new) — forces two parallel tool calls, asserts distinct ids and `{Paris, London}` as a set.
- [x] `TestModels_OpenAIResponses_ChatWithTools` / `TestModels_OpenAIResponses_ToolCallRoundTrip` — non-streaming path unchanged, passes.
- [x] `TestModels_StreamToolCallRoundTrip_Gemini` / `_Anthropic` / `_OpenAIRemote` — tightened helper also validates arguments on every other provider, passes.
- [x] Full `integration-test/models` suite — green, 165s.
- [x] `CGO_CFLAGS="-O1 -g" go build -tags=duckdb_arrow ./...` — green.

Design docs: `specs/001-openai-responses-fc-args/{spec,plan,research,data-model,quickstart,tasks}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)