### PR TITLE
fix(planner): keep RLS permission filter when the query has joins

### DIFF
--- a/pkg/planner/node_select.go
+++ b/pkg/planner/node_select.go
@@ -370,10 +370,14 @@ func selectDataObjectNode(ctx context.Context, defs base.DefinitionsSource, plan
 		nodes = append(nodes, paramNodes...)
 	}
 	if len(joinCatalogNodes) != 0 || len(joinGeneralNodes) != 0 {
-		// if there are joins, we push down only where and vector search nodes
+		// if there are joins, we push down only where, permission filter and vector search nodes
 		whereNode := paramNodes.ForName("where")
 		if whereNode != nil {
 			nodes = append(nodes, whereNode)
+		}
+		permNode := paramNodes.ForName("permission_filter")
+		if permNode != nil {
+			nodes = append(nodes, permNode)
 		}
 		vectorSearchNode := paramNodes.ForName(vectorDistanceNodeName)
 		if vectorSearchNode != nil {


### PR DESCRIPTION
permissionFilterNode was appended to the param nodes but only pushed into the base select on the no-join fast path. When the query navigated a relation (or crossed sources), the join branch pushed down only the where node, silently dropping permission_filter — a full RLS bypass: a client could see rows outside its scope simply by selecting the related object the filter traverses. Push permission_filter alongside where in the join branch so it is ANDed into the base WHERE regardless of joins.