### PR TITLE
fix(perm): row-level filters silently drop literals and boolean operators (RLS bypass)

### DIFF
--- a/pkg/perm/permissions.go
+++ b/pkg/perm/permissions.go
@@ -147,17 +147,23 @@ func applyContextVariable(ctx context.Context, data map[string]any, vars map[str
 		case map[string]any:
 			res[k] = applyContextVariable(ctx, v, vars)
 		case []any:
+			list := make([]any, len(v))
 			for i, vv := range v {
-				switch vv := vv.(type) {
-				case map[string]any:
-					v[i] = applyContextVariable(ctx, vv, vars)
+				if m, ok := vv.(map[string]any); ok {
+					list[i] = applyContextVariable(ctx, m, vars)
+					continue
 				}
+				list[i] = vv
 			}
+			res[k] = list
 		case string:
 			if val, ok := vars[v]; ok {
 				res[k] = val
 				continue
 			}
+			res[k] = v
+		default:
+			res[k] = v
 		}
 	}
 

--- a/pkg/perm/permissions_test.go
+++ b/pkg/perm/permissions_test.go
@@ -1,0 +1,81 @@
+package perm
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/auth"
+)
+
+func authCtx() context.Context {
+	return auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{
+		Role:   "svc",
+		UserId: "2",
+	})
+}
+
+func TestApplyContextVariable_SubstitutesPlaceholder(t *testing.T) {
+	got := applyContextVariable(authCtx(), map[string]any{
+		"agency_id": map[string]any{"eq": "[$auth.user_id_int]"},
+	}, nil)
+	inner, _ := got["agency_id"].(map[string]any)
+	if inner["eq"] != 2 {
+		t.Fatalf("placeholder not substituted: got %#v", got)
+	}
+}
+
+func TestApplyContextVariable_KeepsIntLiteral(t *testing.T) {
+	got := applyContextVariable(authCtx(), map[string]any{
+		"agency_id": map[string]any{"eq": 2},
+	}, nil)
+	inner, _ := got["agency_id"].(map[string]any)
+	if inner["eq"] != 2 {
+		t.Fatalf("int literal dropped: got %#v", got)
+	}
+}
+
+func TestApplyContextVariable_KeepsStringLiteral(t *testing.T) {
+	got := applyContextVariable(authCtx(), map[string]any{
+		"status": map[string]any{"eq": "pending"},
+	}, nil)
+	inner, _ := got["status"].(map[string]any)
+	if inner["eq"] != "pending" {
+		t.Fatalf("string literal dropped: got %#v", got)
+	}
+}
+
+func TestApplyContextVariable_KeepsListOperatorAndSubstitutesInside(t *testing.T) {
+	got := applyContextVariable(authCtx(), map[string]any{
+		"_or": []any{
+			map[string]any{"agency_id": map[string]any{"eq": "[$auth.user_id_int]"}},
+			map[string]any{"building_id": map[string]any{"gt": 5}},
+		},
+	}, nil)
+	list, ok := got["_or"].([]any)
+	if !ok || len(list) != 2 {
+		t.Fatalf("_or branch dropped: got %#v", got)
+	}
+	first, _ := list[0].(map[string]any)
+	agency, _ := first["agency_id"].(map[string]any)
+	if agency["eq"] != 2 {
+		t.Fatalf("placeholder inside _or not substituted: got %#v", list[0])
+	}
+	second, _ := list[1].(map[string]any)
+	building, _ := second["building_id"].(map[string]any)
+	if building["gt"] != 5 {
+		t.Fatalf("literal inside _or dropped: got %#v", list[1])
+	}
+}
+
+func TestApplyContextVariable_NoAuthReturnsUnchanged(t *testing.T) {
+	data := map[string]any{"agency_id": map[string]any{"eq": 2}}
+	got := applyContextVariable(context.Background(), data, nil)
+	inner, _ := got["agency_id"].(map[string]any)
+	if inner["eq"] != 2 {
+		t.Fatalf("unchanged path lost literal: got %#v", got)
+	}
+	if !reflect.DeepEqual(got, data) {
+		t.Fatalf("expected data returned unchanged, got %#v", got)
+	}
+}


### PR DESCRIPTION
## Problem

A role's row-level `filter` (and mutation `data`) only takes effect if it is a **single** `{column: {op: "[$auth.*]"}}` condition. Anything else silently compiles to **no WHERE clause**, so the role sees the whole table — no error is raised. This is a silent row-level-security bypass.

Reproduced against hugr v0.3.37 (DEBUG=true shows the generated SQL) with a self-described MySQL source; the same holds for any engine since the defect is in `applyContextVariable`:

| permission `filter` | generated SQL | result |
|---|---|---|
| `{agency_id: {eq: "[$auth.user_id_int]"}}` | `WHERE agency_id = 2` | ✅ only the intended rows |
| `{agency_id: {eq: 2}}` (int literal) | *(no WHERE)* | whole table |
| `{agency_id: {eq: "2"}}` (string literal) | *(no WHERE)* | whole table |
| `{_or: [{…: "[$auth.*]"}}, {…}]}` | *(no WHERE)* | whole table — the entire `_or` branch is gone, including the placeholder inside it |

## Root cause

`pkg/perm/permissions.go`, `applyContextVariable` rebuilds the map into a fresh `res` but only writes two of the possible value kinds:

```go
case map[string]any:
    res[k] = applyContextVariable(ctx, v, vars)
case []any:
    for i, vv := range v {           // mutates v in place…
        if m, ok := vv.(map[string]any); ok {
            v[i] = applyContextVariable(ctx, m, vars)
        }
    }
    // …but res[k] is NEVER assigned -> the whole _and/_or/_not branch is dropped
case string:
    if val, ok := vars[v]; ok {
        res[k] = val                 // only placeholder hits survive
        continue
    }
    // non-placeholder strings dropped
// no default -> int/bool literals dropped
```

So list operators, literal scalars, and non-placeholder strings are all discarded.

## Fix

Preserve every key: recurse into maps, rebuild lists with their elements substituted, and keep literal / non-placeholder leaves as-is. `[$auth.*]` substitution behaviour is unchanged.

## Tests

Added `pkg/perm/permissions_test.go`: placeholder substitution, int literal, string literal, `_or` with a placeholder + literal inside, and the no-auth passthrough. They fail on the current code (literal dropped / `_or` branch dropped) and pass with the fix. `go build -tags=duckdb_arrow ./...` and `go test -tags=duckdb_arrow ./pkg/perm` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)