### PR TITLE
fix(perm): honor per-type wildcard (type, "*") permission rows

### DIFF
--- a/pkg/perm/permissions.go
+++ b/pkg/perm/permissions.go
@@ -107,28 +107,49 @@ func (r *RolePermissions) DataArgument(ctx context.Context, object, field string
 	return nil
 }
 
+// checkObjectField resolves the effective permission for (object, field) by
+// most-specific-match, per the documented precedence:
+//
+//	exact (object, field) > (object, "*") > ("*", field) > ("*", "*") > open by default
+//
+// A more specific rule always overrides a less specific one, regardless of the
+// order rows are stored in.
 func (r *RolePermissions) checkObjectField(object, field string, toVisible bool) (*Permission, bool) {
 	if r.Disabled {
 		return nil, false
 	}
-	allObjects := true
-	allFields := true
-	for _, p := range r.Permissions {
-		out := p.Disabled
-		if toVisible {
-			out = p.Hidden
-		}
+	var best *Permission
+	bestRank := -1
+	for i := range r.Permissions {
+		p := &r.Permissions[i]
+		rank := -1
 		switch {
-		case p.Object == "*" && p.Field == "*":
-			allObjects = !out
-			allFields = !out
-		case p.Object == "*" && p.Field == field:
-			allFields = !out
 		case p.Object == object && p.Field == field:
-			return &p, !out
+			rank = 3
+		case p.Object == object && p.Field == "*":
+			rank = 2
+		case p.Object == "*" && p.Field == field:
+			rank = 1
+		case p.Object == "*" && p.Field == "*":
+			rank = 0
+		}
+		if rank > bestRank {
+			bestRank, best = rank, p
 		}
 	}
-	return nil, allFields && allObjects
+	if best == nil {
+		return nil, true
+	}
+	out := best.Disabled
+	if toVisible {
+		out = best.Hidden
+	}
+	// Only an exact match carries a permission (its filter/data) back to the
+	// caller; wildcard matches gate access without a concrete rule payload.
+	if bestRank == 3 {
+		return best, !out
+	}
+	return nil, !out
 }
 
 func applyContextVariable(ctx context.Context, data map[string]any, vars map[string]any) map[string]any {

--- a/pkg/perm/permissions_test.go
+++ b/pkg/perm/permissions_test.go
@@ -1,0 +1,40 @@
+package perm
+
+import "testing"
+
+func en(object, field string, disabled bool) Permission {
+	return Permission{Object: object, Field: field, Disabled: disabled}
+}
+
+func TestCheckObjectField_Precedence(t *testing.T) {
+	tests := []struct {
+		name  string
+		perms []Permission
+		want  bool
+	}{
+		{"open by default", nil, true},
+		{"exact deny", []Permission{en("users", "email", true)}, false},
+		{"per-type wildcard deny", []Permission{en("users", "*", true)}, false},
+		{"per-type wildcard allow other type", []Permission{en("orders", "*", true)}, true},
+		{"global deny", []Permission{en("*", "*", true)}, false},
+		{"global deny + exact allow", []Permission{en("*", "*", true), en("users", "email", false)}, true},
+		{"global deny + per-type allow", []Permission{en("*", "*", true), en("users", "*", false)}, true},
+		{"per-type deny + exact allow", []Permission{en("users", "*", true), en("users", "email", false)}, true},
+		{"per-type allow + exact deny", []Permission{en("users", "*", false), en("users", "email", true)}, false},
+		{"field wildcard deny", []Permission{en("*", "email", true)}, false},
+		{"order independence", []Permission{en("users", "email", false), en("users", "*", true), en("*", "*", true)}, true},
+	}
+	for _, tt := range tests {
+		r := &RolePermissions{Permissions: tt.perms}
+		if _, ok := r.Enabled("users", "email"); ok != tt.want {
+			t.Errorf("%s: Enabled = %v, want %v", tt.name, ok, tt.want)
+		}
+	}
+}
+
+func TestCheckObjectField_DisabledRole(t *testing.T) {
+	r := &RolePermissions{Disabled: true}
+	if _, ok := r.Enabled("users", "email"); ok {
+		t.Error("disabled role must deny everything")
+	}
+}


### PR DESCRIPTION
## Problem

A permission row scoped to a whole type — `{type_name: "users", field_name: "*"}` — is silently ignored when access to a concrete field is checked. This is the shape of the built-in `readonly` role (`Mutation`, `*`) and the documented default-deny-then-allow pattern.

Reproduced against hugr v0.3.37: a role with

```graphql
insert_role_permissions(data: {role: "r", type_name: "users", field_name: "*", disabled: true})
```

still reads every column of `users`.

## Root cause

`pkg/perm/permissions.go`, `checkObjectField` matched only three shapes — `("*","*")`, `("*", field)` and exact `(object, field)` — and accumulated wildcard results into two `allObjects`/`allFields` booleans. The `(object, "*")` shape had no case at all, and the boolean accumulation did not implement the documented precedence.

## Fix

Resolve by most-specific-match with the documented precedence:

```
exact (object, field) > (object, "*") > ("*", field) > ("*", "*") > open-by-default
```

A more specific rule always overrides a less specific one, independent of row order. Only an exact match returns its `*Permission` payload (filter/data), as before.

## Tests

Added `pkg/perm/permissions_test.go` (`TestCheckObjectField_Precedence`) covering all shapes, allow-overrides-deny at each specificity level, and order independence. Fails on current code (`per-type wildcard deny`, `global deny + per-type allow`), passes with the fix. `go build -tags=duckdb_arrow ./...` and `go test -tags=duckdb_arrow ./pkg/perm` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)