### PR TITLE
fix(stream): backpressure instead of dropping frames on slow readers

### DIFF
--- a/client/subscribe.go
+++ b/client/subscribe.go
@@ -260,7 +260,7 @@ func (sc *SubscriptionConn) completeSub(id string) {
 	if sub != nil && !sub.done {
 		sub.done = true
 		for _, pipe := range sub.pipes {
-			pipe.Close()
+			pipe.closeChan()
 		}
 		close(sub.eventCh)
 	}
@@ -306,13 +306,16 @@ type batchPipe struct {
 	ch      chan arrow.RecordBatch
 	current arrow.RecordBatch
 	ctx     context.Context
+	cancel  context.CancelFunc
 	closed  sync.Once
 }
 
-func newBatchPipe(ctx context.Context) *batchPipe {
+func newBatchPipe(parent context.Context) *batchPipe {
+	ctx, cancel := context.WithCancel(parent)
 	return &batchPipe{
-		ch:  make(chan arrow.RecordBatch, 256),
-		ctx: ctx,
+		ch:     make(chan arrow.RecordBatch, 256),
+		ctx:    ctx,
+		cancel: cancel,
 	}
 }
 
@@ -323,14 +326,42 @@ func (p *batchPipe) Send(batch arrow.RecordBatch) {
 			batch.Release()
 		}
 	}()
+	// Block on a full channel — backpressure the wire reader instead of
+	// dropping. Dropping a RecordBatch silently corrupts the stream (e.g.
+	// lost LLM content_delta tokens → garbled output). Draining fast enough
+	// is the consumer's responsibility; if it can't keep up we wait. Only
+	// context cancellation (subscription teardown) releases the batch.
 	select {
 	case p.ch <- batch:
-	default:
+	case <-p.ctx.Done():
 		batch.Release()
 	}
 }
 
-func (p *batchPipe) Close()   { p.closed.Do(func() { close(p.ch) }) }
+// closeChan closes the batch channel. It MUST be called only from the sender
+// (readLoop) goroutine on normal end-of-stream, so the consumer can drain any
+// buffered batches before Next reports EOF. Closing from another goroutine
+// while Send is parked on a full channel would be a data race.
+func (p *batchPipe) closeChan() { p.closed.Do(func() { close(p.ch) }) }
+
+// Close tears the pipe down from the consumer/control side. It cancels the
+// pipe context — unblocking a parked Send and Next — and drains buffered
+// batches to release them. It never closes the channel itself: that would
+// race the sender goroutine.
+func (p *batchPipe) Close() {
+	p.cancel()
+	for {
+		select {
+		case b, ok := <-p.ch:
+			if !ok {
+				return // channel closed (normal EOF) and drained
+			}
+			b.Release()
+		default:
+			return // channel empty
+		}
+	}
+}
 func (p *batchPipe) Retain()  {}
 func (p *batchPipe) Release() { p.Close() }
 func (p *batchPipe) Err() error { return nil }

--- a/ipc-stream.go
+++ b/ipc-stream.go
@@ -74,6 +74,7 @@ func (s *Service) ipcStreamHandler(w http.ResponseWriter, r *http.Request) {
 		writeCh: make(chan wsMsg, 256),
 	}
 	ctx, cancel := context.WithCancel(r.Context())
+	stream.connCtx = ctx
 	stream.connCancel = cancel
 	go stream.writer(ctx)
 	if s.config.Debug {
@@ -470,6 +471,7 @@ type wsMsg struct {
 type stream struct {
 	queryId    string
 	conn       *websocket.Conn
+	connCtx    context.Context // connection lifetime; writeCh senders block on this
 	connCancel context.CancelFunc
 	writeCh    chan wsMsg // Single writer goroutine reads from here
 
@@ -536,20 +538,35 @@ func (s *stream) writeJSON(msg any) error {
 	if err != nil {
 		return fmt.Errorf("stream %s: marshal error: %w", s.queryId, err)
 	}
+	// Block until the writer drains a slot (apply backpressure) rather than
+	// dropping the message; bail out if the connection is closing so we never
+	// deadlock once the writer goroutine has stopped.
 	select {
 	case s.writeCh <- wsMsg{msgType: websocket.MessageText, data: data}:
 		return nil
-	default:
-		return fmt.Errorf("stream %s: write channel full", s.queryId)
+	case <-s.connCtx.Done():
+		return fmt.Errorf("stream %s: connection closed: %w", s.queryId, s.connCtx.Err())
 	}
 }
 
 // writeMessage sends a raw message through the write channel.
 func (s *stream) writeMessage(msgType websocket.MessageType, data []byte) error {
+	// Copy before queuing: the binary Arrow path passes buf.Bytes() from a
+	// sync.Pool buffer that the caller Reset()s and returns to the pool the
+	// instant this returns. The writer goroutine drains writeCh asynchronously,
+	// so without a copy the pooled buffer is overwritten by the next frame
+	// before it is sent — corrupting / duplicating stream tokens (garbled or
+	// doubled LLM output over the wire). writeJSON queues a fresh json.Marshal
+	// slice directly and is unaffected.
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	// Block until the writer drains a slot (apply backpressure) rather than
+	// dropping the Arrow frame; bail out if the connection is closing so we
+	// never deadlock once the writer goroutine has stopped.
 	select {
-	case s.writeCh <- wsMsg{msgType: msgType, data: data}:
+	case s.writeCh <- wsMsg{msgType: msgType, data: cp}:
 		return nil
-	default:
-		return fmt.Errorf("stream %s: write channel full", s.queryId)
+	case <-s.connCtx.Done():
+		return fmt.Errorf("stream %s: connection closed: %w", s.queryId, s.connCtx.Err())
 	}
 }


### PR DESCRIPTION
## Problem

Both the IPC stream server (`ipc-stream.go`) and the Go subscription client (`client/subscribe.go`) **dropped frames** when their channel filled up (`select { case ch<-x: default: <drop> }`). For an ordered Arrow stream a dropped frame silently corrupts the stream — e.g. lost LLM `content_delta` tokens produce garbled/truncated output.

## Change

Replace frame-dropping with **backpressure**:

**Server (`ipc-stream.go`)**
- `writeMessage` / `writeJSON` block until the writer goroutine drains a slot, with a `case <-s.connCtx.Done()` escape so a stopped writer can't deadlock senders (the writer uses the same ctx and cancels it on write error).
- Added `connCtx` to the `stream` struct.
- The pooled-buffer copy in `writeMessage` is **kept** — the writer sends asynchronously, so without the copy the pooled buffer is overwritten by the next frame before it is sent.

**Client (`client/subscribe.go`)**
- `batchPipe.Send` blocks until the consumer drains, releasing the batch only on `ctx.Done()`.
- Teardown split to stay **race-free** (only the sender may close a channel):
  - Normal EOF (`completeSub`, runs in the `readLoop` sender goroutine) → `closeChan()` closes the channel so the consumer drains the tail.
  - Consumer/control teardown (`Release`, `removeSub`, `Close`) → cancels the pipe context (unblocks a parked `Send`/`Next`) and drains buffered batches instead of closing the channel.
- `batchPipe` gains its own `cancel` (child ctx of the connection ctx).

Without this split, blocking `Send` + `close()` from a consumer goroutine while `Send` is parked is a data race (the old dropping code masked it because `Send` never parked).

## Testing

`integration-test/subscription` under the race detector:

```
CGO_CFLAGS="-O1 -g" go test -tags=duckdb_arrow -race -count=3 ./...
```

→ **27 tests × 3 runs, 0 data races, 0 failures.** Covers the binary IPC path (`writeMessage` + client `batchPipe`), GraphQL-WS JSON path (`writeJSON`), and multi-user/teardown scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)