### PR TITLE
fix(perm): wildcard precedence matcher and lossless placeholder substitution

### DIFF
--- a/pkg/data-sources/sources/runtime/auth/functions.go
+++ b/pkg/data-sources/sources/runtime/auth/functions.go
@@ -114,8 +114,8 @@ func registerFunctions(ctx context.Context, pool *db.Pool) error {
 				Visible: visible,
 			}
 			if p != nil {
-				res.Filter = p.Data
-				res.Data = p.Filter
+				res.Filter = p.Filter
+				res.Data = p.Data
 			}
 			return res, nil
 		},

--- a/pkg/perm/permissions.go
+++ b/pkg/perm/permissions.go
@@ -87,10 +87,8 @@ func (r *RolePermissions) FilterArgument(ctx context.Context, object, field stri
 	if r.Disabled {
 		return nil
 	}
-	for _, p := range r.Permissions {
-		if p.Object == object && p.Field == field {
-			return applyContextVariable(ctx, p.Filter, nil)
-		}
+	if p := r.bestMatch(object, field); p != nil {
+		return applyContextVariable(ctx, p.Filter, nil)
 	}
 	return nil
 }
@@ -99,38 +97,67 @@ func (r *RolePermissions) DataArgument(ctx context.Context, object, field string
 	if r.Disabled {
 		return nil
 	}
-	for _, p := range r.Permissions {
-		if p.Object == object && p.Field == field {
-			return applyContextVariable(ctx, p.Data, nil)
-		}
+	if p := r.bestMatch(object, field); p != nil {
+		return applyContextVariable(ctx, p.Data, nil)
 	}
 	return nil
+}
+
+// matchRank reports the specificity with which the permission row matches
+// (object, field): 3 = exact (object, field), 2 = (object, *),
+// 1 = (*, field), 0 = (*, *), -1 = no match.
+func (p *Permission) matchRank(object, field string) int {
+	switch {
+	case p.Object == object && p.Field == field:
+		return 3
+	case p.Object == object && p.Field == "*":
+		return 2
+	case p.Object == "*" && p.Field == field:
+		return 1
+	case p.Object == "*" && p.Field == "*":
+		return 0
+	}
+	return -1
+}
+
+// bestMatch returns the most specific permission row matching (object, field):
+// exact (object, field) > (object, *) > (*, field) > (*, *). Rows of equal
+// rank keep the first one in the role's permission list. The winning row
+// decides all of its attributes (disabled/hidden/filter/data) — lower-ranked
+// rows are not consulted.
+func (r *RolePermissions) bestMatch(object, field string) *Permission {
+	best := -1
+	var match *Permission
+	for i := range r.Permissions {
+		rank := r.Permissions[i].matchRank(object, field)
+		if rank > best {
+			best = rank
+			match = &r.Permissions[i]
+		}
+	}
+	return match
 }
 
 func (r *RolePermissions) checkObjectField(object, field string, toVisible bool) (*Permission, bool) {
 	if r.Disabled {
 		return nil, false
 	}
-	allObjects := true
-	allFields := true
-	for _, p := range r.Permissions {
-		out := p.Disabled
-		if toVisible {
-			out = p.Hidden
-		}
-		switch {
-		case p.Object == "*" && p.Field == "*":
-			allObjects = !out
-			allFields = !out
-		case p.Object == "*" && p.Field == field:
-			allFields = !out
-		case p.Object == object && p.Field == field:
-			return &p, !out
-		}
+	p := r.bestMatch(object, field)
+	if p == nil {
+		// open by default: without a matching row access is allowed
+		return nil, true
 	}
-	return nil, allFields && allObjects
+	if toVisible {
+		return p, !p.Hidden
+	}
+	return p, !p.Disabled
 }
 
+// applyContextVariable rebuilds data with `[$auth.*]` placeholder strings
+// substituted from vars (AuthVars when nil). Every other leaf — literal
+// strings, booleans, numbers, nulls, arrays — is preserved as-is, so the
+// output is identical to the input except for substituted placeholders.
+// The input is never mutated.
 func applyContextVariable(ctx context.Context, data map[string]any, vars map[string]any) map[string]any {
 	if len(data) == 0 {
 		return nil
@@ -143,25 +170,30 @@ func applyContextVariable(ctx context.Context, data map[string]any, vars map[str
 	}
 	res := make(map[string]any, len(data))
 	for k, v := range data {
-		switch v := v.(type) {
-		case map[string]any:
-			res[k] = applyContextVariable(ctx, v, vars)
-		case []any:
-			for i, vv := range v {
-				switch vv := vv.(type) {
-				case map[string]any:
-					v[i] = applyContextVariable(ctx, vv, vars)
-				}
-			}
-		case string:
-			if val, ok := vars[v]; ok {
-				res[k] = val
-				continue
-			}
-		}
+		res[k] = applyContextVariableValue(ctx, v, vars)
 	}
 
 	return res
+}
+
+func applyContextVariableValue(ctx context.Context, v any, vars map[string]any) any {
+	switch v := v.(type) {
+	case map[string]any:
+		return applyContextVariable(ctx, v, vars)
+	case []any:
+		res := make([]any, len(v))
+		for i, vv := range v {
+			res[i] = applyContextVariableValue(ctx, vv, vars)
+		}
+		return res
+	case string:
+		if val, ok := vars[v]; ok {
+			return val
+		}
+		return v
+	default:
+		return v
+	}
 }
 
 func AuthVars(ctx context.Context) map[string]any {

--- a/pkg/perm/permissions_test.go
+++ b/pkg/perm/permissions_test.go
@@ -1,0 +1,246 @@
+package perm
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/auth"
+)
+
+func authCtx() context.Context {
+	return auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{
+		Role:     "agent",
+		UserId:   "42",
+		UserName: "Agent A",
+		AuthType: "jwt",
+	})
+}
+
+// The substitution must pass a filter through unchanged except for `[$auth.*]`
+// leaves. It used to drop arrays (the `_or` key vanished => allow-all), literal
+// strings, booleans, numbers and nulls, and it mutated array elements in place.
+func TestApplyContextVariable(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]any
+		want map[string]any
+	}{
+		{
+			name: "placeholder leaf substituted",
+			in:   map[string]any{"agent_id": map[string]any{"eq": "[$auth.user_id]"}},
+			want: map[string]any{"agent_id": map[string]any{"eq": "42"}},
+		},
+		{
+			name: "int placeholder",
+			in:   map[string]any{"owner": map[string]any{"eq": "[$auth.user_id_int]"}},
+			want: map[string]any{"owner": map[string]any{"eq": 42}},
+		},
+		{
+			name: "literal string preserved",
+			in:   map[string]any{"status": map[string]any{"eq": "pending_review"}},
+			want: map[string]any{"status": map[string]any{"eq": "pending_review"}},
+		},
+		{
+			name: "bool, number and null preserved",
+			in:   map[string]any{"shared": map[string]any{"eq": true}, "rank": map[string]any{"gt": 5.0}, "deleted_at": map[string]any{"is_null": nil}},
+			want: map[string]any{"shared": map[string]any{"eq": true}, "rank": map[string]any{"gt": 5.0}, "deleted_at": map[string]any{"is_null": nil}},
+		},
+		{
+			name: "scalar array preserved",
+			in:   map[string]any{"id": map[string]any{"in": []any{1, 2, 3}}},
+			want: map[string]any{"id": map[string]any{"in": []any{1, 2, 3}}},
+		},
+		{
+			name: "_or array survives with substitution in elements",
+			in: map[string]any{"_or": []any{
+				map[string]any{"agent_id": map[string]any{"eq": "[$auth.user_id]"}},
+				map[string]any{"shared": map[string]any{"eq": true}},
+			}},
+			want: map[string]any{"_or": []any{
+				map[string]any{"agent_id": map[string]any{"eq": "42"}},
+				map[string]any{"shared": map[string]any{"eq": true}},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := deepCopyMap(tt.in)
+			got := applyContextVariable(authCtx(), tt.in, nil)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("applyContextVariable() = %#v, want %#v", got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.in, orig) {
+				t.Errorf("input was mutated: %#v, want %#v", tt.in, orig)
+			}
+		})
+	}
+}
+
+func TestApplyContextVariable_NoAuthContext(t *testing.T) {
+	in := map[string]any{"agent_id": map[string]any{"eq": "[$auth.user_id]"}}
+	got := applyContextVariable(context.Background(), in, nil)
+	if !reflect.DeepEqual(got, in) {
+		t.Errorf("without auth vars the filter must pass through unchanged, got %#v", got)
+	}
+}
+
+func deepCopyMap(m map[string]any) map[string]any {
+	res := make(map[string]any, len(m))
+	for k, v := range m {
+		res[k] = deepCopyValue(v)
+	}
+	return res
+}
+
+func deepCopyValue(v any) any {
+	switch v := v.(type) {
+	case map[string]any:
+		return deepCopyMap(v)
+	case []any:
+		res := make([]any, len(v))
+		for i, vv := range v {
+			res[i] = deepCopyValue(vv)
+		}
+		return res
+	default:
+		return v
+	}
+}
+
+// The shipped readonly role relies on ('Mutation', '*', disabled) blocking all
+// mutation fields — the (object, *) case used to be unimplemented, so readonly
+// could mutate.
+func TestCheckObjectField_ReadonlyRole(t *testing.T) {
+	r := RolePermissions{Name: "readonly", Permissions: []Permission{
+		{Object: "Mutation", Field: "*", Disabled: true},
+	}}
+	if _, ok := r.Enabled("Mutation", "core"); ok {
+		t.Error("(Mutation, *) disabled must block every Mutation field")
+	}
+	if _, ok := r.Enabled("Query", "core"); !ok {
+		t.Error("queries must stay open by default")
+	}
+}
+
+// The layered-permissions contract published in the access-control docs:
+// exact (object, field) > (object, *) > (*, field) > (*, *), unmatched = allowed.
+func TestCheckObjectField_Precedence(t *testing.T) {
+	r := RolePermissions{Name: "limited_editor", Permissions: []Permission{
+		{Object: "*", Field: "*", Disabled: false},
+		{Object: "*", Field: "email", Hidden: true},
+		{Object: "users", Field: "ssn", Disabled: true},
+		{Object: "Mutation", Field: "*", Disabled: true},
+		{Object: "Mutation", Field: "update_users", Disabled: false},
+	}}
+
+	tests := []struct {
+		object, field string
+		wantEnabled   bool
+		wantVisible   bool
+	}{
+		{"users", "name", true, true},
+		{"users", "email", true, false},  // (*, email) hidden but not disabled
+		{"users", "ssn", false, true},    // exact disabled
+		{"Mutation", "insert_users", false, true},
+		{"Mutation", "update_users", true, true}, // exact allow beats (Mutation, *)
+	}
+	for _, tt := range tests {
+		if _, ok := r.Enabled(tt.object, tt.field); ok != tt.wantEnabled {
+			t.Errorf("Enabled(%s, %s) = %v, want %v", tt.object, tt.field, ok, tt.wantEnabled)
+		}
+		if _, ok := r.Visible(tt.object, tt.field); ok != tt.wantVisible {
+			t.Errorf("Visible(%s, %s) = %v, want %v", tt.object, tt.field, ok, tt.wantVisible)
+		}
+	}
+}
+
+func TestCheckObjectField_ObjectWildcardBeatsFieldWildcard(t *testing.T) {
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "*", Field: "name", Disabled: false},
+		{Object: "users", Field: "*", Disabled: true},
+	}}
+	if _, ok := r.Enabled("users", "name"); ok {
+		t.Error("(users, *) must beat (*, name)")
+	}
+	if _, ok := r.Enabled("orders", "name"); !ok {
+		t.Error("(*, name) allow must apply to other objects")
+	}
+}
+
+// mcp passes a literal "*" as the field; a seeded (type, "*") row must match it
+// as an exact row.
+func TestCheckObjectField_LiteralStarField(t *testing.T) {
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "mcp:tables:query", Field: "*", Hidden: true},
+	}}
+	if _, ok := r.Visible("mcp:tables:query", "*"); ok {
+		t.Error("literal '*' field must match the (type, '*') row")
+	}
+	if _, ok := r.Visible("mcp:function", "*"); !ok {
+		t.Error("other types stay visible by default")
+	}
+}
+
+// Filter and data lookups must follow the same precedence as enable/visible
+// checks, deterministically — not first-slice-match, exact rows only.
+func TestFilterArgument_Precedence(t *testing.T) {
+	ctx := authCtx()
+	exact := map[string]any{"owner": map[string]any{"eq": "[$auth.user_id]"}}
+	broad := map[string]any{"tenant": map[string]any{"eq": "t1"}}
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "users", Field: "*", Filter: broad},
+		{Object: "users", Field: "orders", Filter: exact},
+	}}
+
+	got := r.FilterArgument(ctx, "users", "orders")
+	want := map[string]any{"owner": map[string]any{"eq": "42"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("exact row must win: got %#v, want %#v", got, want)
+	}
+
+	got = r.FilterArgument(ctx, "users", "profile")
+	if !reflect.DeepEqual(got, broad) {
+		t.Errorf("(users, *) filter must apply to unmatched fields: got %#v", got)
+	}
+
+	if got := r.FilterArgument(ctx, "orders", "items"); got != nil {
+		t.Errorf("no matching row must yield no filter, got %#v", got)
+	}
+
+	disabled := RolePermissions{Disabled: true, Permissions: r.Permissions}
+	if got := disabled.FilterArgument(ctx, "users", "orders"); got != nil {
+		t.Errorf("disabled role must yield no filter, got %#v", got)
+	}
+}
+
+func TestDataArgument_Wildcard(t *testing.T) {
+	ctx := authCtx()
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "Mutation", Field: "*", Data: map[string]any{"created_by": "[$auth.user_id]"}},
+		{Object: "Mutation", Field: "insert_articles", Data: map[string]any{"author_id": "[$auth.user_id]"}},
+	}}
+
+	got := r.DataArgument(ctx, "Mutation", "insert_articles")
+	want := map[string]any{"author_id": "42"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("exact data row must win: got %#v, want %#v", got, want)
+	}
+
+	got = r.DataArgument(ctx, "Mutation", "insert_comments")
+	want = map[string]any{"created_by": "42"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("(Mutation, *) data must apply to unmatched fields: got %#v, want %#v", got, want)
+	}
+}
+
+func TestBestMatch_FirstRowWinsOnTie(t *testing.T) {
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "users", Field: "orders", Filter: map[string]any{"a": map[string]any{"eq": 1}}},
+		{Object: "users", Field: "orders", Filter: map[string]any{"b": map[string]any{"eq": 2}}},
+	}}
+	p := r.bestMatch("users", "orders")
+	if p == nil || !reflect.DeepEqual(p.Filter, map[string]any{"a": map[string]any{"eq": 1}}) {
+		t.Errorf("ties must keep the first row, got %#v", p)
+	}
+}


### PR DESCRIPTION
PR-1 of the permission-system extension (`design/plan-data-object-permissions.md`, items 2+3 of the integration asks). Makes the permission matcher and `[$auth.*]` substitution honor the contract already published in the access-control docs.

## Fixes

**Wildcard matching + precedence (`pkg/perm/permissions.go`)**
- `checkObjectField` had no `(object, *)` case — the shipped `readonly` role seed `('Mutation', '*', disabled)` never matched, so **readonly could execute mutations**.
- All three lookups (`checkObjectField`, `FilterArgument`, `DataArgument`) now share one ranked matcher with the documented precedence: exact `(object, field)` > `(object, *)` > `(*, field)` > `(*, *)`. The most specific row decides all of its attributes; ties keep the first row (deterministic, replaces first-slice-match).

**Placeholder substitution (`applyContextVariable`)**
- Dropped `[]any` values — an `_or` filter collapsed to `{}` = **allow-all** (silent open).
- Dropped literal strings, booleans, numbers, nulls; mutated array elements in place.
- Now: output ≡ input except `[$auth.*]` leaves substituted; input never mutated. Unblocks OR-shared filters (`{_or:[{agent_id:{eq:"[$auth.user_id]"}},{shared:{eq:true}}]}`).

**Drive-by**: `core_auth_check_access_info` UDF reported `filter` and `data` swapped.

## Behavior change (release-notes material)

Existing deployments: `(type, *)` rows start matching (incl. the default `readonly` role — mutations now actually blocked) and complex/literal filters start enforcing. Both were documented behavior that was silently inert.

## Tests

- New `pkg/perm/permissions_test.go` (first tests in the package): substitution table tests incl. `_or`/literals/no-mutation, readonly repro, docs' layered-precedence example, `(object,*)` vs `(*,field)`, mcp literal-`*` field, filter/data precedence + tie determinism.
- Full unit sweep `-tags=duckdb_arrow`: green (only pre-existing unrelated fails: stale `TestFunctionFieldSurvivesAddRemoveAdd`, env-gated `integration-test/mcp`).
- Main E2E: 209 passed, 0 failed.

Next: PR-2 — data-object (table-level) permission layer per `design/design-data-object-permissions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)