### PR TITLE
fix(auth): cookie extractor skips instead of hard-failing when absent

### DIFF
--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -150,8 +150,8 @@ type CookieExtractor string
 
 func (c CookieExtractor) ExtractToken(r *http.Request) (string, error) {
 	cookie, err := r.Cookie(string(c))
-	if err != nil {
-		return "", err
+	if err != nil || cookie.Value == "" {
+		return "", request.ErrNoTokenInRequest
 	}
 	return cookie.Value, nil
 }

--- a/pkg/auth/jwt_test.go
+++ b/pkg/auth/jwt_test.go
@@ -265,3 +265,22 @@ func TestJwtProvider_Authenticate(t *testing.T) {
 		})
 	}
 }
+
+func TestJwtProvider_CookieAbsentSkips(t *testing.T) {
+	config := &JwtConfig{
+		Issuer:     "test-issuer",
+		PublicKey:  rsaPubKey,
+		CookieName: "session",
+		Claims:     UserAuthInfoConfig{Role: "role", UserId: "sub", UserName: "name"},
+	}
+	provider, err := NewJwt(config)
+	if err != nil {
+		t.Fatalf("failed to create JwtProvider: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+
+	if _, err := provider.Authenticate(req); !errors.Is(err, ErrSkipAuth) {
+		t.Errorf("Authenticate() with no token and cookie configured = %v, want ErrSkipAuth", err)
+	}
+}


### PR DESCRIPTION
CookieExtractor returned http.ErrNoCookie when the configured cookie was missing. golang-jwt/v5 MultiExtractor propagates any non-ErrNoTokenInRequest error immediately, so enabling jwt.cookie-name made every tokenless request (anonymous, admin secret, other providers) fail with "named cookie not present" instead of falling through. Return request.ErrNoTokenInRequest so the provider cleanly skips when neither header nor cookie carries a token.