### PR TITLE
fix(auth): fall through to next provider on a foreign JWT token

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -50,6 +50,14 @@ var ErrForbidden = errors.New("forbidden")
 var ErrTokenExpired = errors.New("token expired")
 var ErrNeedAuth = errors.New("authentication required")
 
+// ErrInvalidKeyType is returned by a provider when a token is present but is not
+// verifiable with that provider's key (wrong signing algorithm/key) — i.e. it was
+// most likely issued for a different provider. The middleware treats it as a
+// signal to try the next provider. Unlike ErrSkipAuth (no token at all), it also
+// records that a token was rejected, so a failed authentication attempt is not
+// silently downgraded to anonymous access.
+var ErrInvalidKeyType = errors.New("invalid key type")
+
 // applyImpersonationHeaders checks for x-hugr-impersonated-* headers on the request.
 // If present, wraps the original AuthInfo as ImpersonatedBy and sets the target identity.
 func applyImpersonationHeaders(r *http.Request, original *AuthInfo) *AuthInfo {
@@ -75,10 +83,25 @@ func AuthMiddleware(c Config) func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var err error
 			var authInfo *AuthInfo
+			var anonProvider AuthProvider // anonymous fallback is always evaluated last
+			tokenRejected := false        // a token was presented but no provider could verify it
 			for _, p := range c.Providers {
+				// Defer the anonymous provider to the end so real providers
+				// always get a chance first, regardless of config order.
+				if p.Type() == "anonymous" {
+					anonProvider = p
+					continue
+				}
 				authInfo, err = p.Authenticate(r)
 				if errors.Is(err, ErrSkipAuth) {
 					// Skip authentication for this provider
+					continue
+				}
+				if errors.Is(err, ErrInvalidKeyType) {
+					// Token present but not signed for this provider — try the
+					// next one, but remember it so a rejected token is never
+					// downgraded to anonymous access.
+					tokenRejected = true
 					continue
 				}
 				if errors.Is(err, ErrTokenExpired) {
@@ -86,6 +109,7 @@ func AuthMiddleware(c Config) func(next http.Handler) http.Handler {
 					return
 				}
 				if errors.Is(err, ErrNeedAuth) {
+					tokenRejected = true
 					break
 				}
 				if err != nil {
@@ -95,6 +119,11 @@ func AuthMiddleware(c Config) func(next http.Handler) http.Handler {
 				if authInfo != nil {
 					break
 				}
+			}
+			// Anonymous fallback — evaluated last, and only when no token was
+			// rejected (a present-but-invalid token must not become anonymous).
+			if authInfo == nil && !tokenRejected && anonProvider != nil {
+				authInfo, err = anonProvider.Authenticate(r)
 			}
 			if err == nil && authInfo != nil {
 				// Check for explicit impersonation headers

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -88,8 +88,10 @@ func AuthMiddleware(c Config) func(next http.Handler) http.Handler {
 			for _, p := range c.Providers {
 				// Defer the anonymous provider to the end so real providers
 				// always get a chance first, regardless of config order.
-				if p.Type() == "anonymous" {
-					anonProvider = p
+				if _, ok := p.(*AnonymousProvider); ok {
+					if anonProvider == nil {
+						anonProvider = p // keep the first anonymous provider (config order)
+					}
 					continue
 				}
 				authInfo, err = p.Authenticate(r)

--- a/pkg/auth/auth_middleware_test.go
+++ b/pkg/auth/auth_middleware_test.go
@@ -1,0 +1,99 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// TestAuthMiddleware_MultiProviderFallthrough covers the multi-provider chain:
+// a JWT provider whose key does not match a presented token must not fail the
+// whole request — the middleware falls through to the next provider. A token
+// that no provider can verify is rejected (not downgraded to anonymous), and the
+// anonymous fallback is always evaluated last regardless of config order.
+func TestAuthMiddleware_MultiProviderFallthrough(t *testing.T) {
+	rsaProvider, err := NewJwt(&JwtConfig{Issuer: "rsa", PublicKey: rsaPubKey})
+	if err != nil {
+		t.Fatalf("NewJwt rsa: %v", err)
+	}
+	ecdsaProvider, err := NewJwt(&JwtConfig{Issuer: "ecdsa", PublicKey: ecdsaPubKey})
+	if err != nil {
+		t.Fatalf("NewJwt ecdsa: %v", err)
+	}
+	anon := NewAnonymous(AnonymousConfig{Allowed: true, Role: "guest"})
+
+	ecdsaToken, err := GenerateToken(ecdsaKey, jwt.MapClaims{"sub": "u1", "x-hugr-role": "admin"})
+	if err != nil {
+		t.Fatalf("gen ecdsa token: %v", err)
+	}
+	rsaToken, err := GenerateToken(rsaKey, jwt.MapClaims{"sub": "u2", "x-hugr-role": "admin"})
+	if err != nil {
+		t.Fatalf("gen rsa token: %v", err)
+	}
+
+	newServer := func(providers ...AuthProvider) http.Handler {
+		mw := AuthMiddleware(Config{Providers: providers})
+		return mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ai := AuthInfoFromContext(r.Context())
+			if ai == nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("X-Auth-Type", ai.AuthType)
+			w.Header().Set("X-Role", ai.Role)
+			w.WriteHeader(http.StatusOK)
+		}))
+	}
+	do := func(h http.Handler, token string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("GET", "/", nil)
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("falls through to the provider whose key matches", func(t *testing.T) {
+		rec := do(newServer(rsaProvider, ecdsaProvider), ecdsaToken)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (RSA provider must fall through to ECDSA)", rec.Code)
+		}
+		if got := rec.Header().Get("X-Auth-Type"); got != "jwt" {
+			t.Fatalf("auth type = %q, want jwt", got)
+		}
+		if got := rec.Header().Get("X-Role"); got != "admin" {
+			t.Fatalf("role = %q, want admin", got)
+		}
+	})
+
+	t.Run("present-but-invalid token is rejected, not downgraded to anonymous", func(t *testing.T) {
+		rec := do(newServer(rsaProvider, anon), ecdsaToken)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401 (invalid token must not become anonymous)", rec.Code)
+		}
+	})
+
+	t.Run("no token falls back to anonymous", func(t *testing.T) {
+		rec := do(newServer(rsaProvider, anon), "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (no token -> anonymous)", rec.Code)
+		}
+		if got := rec.Header().Get("X-Auth-Type"); got != "anonymous" {
+			t.Fatalf("auth type = %q, want anonymous", got)
+		}
+	})
+
+	t.Run("anonymous is evaluated last regardless of config order", func(t *testing.T) {
+		// anonymous is FIRST in config, but a valid RSA token must still win.
+		rec := do(newServer(anon, rsaProvider), rsaToken)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if got := rec.Header().Get("X-Auth-Type"); got != "jwt" {
+			t.Fatalf("auth type = %q, want jwt (anonymous must not win over a valid token)", got)
+		}
+	})
+}

--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -93,6 +93,12 @@ func (p *JwtProvider) Authenticate(r *http.Request) (*AuthInfo, error) {
 	if errors.Is(err, request.ErrNoTokenInRequest) {
 		return nil, ErrSkipAuth
 	}
+	if errors.Is(err, jwt.ErrTokenSignatureInvalid) || errors.Is(err, jwt.ErrInvalidKeyType) {
+		// The token is present but not verifiable with this provider's key
+		// (wrong signing algorithm or key) — most likely issued for a different
+		// provider. Let the middleware try the next provider instead of failing.
+		return nil, ErrInvalidKeyType
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse token: %w", err)
 	}

--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -97,7 +97,14 @@ func (p *JwtProvider) Authenticate(r *http.Request) (*AuthInfo, error) {
 		// The token is present but not verifiable with this provider's key
 		// (wrong signing algorithm or key) — most likely issued for a different
 		// provider. Let the middleware try the next provider instead of failing.
+		// (Signature is checked before claims, so a foreign token surfaces here
+		// even if it is also expired.)
 		return nil, ErrInvalidKeyType
+	}
+	if errors.Is(err, jwt.ErrTokenExpired) {
+		// Validly-signed but expired token — it belongs to this provider, so
+		// surface a clear "token expired" 401 instead of a generic parse error.
+		return nil, ErrTokenExpired
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse token: %w", err)

--- a/pkg/auth/jwt_test.go
+++ b/pkg/auth/jwt_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	_ "embed"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,24 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	yaml "gopkg.in/yaml.v2"
 )
+
+// A validly-signed but expired token must surface as ErrTokenExpired (clear 401),
+// not a generic parse error or a fallthrough to the next provider.
+func TestJwtProvider_ExpiredToken(t *testing.T) {
+	p, err := NewJwt(&JwtConfig{Issuer: "rsa", PublicKey: rsaPubKey})
+	if err != nil {
+		t.Fatalf("NewJwt: %v", err)
+	}
+	tok, err := GenerateToken(rsaKey, jwt.MapClaims{"sub": "u", "x-hugr-role": "admin", "exp": 1})
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	if _, err := p.Authenticate(req); !errors.Is(err, ErrTokenExpired) {
+		t.Fatalf("err = %v, want ErrTokenExpired", err)
+	}
+}
 
 var (
 	//go:embed internal/fixture/rsa


### PR DESCRIPTION
## Problem

With multiple auth providers configured (several JWT issuers, or JWT + OIDC), a JWT provider that received a token signed **for a different provider** returned a hard error:

```
HTTP 401: failed to parse token: token signature is invalid: key is of invalid type: RSA verify expects *rsa.PublicKey
```

The middleware treated any non-sentinel error as a hard 401 and **did not try the remaining providers**, so a token valid for provider B was rejected if provider A was checked first.

## Change

- **`auth.ErrInvalidKeyType`** — new sentinel: *a token is present but not verifiable with this provider's key* (wrong signing algorithm/key), i.e. most likely issued for a different provider.
- **`JwtProvider.Authenticate`** returns it on `jwt.ErrTokenSignatureInvalid` / `jwt.ErrInvalidKeyType` instead of a generic error.
- **`AuthMiddleware`**:
  - `continue`s to the next provider on `ErrInvalidKeyType`;
  - records `tokenRejected` so a present-but-invalid token is **never downgraded to anonymous** — it returns 401 instead;
  - the **anonymous provider is always evaluated last**, regardless of its position in the config.

### Resulting behavior
| Request | Result |
|---|---|
| token valid for provider N | authenticated (even if N isn't first) |
| token present, invalid for all | **401** (not anonymous) |
| no token + anonymous allowed | anonymous |
| anonymous listed first + valid token | authenticated (anonymous deferred) |

## Testing

`TestAuthMiddleware_MultiProviderFallthrough` — RSA→ECDSA fallthrough, invalid-token→401, no-token→anonymous, anonymous-evaluated-last. All green; `go test ./pkg/auth/...` passes.

## Follow-up

The OIDC provider lives in the **hugr** repo (`pkg/auth/oidc_provider.go`) and hard-fails with `ErrForbidden` on a foreign token. It should return `auth.ErrInvalidKeyType` too — a separate hugr PR once this sentinel is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)