### PR TITLE
fix: preserve sub-second precision in time serialization

### DIFF
--- a/pkg/data-sources/sources/http/http.go
+++ b/pkg/data-sources/sources/http/http.go
@@ -227,7 +227,10 @@ func valueToRequestParamValue(v any) (res []string, err error) {
 		}
 		return []string{string(b)}, nil
 	case time.Time:
-		return []string{v.Format(time.RFC3339)}, nil
+		// RFC3339Nano, not RFC3339: the latter drops fractional seconds, so a
+		// timestamp filter/argument passed to an HTTP source lost sub-second
+		// precision.
+		return []string{v.Format(time.RFC3339Nano)}, nil
 	case []any:
 		return arrayValueToRequestParamValue(v)
 	case []string:

--- a/pkg/data-sources/sources/http/http_test.go
+++ b/pkg/data-sources/sources/http/http_test.go
@@ -305,6 +305,18 @@ func (s *testServer) authRequest(r *http.Request) bool {
 //go:embed open-api-test.yaml
 var testServerSpec string
 
+func TestValueToRequestParamValue_TimeSubSecond(t *testing.T) {
+	// Regression: a time value passed as an HTTP request parameter must keep
+	// its sub-second precision — RFC3339 dropped the fractional seconds.
+	res, err := valueToRequestParamValue(time.Date(2023, 10, 10, 10, 10, 10, 123456789, time.UTC))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res) != 1 || res[0] != "2023-10-10T10:10:10.123456789Z" {
+		t.Fatalf("expected [2023-10-10T10:10:10.123456789Z], got %v", res)
+	}
+}
+
 func TestHttpSource_Request(t *testing.T) {
 	testServer := &testServer{}
 	server := httptest.NewServer(testServer)

--- a/pkg/engines/duckdb.go
+++ b/pkg/engines/duckdb.go
@@ -118,9 +118,14 @@ func (e *DuckDB) SQLValue(v any) (string, error) {
 		b := wkt.Marshal(v)
 		return fmt.Sprintf("ST_GeomFromText('%s', true)", string(b)), nil
 	case types.DateTime:
-		return fmt.Sprintf("'%s'::TIMESTAMP", time.Time(v).Format("2006-01-02T15:04:05")), nil
+		// .999999999 keeps sub-second precision (trailing zeros trimmed);
+		// the seconds-only layout silently truncated inserted timestamps.
+		return fmt.Sprintf("'%s'::TIMESTAMP", time.Time(v).Format("2006-01-02T15:04:05.999999999")), nil
 	case time.Time:
-		return fmt.Sprintf("'%s'::TIMESTAMPTZ", v.Format(time.RFC3339)), nil
+		// RFC3339Nano, not RFC3339: Format(RFC3339) DROPS fractional
+		// seconds (unlike parsing, which accepts them) — mutation inputs
+		// were stored second-truncated.
+		return fmt.Sprintf("'%s'::TIMESTAMPTZ", v.Format(time.RFC3339Nano)), nil
 	case []types.DateTime:
 		var ss []string
 		for _, dt := range v {

--- a/pkg/engines/duckdb_test.go
+++ b/pkg/engines/duckdb_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hugr-lab/query-engine/types"
 	"github.com/paulmach/orb"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -336,7 +337,7 @@ func Test_extractStructFieldByPath(t *testing.T) {
 func Test_duckdb_SQLValue(t *testing.T) {
 	engine := &DuckDB{}
 	tm := time.Now().Add(-1 * time.Hour)
-	tstr := tm.Format(time.RFC3339)
+	tstr := tm.Format(time.RFC3339Nano)
 	tests := []struct {
 		name     string
 		value    any
@@ -350,6 +351,8 @@ func Test_duckdb_SQLValue(t *testing.T) {
 		{"string value", "test", "'test'", false},
 		{"string with single quote", "test's", "'test''s'", false},
 		{"time value", time.Date(2023, 10, 10, 10, 10, 10, 0, time.UTC), "'2023-10-10T10:10:10Z'::TIMESTAMPTZ", false},
+		{"time value sub-second", time.Date(2023, 10, 10, 10, 10, 10, 123456789, time.UTC), "'2023-10-10T10:10:10.123456789Z'::TIMESTAMPTZ", false},
+		{"datetime value sub-second", types.DateTime(time.Date(2023, 10, 10, 10, 10, 10, 123456789, time.UTC)), "'2023-10-10T10:10:10.123456789'::TIMESTAMP", false},
 		{"duration value", 35 * time.Second, "'35 seconds'::INTERVAL", false},
 		{"duration value", 120 * time.Second, "'2 minutes'::INTERVAL", false},
 		{"duration value", 122 * time.Second, "'2 minutes 2 seconds'::INTERVAL", false},

--- a/pkg/engines/postgres.go
+++ b/pkg/engines/postgres.go
@@ -90,9 +90,14 @@ func (e *Postgres) SQLValue(v any) (string, error) {
 		b := wkt.Marshal(v)
 		return fmt.Sprintf("ST_GeomFromText('%s')", b), nil
 	case types.DateTime:
-		return fmt.Sprintf("'%s'::TIMESTAMP", time.Time(v).Format("2006-01-02T15:04:05")), nil
+		// .999999999 keeps sub-second precision (trailing zeros trimmed);
+		// the seconds-only layout silently truncated inserted timestamps.
+		return fmt.Sprintf("'%s'::TIMESTAMP", time.Time(v).Format("2006-01-02T15:04:05.999999999")), nil
 	case time.Time:
-		return fmt.Sprintf("'%s'::TIMESTAMPTZ", v.Format(time.RFC3339)), nil
+		// RFC3339Nano, not RFC3339: Format(RFC3339) DROPS fractional
+		// seconds (unlike parsing, which accepts them) — mutation inputs
+		// were stored second-truncated.
+		return fmt.Sprintf("'%s'::TIMESTAMPTZ", v.Format(time.RFC3339Nano)), nil
 	case []types.DateTime:
 		var ss []string
 		for _, dt := range v {
@@ -310,7 +315,7 @@ func (e *Postgres) FilterOperationSQLValue(sqlName, path, op string, value any, 
 			}
 			return fmt.Sprintf(jsonPathTemplate, value), params, nil
 		case time.Time:
-			return fmt.Sprintf(jsonPathTemplate, "\""+value.Format(time.RFC3339)+"\""), params, nil
+			return fmt.Sprintf(jsonPathTemplate, "\""+value.Format(time.RFC3339Nano)+"\""), params, nil
 		case time.Duration:
 			params = append(params, value)
 			sqlName += extractPGJsonFieldByPath(path, true)
@@ -617,10 +622,10 @@ func pgRangeValueToSQLValue(v any) (string, error) {
 		detail = v.Detail
 	case ctypes.TimeRange:
 		if !v.Detail.IsLowerInfinity() {
-			lower = v.Lower.Format(time.RFC3339)
+			lower = v.Lower.Format(time.RFC3339Nano)
 		}
 		if !v.Detail.IsUpperInfinity() {
-			upper = v.Upper.Format(time.RFC3339)
+			upper = v.Upper.Format(time.RFC3339Nano)
 		}
 		detail = v.Detail
 	case ctypes.BaseRange:
@@ -635,10 +640,10 @@ func pgRangeValueToSQLValue(v any) (string, error) {
 			}
 		case ctypes.RangeTypeTimestamp:
 			if !v.Detail.IsLowerInfinity() {
-				lower = v.Lower.(time.Time).Format(time.RFC3339)
+				lower = v.Lower.(time.Time).Format(time.RFC3339Nano)
 			}
 			if !v.Detail.IsUpperInfinity() {
-				upper = v.Upper.(time.Time).Format(time.RFC3339)
+				upper = v.Upper.(time.Time).Format(time.RFC3339Nano)
 			}
 		default:
 			return "", fmt.Errorf("invalid range value")

--- a/pkg/engines/postgres_test.go
+++ b/pkg/engines/postgres_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	ctypes "github.com/hugr-lab/query-engine/pkg/catalog/types"
+	"github.com/hugr-lab/query-engine/types"
 	"github.com/paulmach/orb"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -316,7 +317,7 @@ func TestRepackPGJsonRecursive(t *testing.T) {
 func Test_postgres_SQLValue(t *testing.T) {
 	engine := &Postgres{}
 	tm := time.Now().Add(-1 * time.Hour)
-	tstr := tm.Format(time.RFC3339)
+	tstr := tm.Format(time.RFC3339Nano)
 	tests := []struct {
 		name     string
 		value    any
@@ -330,6 +331,8 @@ func Test_postgres_SQLValue(t *testing.T) {
 		{"string value", "test", "'test'", false},
 		{"string with single quote", "test's", "'test''s'", false},
 		{"time value", tm, fmt.Sprintf("'%s'::TIMESTAMPTZ", tstr), false},
+		{"time value sub-second", time.Date(2023, 10, 10, 10, 10, 10, 123456789, time.UTC), "'2023-10-10T10:10:10.123456789Z'::TIMESTAMPTZ", false},
+		{"datetime value sub-second", types.DateTime(time.Date(2023, 10, 10, 10, 10, 10, 123456789, time.UTC)), "'2023-10-10T10:10:10.123456789'::TIMESTAMP", false},
 		{"duration value", 35 * time.Second, "'35 seconds'::INTERVAL", false},
 		{"duration value", 120 * time.Second, "'2 minutes'::INTERVAL", false},
 		{"duration value", 122 * time.Second, "'2 minutes 2 seconds'::INTERVAL", false},

--- a/pkg/planner/at.go
+++ b/pkg/planner/at.go
@@ -81,5 +81,7 @@ func sanitizeTimestamp(ts string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid timestamp %q: must be in RFC3339 format (e.g. 2024-01-15T10:30:00Z): %w", ts, err)
 	}
-	return t.Format(time.RFC3339), nil
+	// RFC3339Nano: Format(RFC3339) silently drops the fractional seconds
+	// the parser accepted.
+	return t.Format(time.RFC3339Nano), nil
 }

--- a/pkg/planner/at_test.go
+++ b/pkg/planner/at_test.go
@@ -292,6 +292,18 @@ func TestSanitizeTimestamp(t *testing.T) {
 		}
 	})
 
+	t.Run("preserves sub-second precision", func(t *testing.T) {
+		// Regression: Format(RFC3339) silently dropped the fractional seconds
+		// the parser accepted, truncating @at timestamps to whole seconds.
+		ts, err := sanitizeTimestamp("2026-01-01T00:00:00.123456789Z")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ts != "2026-01-01T00:00:00.123456789Z" {
+			t.Fatalf("expected sub-second precision preserved, got %q", ts)
+		}
+	})
+
 	t.Run("invalid timestamp", func(t *testing.T) {
 		_, err := sanitizeTimestamp("not-a-timestamp")
 		if err == nil {


### PR DESCRIPTION
## Problem

`time.Time` / `types.DateTime` values were serialized for downstream systems with layouts that **drop fractional seconds** — `time.RFC3339` and the seconds-only `"2006-01-02T15:04:05"` — even though the corresponding parsers accept sub-second input. Timestamps with sub-second precision were therefore silently truncated to whole seconds on the way out (inserts, filters, `@at` time-travel, HTTP source params).

## Change

Use `RFC3339Nano` (and `"…05.999999999"`, trailing zeros trimmed) at every serialization site:

- **`pkg/engines/duckdb.go`, `pkg/engines/postgres.go`** — `SQLValue` for `types.DateTime` (`TIMESTAMP`) and `time.Time` (`TIMESTAMPTZ`)
- **`pkg/engines/postgres.go`** — `FilterOperationSQLValue` (time in a JSON path) and `pgRangeValueToSQLValue` (`TimeRange` + timestamp ranges)
- **`pkg/planner/at.go`** — `sanitizeTimestamp` (`@at` time-travel)
- **`pkg/data-sources/sources/http/http.go`** — `time.Time` as an HTTP request parameter

Input parsing already preserves fractional seconds (Go's RFC3339 parser accepts them), so no input changes are needed.

## Testing

Deterministic sub-second regression tests added for each site (they fail on the old seconds-truncating layouts):
- `Test_duckdb_SQLValue` / `Test_postgres_SQLValue` — new `time.Time` + `types.DateTime` sub-second cases (the `TIMESTAMP`/DateTime branch was previously untested)
- `TestSanitizeTimestamp` — sub-second preservation case
- `TestValueToRequestParamValue_TimeSubSecond` — HTTP param

```
go test -tags=duckdb_arrow ./pkg/engines/... ./pkg/planner/... ./pkg/data-sources/sources/http/...
```

All green; full module builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)