### PR TITLE
feat(auth): resolve custom JWT claims as [$auth.<claim>] for RLS

### DIFF
--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -11,6 +11,8 @@ type AuthInfo struct {
 	AuthProvider string
 	Token        string
 
+	Claims map[string]any
+
 	// ImpersonatedBy holds the original admin identity when this request
 	// is running under impersonation. Nil means no impersonation.
 	ImpersonatedBy *AuthInfo

--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -118,6 +118,11 @@ func (p *JwtProvider) Authenticate(r *http.Request) (*AuthInfo, error) {
 		}
 	}
 
+	rawClaims := make(map[string]any, len(claims))
+	for k, v := range claims {
+		rawClaims[k] = v
+	}
+
 	return &AuthInfo{
 		Role:         role,
 		UserId:       userId,
@@ -125,6 +130,7 @@ func (p *JwtProvider) Authenticate(r *http.Request) (*AuthInfo, error) {
 		AuthType:     "jwt",
 		AuthProvider: p.c.Issuer,
 		Token:        t.Raw,
+		Claims:       rawClaims,
 	}, nil
 }
 

--- a/pkg/auth/jwt_test.go
+++ b/pkg/auth/jwt_test.go
@@ -155,3 +155,44 @@ func TestJwtProvider_Authenticate(t *testing.T) {
 		})
 	}
 }
+
+func TestJwtProvider_CustomClaims(t *testing.T) {
+	config := &JwtConfig{
+		Issuer:    "test-issuer",
+		PublicKey: rsaPubKey,
+		Claims:    UserAuthInfoConfig{Role: "role", UserId: "sub", UserName: "name"},
+	}
+	claims := jwt.MapClaims{
+		"sub":           "user1",
+		"name":          "User One",
+		"role":          "landlord_admin",
+		"agency_id":     "42",
+		"department_id": "sales",
+		"exp":           time.Now().Add(time.Hour).Unix(),
+	}
+
+	token, err := GenerateToken(rsaKey, claims)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	provider, err := NewJwt(config)
+	if err != nil {
+		t.Fatalf("failed to create JwtProvider: %v", err)
+	}
+
+	authInfo, err := provider.Authenticate(req)
+	if err != nil {
+		t.Fatalf("Authenticate() error = %v", err)
+	}
+
+	if got := authInfo.Claims["agency_id"]; got != "42" {
+		t.Errorf("Claims[agency_id] = %v, want 42", got)
+	}
+	if got := authInfo.Claims["department_id"]; got != "sales" {
+		t.Errorf("Claims[department_id] = %v, want sales", got)
+	}
+}

--- a/pkg/perm/authvars_test.go
+++ b/pkg/perm/authvars_test.go
@@ -1,0 +1,25 @@
+package perm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/auth"
+)
+
+func TestAuthVars_CustomClaims(t *testing.T) {
+	ctx := auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{
+		Role:   "landlord_admin",
+		UserId: "user1",
+		Claims: map[string]any{"agency_id": "42", "role": "spoofed"},
+	})
+
+	vars := AuthVars(ctx)
+
+	if got := vars["[$auth.agency_id]"]; got != "42" {
+		t.Errorf("[$auth.agency_id] = %v, want 42", got)
+	}
+	if got := vars["[$auth.role]"]; got != "landlord_admin" {
+		t.Errorf("[$auth.role] = %v, want landlord_admin (built-in must not be shadowed by raw claim)", got)
+	}
+}

--- a/pkg/perm/permissions.go
+++ b/pkg/perm/permissions.go
@@ -8,9 +8,9 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/hugr-lab/query-engine/pkg/auth"
-	"github.com/hugr-lab/query-engine/pkg/engines"
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
 	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
+	"github.com/hugr-lab/query-engine/pkg/engines"
 )
 
 type RolePermissions struct {
@@ -53,7 +53,6 @@ func (r *RolePermissions) CheckQuery(query *ast.Field) error {
 
 	return nil
 }
-
 
 func (r *RolePermissions) CheckMutationInput(ctx context.Context, defs base.DefinitionsSource, inputName string, data map[string]any) error {
 	if r.Disabled {
@@ -172,14 +171,16 @@ func AuthVars(ctx context.Context) map[string]any {
 
 	userIdInt, _ := strconv.Atoi(ai.UserId)
 
-	vars := map[string]any{
-		"[$auth.user_name]":   ai.UserName,
-		"[$auth.user_id]":     ai.UserId,
-		"[$auth.user_id_int]": userIdInt,
-		"[$auth.role]":        ai.Role,
-		"[$auth.auth_type]":   ai.AuthType,
-		"[$auth.provider]":    ai.AuthProvider,
+	vars := make(map[string]any, len(ai.Claims)+9)
+	for k, v := range ai.Claims {
+		vars["[$auth."+k+"]"] = v
 	}
+	vars["[$auth.user_name]"] = ai.UserName
+	vars["[$auth.user_id]"] = ai.UserId
+	vars["[$auth.user_id_int]"] = userIdInt
+	vars["[$auth.role]"] = ai.Role
+	vars["[$auth.auth_type]"] = ai.AuthType
+	vars["[$auth.provider]"] = ai.AuthProvider
 	if ai.ImpersonatedBy != nil {
 		vars["[$auth.impersonated_by_role]"] = ai.ImpersonatedBy.Role
 		vars["[$auth.impersonated_by_user_id]"] = ai.ImpersonatedBy.UserId


### PR DESCRIPTION
AuthInfo gains a Claims map; the JWT provider copies every verified token claim into it, and AuthVars expands them into [$auth.<claim>] placeholders. Built-in placeholders (role, user_id, ...) are written last so a raw claim of the same name cannot shadow the canonical identity.

Enables tenant-scoped RLS filters like agency_id = [$auth.agency_id], which the docs describe but the engine did not implement.