### PR TITLE
feat(models): embedding_distance function (core.models)

### DIFF
--- a/integration-test/models/models_test.go
+++ b/integration-test/models/models_test.go
@@ -188,6 +188,9 @@ func TestModels_EmbeddingDistance(t *testing.T) {
 		inner: embedding_distance(model: "test_embedder", text1: "hello world", text2: "goodbye", distance: Inner)
 	} } } }`, nil)
 	defer res.Close()
+	// Without this, a field-level error would leave the (non-pointer) float fields
+	// at 0.0 and the InDelta(0.0, ...) checks below would pass green on failure.
+	require.Empty(t, res.Errors, "unexpected query errors: %v", res.Errors)
 
 	var r struct {
 		Same      float64 `json:"same"`
@@ -219,6 +222,7 @@ func TestModels_EmbeddingDistance_Metrics(t *testing.T) {
 		inner_ba: embedding_distance(model: "test_embedder", text1: "espresso at dawn", text2: "morning coffee", distance: Inner)
 	} } } }`, nil)
 	defer res.Close()
+	require.Empty(t, res.Errors, "unexpected query errors: %v", res.Errors)
 
 	var r struct {
 		CosineAB float64 `json:"cosine_ab"`
@@ -241,20 +245,28 @@ func TestModels_EmbeddingDistance_Metrics(t *testing.T) {
 	t.Logf("cosine=%g l2=%g inner=%g", r.CosineAB, r.L2AB, r.InnerAB)
 }
 
-// US3: bad inputs surface clear errors, never a (wrong) value.
+// US3: bad inputs surface clear errors carrying the documented wording, never a value.
 func TestModels_EmbeddingDistance_Errors(t *testing.T) {
 	ctx := context.Background()
+
+	// errText returns the combined error text whether it arrived as a transport
+	// error or as a GraphQL field error in the response.
+	errText := func(res *types.Response, err error) string {
+		if err != nil {
+			return err.Error()
+		}
+		if res != nil {
+			defer res.Close()
+			return fmt.Sprintf("%v %v", res.Errors, res.Err())
+		}
+		return ""
+	}
 
 	// Unknown model — fails at source resolution (no embedder needed).
 	t.Run("unknown_model", func(t *testing.T) {
 		res, err := testService.Query(ctx,
 			`{ function { core { models { embedding_distance(model: "nonexistent", text1: "a", text2: "b", distance: Cosine) } } } }`, nil)
-		if err != nil {
-			t.Logf("expected error: %v", err)
-			return
-		}
-		defer res.Close()
-		assert.True(t, len(res.Errors) > 0 || res.Err() != nil, "unknown model should error")
+		assert.Contains(t, errText(res, err), "not found", "unknown model should report 'not found'")
 	})
 
 	// Non-embedding source — calling it with an LLM source must error.
@@ -264,24 +276,16 @@ func TestModels_EmbeddingDistance_Errors(t *testing.T) {
 		}
 		res, err := testService.Query(ctx,
 			`{ function { core { models { embedding_distance(model: "test_llm", text1: "a", text2: "b", distance: Cosine) } } } }`, nil)
-		if err != nil {
-			t.Logf("expected error: %v", err)
-			return
-		}
-		defer res.Close()
-		assert.True(t, len(res.Errors) > 0 || res.Err() != nil, "non-embedding source should error")
+		assert.Contains(t, errText(res, err), "is not an embedding source")
 	})
 
-	// Invalid metric — rejected by the GraphQL VectorDistanceType enum before execution.
+	// Invalid metric — rejected by the GraphQL VectorDistanceType enum at validation
+	// (this exercises the GraphQL schema wiring, not the UDF's own metric guard, which
+	// is covered by the unit test's raw-SQL path).
 	t.Run("invalid_metric_enum", func(t *testing.T) {
 		res, err := testService.Query(ctx,
 			`{ function { core { models { embedding_distance(model: "test_embedder", text1: "a", text2: "b", distance: Nope) } } } }`, nil)
-		if err != nil {
-			t.Logf("expected validation error: %v", err)
-			return
-		}
-		defer res.Close()
-		assert.True(t, len(res.Errors) > 0 || res.Err() != nil, "invalid enum value should error")
+		assert.Contains(t, errText(res, err), "VectorDistanceType", "invalid enum value should be rejected by VectorDistanceType validation")
 	})
 }
 

--- a/integration-test/models/models_test.go
+++ b/integration-test/models/models_test.go
@@ -175,6 +175,116 @@ func TestModels_Embedding_NotFound(t *testing.T) {
 	assert.True(t, len(res.Errors) > 0 || err != nil, "should error for nonexistent model")
 }
 
+func TestModels_EmbeddingDistance(t *testing.T) {
+	if os.Getenv("EMBEDDER_URL") == "" {
+		t.Skip("EMBEDDER_URL not set")
+	}
+	// US1 + US2: one call returns a Float distance; identical ~0; related < unrelated.
+	res := query(t, `{ function { core { models {
+		same: embedding_distance(model: "test_embedder", text1: "hello world", text2: "hello world", distance: Cosine)
+		related: embedding_distance(model: "test_embedder", text1: "a cat sat on the mat", text2: "a feline rested on the rug", distance: Cosine)
+		unrelated: embedding_distance(model: "test_embedder", text1: "a cat sat on the mat", text2: "quarterly financial earnings report", distance: Cosine)
+		l2: embedding_distance(model: "test_embedder", text1: "hello world", text2: "hello world", distance: L2)
+		inner: embedding_distance(model: "test_embedder", text1: "hello world", text2: "goodbye", distance: Inner)
+	} } } }`, nil)
+	defer res.Close()
+
+	var r struct {
+		Same      float64 `json:"same"`
+		Related   float64 `json:"related"`
+		Unrelated float64 `json:"unrelated"`
+		L2        float64 `json:"l2"`
+		Inner     float64 `json:"inner"`
+	}
+	err := res.ScanData("function.core.models", &r)
+	require.NoError(t, err)
+
+	assert.InDelta(t, 0.0, r.Same, 1e-3, "identical strings → cosine distance ~0")
+	assert.InDelta(t, 0.0, r.L2, 1e-3, "identical strings → L2 distance ~0")
+	assert.Less(t, r.Related, r.Unrelated, "related pair should be closer than unrelated pair")
+	t.Logf("cosine: same=%g related=%g unrelated=%g; l2(same)=%g inner=%g", r.Same, r.Related, r.Unrelated, r.L2, r.Inner)
+}
+
+// US2: every metric is symmetric and in its expected range.
+func TestModels_EmbeddingDistance_Metrics(t *testing.T) {
+	if os.Getenv("EMBEDDER_URL") == "" {
+		t.Skip("EMBEDDER_URL not set")
+	}
+	res := query(t, `{ function { core { models {
+		cosine_ab: embedding_distance(model: "test_embedder", text1: "morning coffee", text2: "espresso at dawn", distance: Cosine)
+		cosine_ba: embedding_distance(model: "test_embedder", text1: "espresso at dawn", text2: "morning coffee", distance: Cosine)
+		l2_ab: embedding_distance(model: "test_embedder", text1: "morning coffee", text2: "espresso at dawn", distance: L2)
+		l2_ba: embedding_distance(model: "test_embedder", text1: "espresso at dawn", text2: "morning coffee", distance: L2)
+		inner_ab: embedding_distance(model: "test_embedder", text1: "morning coffee", text2: "espresso at dawn", distance: Inner)
+		inner_ba: embedding_distance(model: "test_embedder", text1: "espresso at dawn", text2: "morning coffee", distance: Inner)
+	} } } }`, nil)
+	defer res.Close()
+
+	var r struct {
+		CosineAB float64 `json:"cosine_ab"`
+		CosineBA float64 `json:"cosine_ba"`
+		L2AB     float64 `json:"l2_ab"`
+		L2BA     float64 `json:"l2_ba"`
+		InnerAB  float64 `json:"inner_ab"`
+		InnerBA  float64 `json:"inner_ba"`
+	}
+	require.NoError(t, res.ScanData("function.core.models", &r))
+
+	// Symmetric: d(a,b) == d(b,a) for all metrics.
+	assert.InDelta(t, r.CosineAB, r.CosineBA, 1e-6, "cosine must be symmetric")
+	assert.InDelta(t, r.L2AB, r.L2BA, 1e-6, "L2 must be symmetric")
+	assert.InDelta(t, r.InnerAB, r.InnerBA, 1e-6, "inner must be symmetric")
+	// Ranges: cosine distance in [0,2]; L2 >= 0.
+	assert.GreaterOrEqual(t, r.CosineAB, 0.0)
+	assert.LessOrEqual(t, r.CosineAB, 2.0)
+	assert.GreaterOrEqual(t, r.L2AB, 0.0)
+	t.Logf("cosine=%g l2=%g inner=%g", r.CosineAB, r.L2AB, r.InnerAB)
+}
+
+// US3: bad inputs surface clear errors, never a (wrong) value.
+func TestModels_EmbeddingDistance_Errors(t *testing.T) {
+	ctx := context.Background()
+
+	// Unknown model — fails at source resolution (no embedder needed).
+	t.Run("unknown_model", func(t *testing.T) {
+		res, err := testService.Query(ctx,
+			`{ function { core { models { embedding_distance(model: "nonexistent", text1: "a", text2: "b", distance: Cosine) } } } }`, nil)
+		if err != nil {
+			t.Logf("expected error: %v", err)
+			return
+		}
+		defer res.Close()
+		assert.True(t, len(res.Errors) > 0 || res.Err() != nil, "unknown model should error")
+	})
+
+	// Non-embedding source — calling it with an LLM source must error.
+	t.Run("non_embedding_source", func(t *testing.T) {
+		if os.Getenv("LLM_URL") == "" {
+			t.Skip("LLM_URL not set")
+		}
+		res, err := testService.Query(ctx,
+			`{ function { core { models { embedding_distance(model: "test_llm", text1: "a", text2: "b", distance: Cosine) } } } }`, nil)
+		if err != nil {
+			t.Logf("expected error: %v", err)
+			return
+		}
+		defer res.Close()
+		assert.True(t, len(res.Errors) > 0 || res.Err() != nil, "non-embedding source should error")
+	})
+
+	// Invalid metric — rejected by the GraphQL VectorDistanceType enum before execution.
+	t.Run("invalid_metric_enum", func(t *testing.T) {
+		res, err := testService.Query(ctx,
+			`{ function { core { models { embedding_distance(model: "test_embedder", text1: "a", text2: "b", distance: Nope) } } } }`, nil)
+		if err != nil {
+			t.Logf("expected validation error: %v", err)
+			return
+		}
+		defer res.Close()
+		assert.True(t, len(res.Errors) > 0 || res.Err() != nil, "invalid enum value should error")
+	})
+}
+
 // --- US2: Completion ---
 
 func TestModels_Completion(t *testing.T) {

--- a/pkg/data-sources/sources/runtime/models/embedding_distance_test.go
+++ b/pkg/data-sources/sources/runtime/models/embedding_distance_test.go
@@ -1,0 +1,196 @@
+//go:build duckdb_arrow
+
+package models_test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/data-sources/sources"
+	models "github.com/hugr-lab/query-engine/pkg/data-sources/sources/runtime/models"
+	"github.com/hugr-lab/query-engine/pkg/db"
+	"github.com/hugr-lab/query-engine/pkg/engines"
+	"github.com/hugr-lab/query-engine/types"
+)
+
+// stubEmbedder implements sources.Source + sources.EmbeddingSource, returning
+// fixed vectors per input string so distances are fully deterministic.
+type stubEmbedder struct {
+	name string
+	vecs map[string]types.Vector
+}
+
+func (s *stubEmbedder) Name() string                               { return s.name }
+func (s *stubEmbedder) Definition() types.DataSource               { return types.DataSource{} }
+func (s *stubEmbedder) Engine() engines.Engine                     { return engines.NewDuckDB() }
+func (s *stubEmbedder) IsAttached() bool                           { return true }
+func (s *stubEmbedder) ReadOnly() bool                             { return true }
+func (s *stubEmbedder) Attach(_ context.Context, _ *db.Pool) error { return nil }
+func (s *stubEmbedder) Detach(_ context.Context, _ *db.Pool) error { return nil }
+func (s *stubEmbedder) ModelInfo() types.ModelInfo {
+	return types.ModelInfo{Name: s.name, Type: "embedding"}
+}
+
+func (s *stubEmbedder) CreateEmbedding(_ context.Context, input string) (*types.EmbeddingResult, error) {
+	v, ok := s.vecs[input]
+	if !ok {
+		return nil, fmt.Errorf("no vector for %q", input)
+	}
+	return &types.EmbeddingResult{Vector: v}, nil
+}
+
+func (s *stubEmbedder) CreateEmbeddings(_ context.Context, inputs []string) (*types.EmbeddingsResult, error) {
+	out := make([]types.Vector, len(inputs))
+	for i, in := range inputs {
+		v, ok := s.vecs[in]
+		if !ok {
+			return nil, fmt.Errorf("no vector for %q", in)
+		}
+		out[i] = v
+	}
+	return &types.EmbeddingsResult{Vectors: out}, nil
+}
+
+// plainSource implements sources.Source but NOT sources.EmbeddingSource.
+type plainSource struct{ name string }
+
+func (s *plainSource) Name() string                               { return s.name }
+func (s *plainSource) Definition() types.DataSource               { return types.DataSource{} }
+func (s *plainSource) Engine() engines.Engine                     { return engines.NewDuckDB() }
+func (s *plainSource) IsAttached() bool                           { return true }
+func (s *plainSource) ReadOnly() bool                             { return true }
+func (s *plainSource) Attach(_ context.Context, _ *db.Pool) error { return nil }
+func (s *plainSource) Detach(_ context.Context, _ *db.Pool) error { return nil }
+
+// fakeResolver resolves sources by name from a fixed map.
+type fakeResolver struct{ m map[string]sources.Source }
+
+func (r fakeResolver) Resolve(name string) (sources.Source, error) {
+	s, ok := r.m[name]
+	if !ok {
+		return nil, fmt.Errorf("data source %q not found", name)
+	}
+	return s, nil
+}
+
+func (r fakeResolver) ResolveAll() []sources.Source {
+	out := make([]sources.Source, 0, len(r.m))
+	for _, s := range r.m {
+		out = append(out, s)
+	}
+	return out
+}
+
+// newTestSource spins up the core.models source against an in-memory DuckDB with
+// a stub embedding source ("emb", with fixed vectors) and a non-embedding source
+// ("plain"). Returns the pool for issuing queries.
+func newTestSource(t *testing.T) *db.Pool {
+	t.Helper()
+	ctx := context.Background()
+	pool, err := db.NewPool("")
+	if err != nil {
+		t.Fatalf("new pool: %v", err)
+	}
+	t.Cleanup(func() { _ = pool.Close() })
+
+	src := models.New()
+	src.DataSourceServiceSetup(fakeResolver{m: map[string]sources.Source{
+		"emb": &stubEmbedder{name: "emb", vecs: map[string]types.Vector{
+			"a":    {1, 0, 0},
+			"a2":   {1, 0, 0},     // identical to "a"
+			"sim":  {0.9, 0.1, 0}, // close to "a"
+			"orth": {0, 1, 0},     // orthogonal to "a"
+		}},
+		"plain": &plainSource{name: "plain"},
+	}})
+	if err := src.Attach(ctx, pool); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	return pool
+}
+
+func scalar(t *testing.T, pool *db.Pool, query string) (float64, error) {
+	t.Helper()
+	ctx := context.Background()
+	conn, err := pool.Conn(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+	var v float64
+	err = conn.QueryRow(ctx, query).Scan(&v)
+	return v, err
+}
+
+// T004 [US1]: a single call returns a distance; identical → ~0, related < unrelated.
+func TestEmbeddingDistance_Behavior(t *testing.T) {
+	pool := newTestSource(t)
+
+	same, err := scalar(t, pool, `SELECT core_models_embedding_distance('emb','a','a2','Cosine')`)
+	if err != nil {
+		t.Fatalf("identical: %v", err)
+	}
+	if math.Abs(same) > 1e-6 {
+		t.Errorf("identical strings: cosine distance = %g, want ~0", same)
+	}
+
+	related, err := scalar(t, pool, `SELECT core_models_embedding_distance('emb','a','sim','Cosine')`)
+	if err != nil {
+		t.Fatalf("related: %v", err)
+	}
+	unrelated, err := scalar(t, pool, `SELECT core_models_embedding_distance('emb','a','orth','Cosine')`)
+	if err != nil {
+		t.Fatalf("unrelated: %v", err)
+	}
+	if !(related < unrelated) {
+		t.Errorf("expected related (%g) < unrelated (%g)", related, unrelated)
+	}
+}
+
+// T005/T006 [US2]: each metric equals a direct array_* call over the same vectors.
+func TestEmbeddingDistance_ParityWithVectorSearch(t *testing.T) {
+	pool := newTestSource(t)
+
+	cases := []struct {
+		metric string
+		arrFn  string
+	}{
+		{"L2", "array_distance"},
+		{"Cosine", "array_cosine_distance"},
+		{"Inner", "array_negative_inner_product"},
+	}
+	for _, c := range cases {
+		t.Run(c.metric, func(t *testing.T) {
+			got, err := scalar(t, pool,
+				fmt.Sprintf(`SELECT core_models_embedding_distance('emb','a','orth','%s')`, c.metric))
+			if err != nil {
+				t.Fatalf("function: %v", err)
+			}
+			want, err := scalar(t, pool,
+				fmt.Sprintf(`SELECT %s([1,0,0]::FLOAT[3], [0,1,0]::FLOAT[3])`, c.arrFn))
+			if err != nil {
+				t.Fatalf("direct %s: %v", c.arrFn, err)
+			}
+			if math.Abs(got-want) > 1e-6 {
+				t.Errorf("%s: function=%g, direct %s=%g (must match)", c.metric, got, c.arrFn, want)
+			}
+		})
+	}
+}
+
+// T008 [US3]: unknown model and non-embedding source return errors, no value.
+func TestEmbeddingDistance_Errors(t *testing.T) {
+	pool := newTestSource(t)
+
+	if _, err := scalar(t, pool, `SELECT core_models_embedding_distance('missing','a','orth','Cosine')`); err == nil {
+		t.Error("unknown model: expected error, got nil")
+	}
+	if _, err := scalar(t, pool, `SELECT core_models_embedding_distance('plain','a','orth','Cosine')`); err == nil {
+		t.Error("non-embedding source: expected error, got nil")
+	}
+	if _, err := scalar(t, pool, `SELECT core_models_embedding_distance('emb','a','orth','Nope')`); err == nil {
+		t.Error("unsupported metric: expected error, got nil")
+	}
+}

--- a/pkg/data-sources/sources/runtime/models/embedding_distance_test.go
+++ b/pkg/data-sources/sources/runtime/models/embedding_distance_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/hugr-lab/query-engine/pkg/data-sources/sources"
@@ -100,8 +101,9 @@ func newTestSource(t *testing.T) *db.Pool {
 		"emb": &stubEmbedder{name: "emb", vecs: map[string]types.Vector{
 			"a":    {1, 0, 0},
 			"a2":   {1, 0, 0},     // identical to "a"
-			"sim":  {0.9, 0.1, 0}, // close to "a"
+			"sim":  {0.9, 0.1, 0}, // close to "a", non-orthogonal (nonzero dot)
 			"orth": {0, 1, 0},     // orthogonal to "a"
+			"zero": {0, 0, 0},     // zero-norm (cosine undefined)
 		}},
 		"plain": &plainSource{name: "plain"},
 	}})
@@ -161,15 +163,18 @@ func TestEmbeddingDistance_ParityWithVectorSearch(t *testing.T) {
 		{"Cosine", "array_cosine_distance"},
 		{"Inner", "array_negative_inner_product"},
 	}
+	// Use non-orthogonal vectors ("a"=[1,0,0], "sim"=[0.9,0.1,0]) so every metric
+	// has a distinctive non-zero expected value — in particular Inner = -0.9, not 0
+	// (orthogonal inputs would make the Inner case a meaningless 0==0 comparison).
 	for _, c := range cases {
 		t.Run(c.metric, func(t *testing.T) {
 			got, err := scalar(t, pool,
-				fmt.Sprintf(`SELECT core_models_embedding_distance('emb','a','orth','%s')`, c.metric))
+				fmt.Sprintf(`SELECT core_models_embedding_distance('emb','a','sim','%s')`, c.metric))
 			if err != nil {
 				t.Fatalf("function: %v", err)
 			}
 			want, err := scalar(t, pool,
-				fmt.Sprintf(`SELECT %s([1,0,0]::FLOAT[3], [0,1,0]::FLOAT[3])`, c.arrFn))
+				fmt.Sprintf(`SELECT %s([1,0,0]::FLOAT[3], [0.9,0.1,0]::FLOAT[3])`, c.arrFn))
 			if err != nil {
 				t.Fatalf("direct %s: %v", c.arrFn, err)
 			}
@@ -180,17 +185,69 @@ func TestEmbeddingDistance_ParityWithVectorSearch(t *testing.T) {
 	}
 }
 
-// T008 [US3]: unknown model and non-embedding source return errors, no value.
+// T008 [US3]: bad inputs return errors carrying the documented wording, no value.
 func TestEmbeddingDistance_Errors(t *testing.T) {
 	pool := newTestSource(t)
 
-	if _, err := scalar(t, pool, `SELECT core_models_embedding_distance('missing','a','orth','Cosine')`); err == nil {
-		t.Error("unknown model: expected error, got nil")
+	cases := []struct {
+		name, query, wantSubstr string
+	}{
+		{"unknown model", `SELECT core_models_embedding_distance('missing','a','orth','Cosine')`, "not found"},
+		{"non-embedding source", `SELECT core_models_embedding_distance('plain','a','orth','Cosine')`, "is not an embedding source"},
+		{"unsupported metric", `SELECT core_models_embedding_distance('emb','a','orth','Nope')`, "unsupported distance metric"},
 	}
-	if _, err := scalar(t, pool, `SELECT core_models_embedding_distance('plain','a','orth','Cosine')`); err == nil {
-		t.Error("non-embedding source: expected error, got nil")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := scalar(t, pool, c.query)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), c.wantSubstr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), c.wantSubstr)
+			}
+		})
 	}
-	if _, err := scalar(t, pool, `SELECT core_models_embedding_distance('emb','a','orth','Nope')`); err == nil {
-		t.Error("unsupported metric: expected error, got nil")
+}
+
+// T006 / research R6 [US2]: a zero-norm vector under Cosine. DuckDB's
+// array_cosine_distance returns the maximum distance 2.0 for an undefined
+// (zero-norm) cosine — it does not error or fabricate a small value. This test
+// locks that observed engine behavior (same value vector search would yield).
+func TestEmbeddingDistance_ZeroNormCosine(t *testing.T) {
+	pool := newTestSource(t)
+	got, err := scalar(t, pool, `SELECT core_models_embedding_distance('emb','a','zero','Cosine')`)
+	if err != nil {
+		t.Fatalf("zero-norm cosine: %v", err)
+	}
+	if math.Abs(got-2.0) > 1e-6 {
+		t.Errorf("zero-norm cosine = %g, want 2.0 (DuckDB max cosine distance)", got)
+	}
+}
+
+// US2: every metric is symmetric, and Inner self-distance of a unit vector = -1.
+func TestEmbeddingDistance_SymmetryAndSelf(t *testing.T) {
+	pool := newTestSource(t)
+
+	for _, m := range []string{"L2", "Cosine", "Inner"} {
+		ab, err := scalar(t, pool, fmt.Sprintf(`SELECT core_models_embedding_distance('emb','a','sim','%s')`, m))
+		if err != nil {
+			t.Fatalf("%s a,sim: %v", m, err)
+		}
+		ba, err := scalar(t, pool, fmt.Sprintf(`SELECT core_models_embedding_distance('emb','sim','a','%s')`, m))
+		if err != nil {
+			t.Fatalf("%s sim,a: %v", m, err)
+		}
+		if math.Abs(ab-ba) > 1e-6 {
+			t.Errorf("%s not symmetric: d(a,sim)=%g d(sim,a)=%g", m, ab, ba)
+		}
+	}
+
+	// Inner self-distance for unit vector a=[1,0,0] is -(a·a) = -1.
+	self, err := scalar(t, pool, `SELECT core_models_embedding_distance('emb','a','a2','Inner')`)
+	if err != nil {
+		t.Fatalf("inner self: %v", err)
+	}
+	if math.Abs(self-(-1.0)) > 1e-6 {
+		t.Errorf("inner self-distance = %g, want -1", self)
 	}
 }

--- a/pkg/data-sources/sources/runtime/models/schema.graphql
+++ b/pkg/data-sources/sources/runtime/models/schema.graphql
@@ -17,6 +17,19 @@ extend type Function {
   ): embeddings_result
     @function(name: "core_models_embeddings")
 
+  "Distance between the embeddings of two strings, using the same metrics as vector search"
+  embedding_distance(
+    "Name of the embedding data source"
+    model: String!
+    "First text to embed"
+    text1: String!
+    "Second text to embed"
+    text2: String!
+    "Distance metric (same enum as vector search): L2, Cosine, Inner"
+    distance: VectorDistanceType!
+  ): Float
+    @function(name: "core_models_embedding_distance")
+
   "Simple text completion"
   completion(
     "Name of the LLM data source"

--- a/pkg/data-sources/sources/runtime/models/source.go
+++ b/pkg/data-sources/sources/runtime/models/source.go
@@ -148,6 +148,85 @@ func (s *Source) registerUDFs(ctx context.Context) error {
 		return fmt.Errorf("register core_models_embeddings: %w", err)
 	}
 
+	// core_models_embedding_distance(model, text1, text2, distance) → DOUBLE
+	// Embeds both strings, then computes the distance with the SAME DuckDB SQL
+	// vector search uses (engine.SQLValue + VectorDistanceSQL switch).
+	type embeddingDistanceArgs struct {
+		model    string
+		text1    string
+		text2    string
+		distance string // "L2" | "Cosine" | "Inner"
+	}
+	err = db.RegisterScalarFunction(ctx, s.db, &db.ScalarFunctionWithArgs[embeddingDistanceArgs, float64]{
+		Name: "core_models_embedding_distance",
+		Execute: func(ctx context.Context, args embeddingDistanceArgs) (float64, error) {
+			ds, err := s.resolver.Resolve(args.model)
+			if err != nil {
+				return 0, fmt.Errorf("model %q not found: %w", args.model, err)
+			}
+			emb, ok := ds.(sources.EmbeddingSource)
+			if !ok {
+				return 0, fmt.Errorf("data source %q is not an embedding source", args.model)
+			}
+			res, err := emb.CreateEmbeddings(ctx, []string{args.text1, args.text2})
+			if err != nil {
+				return 0, err
+			}
+			if len(res.Vectors) != 2 {
+				return 0, fmt.Errorf("embedding source returned %d vectors, want 2", len(res.Vectors))
+			}
+			// Same distance SQL as vector search: first vector as a FLOAT[N]
+			// literal, the metric switch from the engine. The second vector is
+			// rendered into the expression as a literal via ApplyQueryParams
+			// (Vector has no driver.Valuer, so it cannot be a bound param).
+			e := s.Engine()
+			ec, ok := e.(engines.EngineVectorDistanceCalculator)
+			if !ok {
+				return 0, fmt.Errorf("engine does not support vector distance")
+			}
+			lit, err := e.SQLValue(res.Vectors[0])
+			if err != nil {
+				return 0, fmt.Errorf("render vector: %w", err)
+			}
+			expr, params, err := ec.VectorDistanceSQL(lit, args.distance, res.Vectors[1], nil)
+			if err != nil {
+				return 0, err
+			}
+			sqlExpr, _, err := engines.ApplyQueryParams(e, expr, params)
+			if err != nil {
+				return 0, fmt.Errorf("render distance sql: %w", err)
+			}
+			conn, err := s.db.Conn(ctx)
+			if err != nil {
+				return 0, err
+			}
+			defer conn.Close()
+			var dist float64
+			if err := conn.QueryRow(ctx, "SELECT "+sqlExpr).Scan(&dist); err != nil {
+				return 0, fmt.Errorf("compute distance: %w", err)
+			}
+			return dist, nil
+		},
+		ConvertInput: func(args []driver.Value) (embeddingDistanceArgs, error) {
+			return embeddingDistanceArgs{
+				model:    args[0].(string),
+				text1:    args[1].(string),
+				text2:    args[2].(string),
+				distance: args[3].(string),
+			}, nil
+		},
+		InputTypes: []duckdb.TypeInfo{
+			runtime.DuckDBTypeInfoByNameMust("VARCHAR"),
+			runtime.DuckDBTypeInfoByNameMust("VARCHAR"),
+			runtime.DuckDBTypeInfoByNameMust("VARCHAR"),
+			runtime.DuckDBTypeInfoByNameMust("VARCHAR"),
+		},
+		OutputType: runtime.DuckDBTypeInfoByNameMust("DOUBLE"),
+	})
+	if err != nil {
+		return fmt.Errorf("register core_models_embedding_distance: %w", err)
+	}
+
 	// core_models_completion(model, prompt, max_tokens, temperature) → llm_result struct
 	type completionArgs struct {
 		model       string


### PR DESCRIPTION
## Summary

Adds a `core.models` function **`embedding_distance(model, text1, text2, distance)`** → `Float` that embeds two strings with a named embedding source and returns the distance between the resulting vectors under the chosen metric — the **same `VectorDistanceType` enum** (`L2` / `Cosine` / `Inner`) and **same DuckDB SQL** vector search uses.

```graphql
query { function { core { models {
  embedding_distance(model: "my_embedder", text1: "cat", text2: "kitten", distance: Cosine)
} } } }
```

## How it works

The UDF (`core_models_embedding_distance`, registered next to `core_models_embedding`):
1. resolves the source → asserts `sources.EmbeddingSource`
2. embeds both strings in one `CreateEmbeddings([text1, text2])` batch (same model + dimension)
3. computes the distance with the **engine's own SQL**: `engine.SQLValue` renders the first vector to a `FLOAT[N]` literal, `engine.VectorDistanceSQL` builds the metric expression (`array_distance` / `array_cosine_distance` / `array_negative_inner_product`), `ApplyQueryParams` inlines the second vector, and the scalar `SELECT` runs on a pooled connection.

No re-implemented metric math — **parity with vector search is structural** (the identical engine method). The earlier LIST-vs-`FLOAT[N]` concern is solved by `SQLValue`'s `len(v)` cast; nested `QueryRow`-from-a-UDF follows the existing DuckLake source pattern.

## Files

- `pkg/data-sources/sources/runtime/models/source.go` — register the UDF
- `pkg/data-sources/sources/runtime/models/schema.graphql` — `embedding_distance(...): Float @function`
- `pkg/data-sources/sources/runtime/models/embedding_distance_test.go` — deterministic unit tests
- `integration-test/models/models_test.go` — GraphQL end-to-end tests

## Testing

- **Unit (no embedder needed)**: behavior (identical→0, related<unrelated), **exact parity** vs direct `array_*` for all three metrics, and errors — via a stub `EmbeddingSource`.
- **Integration (live embedder)**: GraphQL behavior, metric **symmetry + ranges**, and error handling — incl. the `VectorDistanceType` enum rejecting an invalid value at validation.
- `go build` + `go vet` clean.

## Notes

- Returns only the distance (scalar `Float`); token usage / raw vectors are out of scope.
- Read-only query function; runs under the caller's context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)