### PR TITLE
feat(perm): data-object (table-level) permissions that compose across all paths

### DIFF
--- a/integration-test/e2e/run.sh
+++ b/integration-test/e2e/run.sh
@@ -7,6 +7,11 @@
 #   ./run.sh --keep       # Keep containers running after tests
 #   ./run.sh --duckdb-only  # Skip PostgreSQL CoreDB tests
 #   UPDATE_EXPECTED=1 ./run.sh  # Update expected output files
+#   ONLY=permissions ./run.sh   # Run a single test category
+#
+# A multistep test step NN_name.graphql may have a NN_name.headers file with
+# one "Header-Name: value" per line — the headers are sent with that step's
+# request (e.g. x-hugr-impersonated-* for permission tests).
 
 set -eo pipefail
 
@@ -155,9 +160,18 @@ run_multistep_test() {
 
     local query
     query=$(cat "$query_file")
+    # optional per-step headers (one "Header-Name: value" per line)
+    local header_args=()
+    local headers_file="${query_file%.graphql}.headers"
+    if [ -f "$headers_file" ]; then
+      while IFS= read -r hline || [ -n "$hline" ]; do
+        [ -n "$hline" ] && header_args+=(-H "$hline")
+      done < "$headers_file"
+    fi
     local actual
     actual=$(curl -sf -X POST "$engine_url/query" \
       -H "Content-Type: application/json" \
+      "${header_args[@]}" \
       -d "{\"query\": $(echo "$query" | jq -Rs .)}" 2>/dev/null) || {
       echo "  FAIL: $test_name (step $step_num request failed)"
       FAIL=$((FAIL + 1))
@@ -258,6 +272,10 @@ run_tests_against() {
     [ -d "$category_dir" ] || continue
     category=$(basename "$category_dir")
 
+    # Run a single category when ONLY is set
+    if [ -n "${ONLY:-}" ] && [ "$category" != "$ONLY" ]; then
+      continue
+    fi
     # Skip cluster tests — they use multi-node routing
     [ "$category" = "cluster" ] && continue
     # Skip iceberg tests for non-DuckDB engines and --duckdb-only mode

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/01_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/01_expected.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "core": {
+      "insert_roles": {
+        "name": "e2e_perm_denied"
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/01_setup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/01_setup.graphql
@@ -1,0 +1,13 @@
+mutation {
+  core {
+    insert_roles(data: {
+      name: "e2e_perm_denied"
+      description: "E2E data-object disabled role"
+      permissions: [
+        { type_name: "data-object:query", field_name: "pg_store_products", disabled: true }
+      ]
+    }) {
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/02_direct_query.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/02_direct_query.graphql
@@ -1,0 +1,8 @@
+# A disabled data-object:query row denies the table on the direct path.
+{
+  pg_store {
+    products {
+      id
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/02_direct_query.headers
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/02_direct_query.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_perm_denied
+x-hugr-impersonated-user-id: denied-1
+x-hugr-impersonated-user-name: Denied One

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/02_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/02_expected.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "message": "forbidden"
+    }
+  ]
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/03_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/03_expected.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "message": "forbidden"
+    }
+  ]
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/03_relation_path.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/03_relation_path.graphql
@@ -1,0 +1,11 @@
+# The deny must hold when the table is reached through a relation.
+{
+  pg_store {
+    categories {
+      id
+      products {
+        id
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/03_relation_path.headers
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/03_relation_path.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_perm_denied
+x-hugr-impersonated-user-id: denied-1
+x-hugr-impersonated-user-name: Denied One

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/04_aggregation.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/04_aggregation.graphql
@@ -1,0 +1,9 @@
+# The aggregation field returns a different GraphQL type, so this exercises
+# the planner-level deny (the resolved target object), not the validator.
+{
+  pg_store {
+    products_aggregation {
+      _rows_count
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/04_aggregation.headers
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/04_aggregation.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_perm_denied
+x-hugr-impersonated-user-id: denied-1
+x-hugr-impersonated-user-name: Denied One

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/04_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/04_expected.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "message": "forbidden"
+    }
+  ]
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/05_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/05_expected.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "message": "forbidden"
+    }
+  ]
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/05_insert.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/05_insert.graphql
@@ -1,0 +1,8 @@
+# A disabled data-object:query row is the floor: mutations are denied too.
+mutation {
+  pg_store {
+    insert_products(data: { name: "Should Not Exist", price: 1.0, quantity: 1 }) {
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/05_insert.headers
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/05_insert.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_perm_denied
+x-hugr-impersonated-user-id: denied-1
+x-hugr-impersonated-user-name: Denied One

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/06_cleanup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/06_cleanup.graphql
@@ -1,0 +1,10 @@
+mutation {
+  core {
+    delete_role_permissions(filter: { role: { eq: "e2e_perm_denied" } }) {
+      success
+    }
+    delete_roles(filter: { name: { eq: "e2e_perm_denied" } }) {
+      success
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_disabled/06_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_disabled/06_expected.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "core": {
+      "delete_role_permissions": {
+        "success": true
+      },
+      "delete_roles": {
+        "success": true
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/01_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/01_expected.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "core": {
+      "insert_roles": {
+        "name": "e2e_perm_scoped"
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/01_setup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/01_setup.graphql
@@ -1,0 +1,14 @@
+mutation {
+  core {
+    insert_roles(data: {
+      name: "e2e_perm_scoped"
+      description: "E2E data-object scoped role"
+      permissions: [
+        { type_name: "data-object:query", field_name: "pg_store_products", filter: { id: { in: [1, 2] } } }
+        { type_name: "data-object:query", field_name: "pg_store_categories", filter: { id: { eq: 2 } } }
+      ]
+    }) {
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/02_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/02_expected.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "pg_store": {
+      "products": [
+        {
+          "id": 1,
+          "name": "Laptop Pro"
+        },
+        {
+          "id": 2,
+          "name": "Wireless Mouse"
+        }
+      ]
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/02_scoped_list.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/02_scoped_list.graphql
@@ -1,0 +1,9 @@
+# The data-object:query filter applies to the top-level list field.
+{
+  pg_store {
+    products(order_by: [{field: "id", direction: ASC}]) {
+      id
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/02_scoped_list.headers
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/02_scoped_list.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_perm_scoped
+x-hugr-impersonated-user-id: agent-a
+x-hugr-impersonated-user-name: Agent A

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/03_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/03_expected.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "pg_store": {
+      "products": [
+        {
+          "category": {
+            "id": 2,
+            "name": "Computers"
+          },
+          "id": 1
+        },
+        {
+          "category": null,
+          "id": 2
+        }
+      ]
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/03_forward_ref.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/03_forward_ref.graphql
@@ -1,0 +1,14 @@
+# Repro A (query-engine-asks item 1): the categories filter must compose
+# through the forward reference — product 2's category (id 3) is outside the
+# {id: {eq: 2}} filter and must come back null, not leak.
+{
+  pg_store {
+    products(order_by: [{field: "id", direction: ASC}]) {
+      id
+      category {
+        id
+        name
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/03_forward_ref.headers
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/03_forward_ref.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_perm_scoped
+x-hugr-impersonated-user-id: agent-a
+x-hugr-impersonated-user-name: Agent A

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/04_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/04_expected.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "pg_store": {
+      "categories": [
+        {
+          "id": 2,
+          "name": "Computers",
+          "products": [
+            {
+              "id": 1,
+              "name": "Laptop Pro"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/04_reverse_ref.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/04_reverse_ref.graphql
@@ -1,0 +1,15 @@
+# Repro B: the products filter must compose through the reverse reference —
+# category 2 contains products 1 and 5, but only product 1 passes the
+# {id: {in: [1, 2]}} products filter.
+{
+  pg_store {
+    categories(order_by: [{field: "id", direction: ASC}]) {
+      id
+      name
+      products(order_by: [{field: "id", direction: ASC}]) {
+        id
+        name
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/04_reverse_ref.headers
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/04_reverse_ref.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_perm_scoped
+x-hugr-impersonated-user-id: agent-a
+x-hugr-impersonated-user-name: Agent A

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/05_agg_by_pk.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/05_agg_by_pk.graphql
@@ -1,0 +1,14 @@
+# The same table-level filter must reach aggregations and _by_pk lookups.
+{
+  pg_store {
+    products_aggregation {
+      _rows_count
+    }
+    visible: products_by_pk(id: 1) {
+      id
+    }
+    filtered: products_by_pk(id: 3) {
+      id
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/05_agg_by_pk.headers
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/05_agg_by_pk.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_perm_scoped
+x-hugr-impersonated-user-id: agent-a
+x-hugr-impersonated-user-name: Agent A

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/05_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/05_expected.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "pg_store": {
+      "filtered": null,
+      "products_aggregation": {
+        "_rows_count": 2
+      },
+      "visible": {
+        "id": 1
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/06_cleanup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/06_cleanup.graphql
@@ -1,0 +1,10 @@
+mutation {
+  core {
+    delete_role_permissions(filter: { role: { eq: "e2e_perm_scoped" } }) {
+      success
+    }
+    delete_roles(filter: { name: { eq: "e2e_perm_scoped" } }) {
+      success
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/data_object_filter/06_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/data_object_filter/06_expected.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "core": {
+      "delete_role_permissions": {
+        "success": true
+      },
+      "delete_roles": {
+        "success": true
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/01_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/01_expected.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "core": {
+      "insert_roles": {
+        "name": "e2e_perm_writer"
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/01_setup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/01_setup.graphql
@@ -1,0 +1,14 @@
+mutation {
+  core {
+    insert_roles(data: {
+      name: "e2e_perm_writer"
+      description: "E2E data-object force-stamp role"
+      permissions: [
+        { type_name: "data-object:insert", field_name: "pg_store_products", data: { description: "[$auth.user_id]" } }
+        { type_name: "data-object:update", field_name: "pg_store_products", data: { description: "[$auth.user_id]" } }
+      ]
+    }) {
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/02_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/02_expected.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "pg_store": {
+      "insert_products": {
+        "description": "writer-1",
+        "name": "E2E Perm Product",
+        "quantity": 3
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/02_insert_spoofed.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/02_insert_spoofed.graphql
@@ -1,0 +1,18 @@
+# data-object:insert data must overwrite (force-stamp) the client-submitted
+# value — description becomes the impersonated user id, not "spoofed".
+mutation {
+  pg_store {
+    insert_products(data: {
+      name: "E2E Perm Product"
+      price: 9.99
+      quantity: 3
+      is_active: false
+      description: "spoofed"
+      category_id: 3
+    }) {
+      name
+      quantity
+      description
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/02_insert_spoofed.headers
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/02_insert_spoofed.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_perm_writer
+x-hugr-impersonated-user-id: writer-1
+x-hugr-impersonated-user-name: Writer One

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/03_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/03_expected.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "pg_store": {
+      "update_products": {
+        "success": true
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/03_update_spoofed.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/03_update_spoofed.graphql
@@ -1,0 +1,11 @@
+# data-object:update data must overwrite the client value on updates too.
+mutation {
+  pg_store {
+    update_products(
+      filter: { name: { eq: "E2E Perm Product" } }
+      data: { quantity: 4, description: "spoofed-again" }
+    ) {
+      success
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/03_update_spoofed.headers
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/03_update_spoofed.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_perm_writer
+x-hugr-impersonated-user-id: writer-1
+x-hugr-impersonated-user-name: Writer One

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/04_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/04_expected.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "pg_store": {
+      "products": [
+        {
+          "description": "writer-1",
+          "name": "E2E Perm Product",
+          "quantity": 4
+        }
+      ]
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/04_verify.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/04_verify.graphql
@@ -1,0 +1,9 @@
+{
+  pg_store {
+    products(filter: { name: { eq: "E2E Perm Product" } }) {
+      name
+      quantity
+      description
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/05_cleanup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/05_cleanup.graphql
@@ -1,0 +1,15 @@
+mutation {
+  pg_store {
+    delete_products(filter: { name: { eq: "E2E Perm Product" } }) {
+      success
+    }
+  }
+  core {
+    delete_role_permissions(filter: { role: { eq: "e2e_perm_writer" } }) {
+      success
+    }
+    delete_roles(filter: { name: { eq: "e2e_perm_writer" } }) {
+      success
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/insert_stamp/05_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/insert_stamp/05_expected.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "core": {
+      "delete_role_permissions": {
+        "success": true
+      },
+      "delete_roles": {
+        "success": true
+      }
+    },
+    "pg_store": {
+      "delete_products": {
+        "success": true
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/01_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/01_expected.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "core": {
+      "insert_roles": {
+        "name": "e2e_perm_m2m"
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/01_setup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/01_setup.graphql
@@ -1,0 +1,13 @@
+mutation {
+  core {
+    insert_roles(data: {
+      name: "e2e_perm_m2m"
+      description: "E2E m2m junction deny role"
+      permissions: [
+        { type_name: "data-object:insert", field_name: "pg_store_product_tags", disabled: true }
+      ]
+    }) {
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/02_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/02_expected.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "message": "forbidden"
+    }
+  ]
+}

--- a/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/02_nested_insert.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/02_nested_insert.graphql
@@ -1,0 +1,17 @@
+# A nested m2m insert writes a junction (pg_store_product_tags) row as a side
+# effect. With data-object:insert disabled on the junction, the whole mutation
+# must be denied — the junction is materialised inside the insert walk, not on
+# a top-level field, so this only holds because the walk enforces the rule at
+# the junction's insert site (regression guard for the m2m bypass).
+mutation {
+  pg_store {
+    insert_products(data: {
+      name: "M2M Bypass Product"
+      price: 1.0
+      quantity: 1
+      product_tags: [{ name: "e2e-bypass-tag" }]
+    }) {
+      id
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/02_nested_insert.headers
+++ b/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/02_nested_insert.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_perm_m2m
+x-hugr-impersonated-user-id: m2m-1
+x-hugr-impersonated-user-name: M2M One

--- a/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/03_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/03_expected.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "pg_store": {
+      "products": [],
+      "tags": []
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/03_verify_no_leak.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/03_verify_no_leak.graphql
@@ -1,0 +1,12 @@
+# The denied mutation must not have written the product or the tag (the plan is
+# rejected before any statement runs).
+{
+  pg_store {
+    products(filter: { name: { eq: "M2M Bypass Product" } }) {
+      id
+    }
+    tags(filter: { name: { eq: "e2e-bypass-tag" } }) {
+      id
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/04_cleanup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/04_cleanup.graphql
@@ -1,0 +1,10 @@
+mutation {
+  core {
+    delete_role_permissions(filter: { role: { eq: "e2e_perm_m2m" } }) {
+      success
+    }
+    delete_roles(filter: { name: { eq: "e2e_perm_m2m" } }) {
+      success
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/04_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/m2m_junction_deny/04_expected.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "core": {
+      "delete_role_permissions": {
+        "success": true
+      },
+      "delete_roles": {
+        "success": true
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/readonly_role/01_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/readonly_role/01_expected.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "pg_store": {
+      "products_by_pk": {
+        "id": 1,
+        "name": "Laptop Pro"
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/readonly_role/01_query.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/readonly_role/01_query.graphql
@@ -1,0 +1,9 @@
+# The built-in readonly role: queries stay open by default.
+{
+  pg_store {
+    products_by_pk(id: 1) {
+      id
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/readonly_role/01_query.headers
+++ b/integration-test/e2e/testdata/queries/permissions/readonly_role/01_query.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: readonly
+x-hugr-impersonated-user-id: ro-1
+x-hugr-impersonated-user-name: Readonly One

--- a/integration-test/e2e/testdata/queries/permissions/readonly_role/02_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/readonly_role/02_expected.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "message": "forbidden"
+    }
+  ]
+}

--- a/integration-test/e2e/testdata/queries/permissions/readonly_role/02_mutation.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/readonly_role/02_mutation.graphql
@@ -1,0 +1,10 @@
+# The shipped seed ('readonly', 'Mutation', '*', disabled) must block every
+# mutation — the (object, *) wildcard case used to be unimplemented, so
+# readonly could mutate.
+mutation {
+  pg_store {
+    insert_products(data: { name: "Readonly Must Not Insert", price: 1.0, quantity: 1 }) {
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/readonly_role/02_mutation.headers
+++ b/integration-test/e2e/testdata/queries/permissions/readonly_role/02_mutation.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: readonly
+x-hugr-impersonated-user-id: ro-1
+x-hugr-impersonated-user-name: Readonly One

--- a/pkg/catalog/sdl/objects.go
+++ b/pkg/catalog/sdl/objects.go
@@ -73,6 +73,15 @@ func DataObjectInfo(def *ast.Definition) *Object {
 	return &info
 }
 
+// TypeName returns the GraphQL type name of the data object definition —
+// the identity used to key table-level (data-object:*) permission rows.
+func (info *Object) TypeName() string {
+	if info == nil || info.def == nil {
+		return ""
+	}
+	return info.def.Name
+}
+
 func CatalogName(def *ast.Definition) string {
 	return base.DefinitionCatalog(def)
 }

--- a/pkg/catalog/sdl/queries.go
+++ b/pkg/catalog/sdl/queries.go
@@ -404,6 +404,10 @@ func (m *Mutation) ReferencesMutation(name string) *Mutation {
 		return nil
 	}
 	ref := FieldReferencesInfo(m.ctx, m.defs, m.ObjectDefinition, f)
+	if ref == nil {
+		// not a reference field (plain struct/JSON object value)
+		return nil
+	}
 	rt := ref.ReferencesObjectDef(m.ctx, m.defs)
 	if rt == nil {
 		return nil

--- a/pkg/catalog/sdl/queries.go
+++ b/pkg/catalog/sdl/queries.go
@@ -305,6 +305,21 @@ func (m *Mutation) FieldDefinition(name string) *ast.FieldDefinition {
 	return m.ObjectDefinition.Fields.ForName(name)
 }
 
+// DataInputType returns the type of the mutation's "data" argument (the input
+// object carrying the row values). Nil for mutations without a data argument
+// (e.g. delete). Used to coerce permission force-stamp values to the object's
+// field types.
+func (m *Mutation) DataInputType() *ast.Type {
+	if m.query == nil {
+		return nil
+	}
+	arg := m.query.Arguments.ForName("data")
+	if arg == nil {
+		return nil
+	}
+	return arg.Type
+}
+
 func (m *Mutation) ReferencesFields() []string {
 	var out []string
 	if m.Type == MutationTypeDelete {

--- a/pkg/metadata/schema.go
+++ b/pkg/metadata/schema.go
@@ -158,8 +158,10 @@ func typeResolver(ctx context.Context, provider catalog.Provider, typeDef *ast.T
 					if _, ok := p.Visible(def.Name, f.Name); !ok {
 						continue
 					}
-					// hide fields returning a hidden data object (table-level rule)
-					if p.DataObjectHidden(f.Type.Name()) {
+					// hide fields returning a hidden data object (table-level rule);
+					// scalar return types can never name a data object, so skip
+					// the permission scan for them
+					if tn := f.Type.Name(); !sdl.IsScalarType(tn) && p.DataObjectHidden(tn) {
 						continue
 					}
 				}

--- a/pkg/metadata/schema.go
+++ b/pkg/metadata/schema.go
@@ -158,6 +158,10 @@ func typeResolver(ctx context.Context, provider catalog.Provider, typeDef *ast.T
 					if _, ok := p.Visible(def.Name, f.Name); !ok {
 						continue
 					}
+					// hide fields returning a hidden data object (table-level rule)
+					if p.DataObjectHidden(f.Type.Name()) {
+						continue
+					}
 				}
 				data, err := fieldResolver(ctx, provider, f, field.SelectionSet, maxDepth-1)
 				if err != nil {

--- a/pkg/perm/data_object.go
+++ b/pkg/perm/data_object.go
@@ -1,0 +1,116 @@
+package perm
+
+import (
+	"context"
+)
+
+// Op is a data-object operation for table-level permission lookups.
+type Op string
+
+const (
+	OpQuery  Op = "query"
+	OpInsert Op = "insert"
+	OpUpdate Op = "update"
+	OpDelete Op = "delete"
+)
+
+// DataObjectTypePrefix marks permission rows that carry table-level rules.
+// Such rows use a synthetic type_name ("data-object:query", "data-object:insert",
+// "data-object:update", "data-object:delete") and put the data-object's GraphQL
+// type name (or "*" for all data objects) in field_name. The ":" makes collision
+// with real GraphQL type names impossible, so field-level rows are unaffected.
+const DataObjectTypePrefix = "data-object:"
+
+// dataObjectMatch returns the data-object permission row for the operation and
+// object type name. An exact field_name match wins over a "*" row.
+func (r *RolePermissions) dataObjectMatch(op Op, objType string) *Permission {
+	if objType == "" {
+		return nil
+	}
+	typeName := DataObjectTypePrefix + string(op)
+	var wildcard *Permission
+	for i := range r.Permissions {
+		p := &r.Permissions[i]
+		if p.Object != typeName {
+			continue
+		}
+		switch p.Field {
+		case objType:
+			return p
+		case "*":
+			if wildcard == nil {
+				wildcard = p
+			}
+		}
+	}
+	return wildcard
+}
+
+// DataObjectFilter returns the table-level filter for the data object, with
+// [$auth.*] placeholders substituted. The filter is a property of the TABLE:
+// the planner applies it wherever the object is materialised — top-level
+// queries, _by_pk, relations, _join, aggregations, and mutation WHERE clauses.
+// For OpDelete/OpUpdate the op-specific row's filter takes precedence; when it
+// is absent the OpQuery filter applies (you cannot delete/update rows you
+// cannot read, unless an op row explicitly widens or narrows the scope).
+func (r *RolePermissions) DataObjectFilter(ctx context.Context, objType string, op Op) map[string]any {
+	if r.Disabled {
+		return nil
+	}
+	p := r.dataObjectMatch(op, objType)
+	if (p == nil || len(p.Filter) == 0) && op != OpQuery {
+		p = r.dataObjectMatch(OpQuery, objType)
+	}
+	if p == nil {
+		return nil
+	}
+	return applyContextVariable(ctx, p.Filter, nil)
+}
+
+// DataObjectData returns the table-level data values for insert/update
+// mutations, with [$auth.*] placeholders substituted. These values are applied
+// over the client's data (force-stamp): a data-object:insert row with
+// {owner_id: "[$auth.user_id]"} makes it impossible to insert rows for another
+// principal regardless of the submitted data.
+func (r *RolePermissions) DataObjectData(ctx context.Context, objType string, op Op) map[string]any {
+	if r.Disabled {
+		return nil
+	}
+	p := r.dataObjectMatch(op, objType)
+	if p == nil {
+		return nil
+	}
+	return applyContextVariable(ctx, p.Data, nil)
+}
+
+// DataObjectDisabled reports whether the operation on the data object is
+// denied. A disabled data-object:query row denies the table on EVERY path
+// (reads and mutations alike); op-specific rows can additionally deny a single
+// operation.
+func (r *RolePermissions) DataObjectDisabled(objType string, op Op) bool {
+	if r.Disabled {
+		return true
+	}
+	if p := r.dataObjectMatch(op, objType); p != nil && p.Disabled {
+		return true
+	}
+	if op == OpQuery {
+		return false
+	}
+	if p := r.dataObjectMatch(OpQuery, objType); p != nil && p.Disabled {
+		return true
+	}
+	return false
+}
+
+// DataObjectHidden reports whether the data object is hidden from
+// introspection (set on the data-object:query row). Fields returning a hidden
+// data object are omitted from the introspected schema but remain queryable
+// unless also disabled.
+func (r *RolePermissions) DataObjectHidden(objType string) bool {
+	if r.Disabled {
+		return true
+	}
+	p := r.dataObjectMatch(OpQuery, objType)
+	return p != nil && p.Hidden
+}

--- a/pkg/perm/data_object_test.go
+++ b/pkg/perm/data_object_test.go
@@ -1,0 +1,142 @@
+package perm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDataObjectFilter(t *testing.T) {
+	ctx := authCtx()
+	own := map[string]any{"agent_id": map[string]any{"eq": "[$auth.user_id]"}}
+	ownSub := map[string]any{"agent_id": map[string]any{"eq": "42"}}
+	del := map[string]any{"pin": map[string]any{"eq": false}}
+
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "data-object:query", Field: "skills", Filter: own},
+		{Object: "data-object:delete", Field: "skills", Filter: del},
+	}}
+
+	if got := r.DataObjectFilter(ctx, "skills", OpQuery); !reflect.DeepEqual(got, ownSub) {
+		t.Errorf("query filter = %#v, want %#v", got, ownSub)
+	}
+	if got := r.DataObjectFilter(ctx, "skills", OpDelete); !reflect.DeepEqual(got, del) {
+		t.Errorf("delete filter must use the op-specific row, got %#v", got)
+	}
+	// no :update row — falls back to the :query filter (you cannot update rows
+	// you cannot read unless an op row explicitly says otherwise)
+	if got := r.DataObjectFilter(ctx, "skills", OpUpdate); !reflect.DeepEqual(got, ownSub) {
+		t.Errorf("update filter must fall back to :query, got %#v", got)
+	}
+	if got := r.DataObjectFilter(ctx, "other_table", OpQuery); got != nil {
+		t.Errorf("unmatched object must have no filter, got %#v", got)
+	}
+}
+
+func TestDataObjectFilter_Wildcard(t *testing.T) {
+	ctx := authCtx()
+	exact := map[string]any{"agent_id": map[string]any{"eq": "a"}}
+	all := map[string]any{"tenant": map[string]any{"eq": "t"}}
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "data-object:query", Field: "*", Filter: all},
+		{Object: "data-object:query", Field: "skills", Filter: exact},
+	}}
+	if got := r.DataObjectFilter(ctx, "skills", OpQuery); !reflect.DeepEqual(got, exact) {
+		t.Errorf("exact object row must beat '*', got %#v", got)
+	}
+	if got := r.DataObjectFilter(ctx, "sessions", OpQuery); !reflect.DeepEqual(got, all) {
+		t.Errorf("'*' row must apply to other data objects, got %#v", got)
+	}
+}
+
+func TestDataObjectData_ForceStamp(t *testing.T) {
+	ctx := authCtx()
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "data-object:insert", Field: "skills", Data: map[string]any{"agent_id": "[$auth.user_id]"}},
+	}}
+	got := r.DataObjectData(ctx, "skills", OpInsert)
+	want := map[string]any{"agent_id": "42"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("insert data = %#v, want %#v", got, want)
+	}
+	if got := r.DataObjectData(ctx, "skills", OpUpdate); got != nil {
+		t.Errorf("no :update row must yield no data (no cross-op fallback for data), got %#v", got)
+	}
+}
+
+func TestDataObjectDisabled(t *testing.T) {
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "data-object:query", Field: "secrets", Disabled: true},
+		{Object: "data-object:insert", Field: "audit_log", Disabled: true},
+	}}
+
+	// a disabled :query row denies the table on every path, mutations included
+	for _, op := range []Op{OpQuery, OpInsert, OpUpdate, OpDelete} {
+		if !r.DataObjectDisabled("secrets", op) {
+			t.Errorf("disabled :query row must deny op %s", op)
+		}
+	}
+	// an op-specific row denies only that op
+	if !r.DataObjectDisabled("audit_log", OpInsert) {
+		t.Error("disabled :insert row must deny insert")
+	}
+	if r.DataObjectDisabled("audit_log", OpQuery) {
+		t.Error("disabled :insert row must not deny reads")
+	}
+	if r.DataObjectDisabled("other", OpQuery) {
+		t.Error("unmatched object must stay open")
+	}
+
+	disabled := RolePermissions{Disabled: true}
+	if !disabled.DataObjectDisabled("anything", OpQuery) {
+		t.Error("disabled role denies everything")
+	}
+}
+
+func TestDataObjectHidden(t *testing.T) {
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "data-object:query", Field: "internal_notes", Hidden: true},
+	}}
+	if !r.DataObjectHidden("internal_notes") {
+		t.Error("hidden :query row must hide the data object")
+	}
+	if r.DataObjectHidden("products") {
+		t.Error("unmatched object must stay visible")
+	}
+}
+
+// data-object rows live in a synthetic type_name namespace ("data-object:...")
+// that cannot collide with GraphQL type names, so they must not leak into
+// field-level lookups — and field-level rows must not answer data-object
+// lookups.
+func TestDataObjectRows_DoNotAffectFieldLevel(t *testing.T) {
+	ctx := authCtx()
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "data-object:query", Field: "skills", Disabled: true, Filter: map[string]any{"x": map[string]any{"eq": 1}}},
+	}}
+	if _, ok := r.Enabled("skills", "name"); !ok {
+		t.Error("data-object row must not disable field-level access checks")
+	}
+	if got := r.FilterArgument(ctx, "skills", "name"); got != nil {
+		t.Errorf("data-object row must not produce a field-level filter, got %#v", got)
+	}
+
+	fieldOnly := RolePermissions{Permissions: []Permission{
+		{Object: "Query", Field: "skills", Filter: map[string]any{"x": map[string]any{"eq": 1}}},
+	}}
+	if got := fieldOnly.DataObjectFilter(ctx, "skills", OpQuery); got != nil {
+		t.Errorf("field-level rows must not answer data-object lookups, got %#v", got)
+	}
+	if fieldOnly.DataObjectDisabled("skills", OpQuery) {
+		t.Error("field-level rows must not disable data objects")
+	}
+}
+
+func TestDataObjectMatch_EmptyObjType(t *testing.T) {
+	r := RolePermissions{Permissions: []Permission{
+		{Object: "data-object:query", Field: "*", Disabled: true},
+	}}
+	// an empty object type (non-data-object target) never matches, even "*"
+	if r.DataObjectDisabled("", OpQuery) {
+		t.Error("empty objType must not match data-object rows")
+	}
+}

--- a/pkg/perm/validation_rule.go
+++ b/pkg/perm/validation_rule.go
@@ -20,6 +20,12 @@ func (r *PermissionFieldRule) EnterField(ctx *validator.WalkContext, parentDef *
 	if !ok {
 		return gqlerror.List{gqlerror.WrapIfUnwrapped(auth.ErrForbidden)}
 	}
+	// Deny fields returning a disabled data object (table-level rule). This is
+	// a fast-path for plain fields; aggregation and mutation paths are enforced
+	// in the planner, where the target object is resolved.
+	if field.Definition != nil && checker.DataObjectDisabled(field.Definition.Type.Name(), OpQuery) {
+		return gqlerror.List{gqlerror.WrapIfUnwrapped(auth.ErrForbidden)}
+	}
 	return nil
 }
 

--- a/pkg/perm/validation_rule.go
+++ b/pkg/perm/validation_rule.go
@@ -2,6 +2,7 @@ package perm
 
 import (
 	"github.com/hugr-lab/query-engine/pkg/auth"
+	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
 	"github.com/hugr-lab/query-engine/pkg/catalog/validator"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -22,9 +23,13 @@ func (r *PermissionFieldRule) EnterField(ctx *validator.WalkContext, parentDef *
 	}
 	// Deny fields returning a disabled data object (table-level rule). This is
 	// a fast-path for plain fields; aggregation and mutation paths are enforced
-	// in the planner, where the target object is resolved.
-	if field.Definition != nil && checker.DataObjectDisabled(field.Definition.Type.Name(), OpQuery) {
-		return gqlerror.List{gqlerror.WrapIfUnwrapped(auth.ErrForbidden)}
+	// in the planner, where the target object is resolved. Scalar return types
+	// can never name a data object, so skip the permission scan for them (most
+	// selected fields are scalars).
+	if field.Definition != nil {
+		if rt := field.Definition.Type.Name(); !sdl.IsScalarType(rt) && checker.DataObjectDisabled(rt, OpQuery) {
+			return gqlerror.List{gqlerror.WrapIfUnwrapped(auth.ErrForbidden)}
+		}
 	}
 	return nil
 }

--- a/pkg/planner/node_delete.go
+++ b/pkg/planner/node_delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hugr-lab/query-engine/pkg/db"
 	"github.com/hugr-lab/query-engine/pkg/engines"
 	"github.com/hugr-lab/query-engine/pkg/catalog"
+	"github.com/hugr-lab/query-engine/pkg/perm"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -65,7 +66,7 @@ func deleteRootNode(ctx context.Context, provider catalog.Provider, planner Cata
 		nodes = append(nodes, whereNode)
 	}
 
-	pf, err := permissionFilterNode(ctx, provider, info, query, "_object", false)
+	pf, err := permissionFilterNode(ctx, provider, info, query, "_object", false, perm.OpDelete)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/planner/node_delete.go
+++ b/pkg/planner/node_delete.go
@@ -88,7 +88,7 @@ func deleteRootNode(ctx context.Context, provider catalog.Provider, planner Cata
 			if where != nil {
 				whereSQL += where.Result
 			}
-			pf := children.ForName("permission_filter")
+			pf := children.ForName(permissionFilterNodeName)
 			if pf != nil {
 				if whereSQL != "" {
 					whereSQL += " AND "

--- a/pkg/planner/node_insert.go
+++ b/pkg/planner/node_insert.go
@@ -63,6 +63,13 @@ func insertRootNode(ctx context.Context, provider catalog.Provider, planner Cata
 	if d == nil && summary == nil {
 		return nil, sdl.ErrorPosf(query.Position, "data or summary argument is not provided for mutation")
 	}
+	m := sdl.MutationInfo(ctx, provider, query.Definition)
+	if m == nil {
+		return nil, sdl.ErrorPosf(query.Position, "mutation %s is not defined", query.Alias)
+	}
+	if m.Type != sdl.MutationTypeInsert {
+		return nil, sdl.ErrorPosf(query.Position, "mutation %s type is not insert", query.Alias)
+	}
 	var data map[string]any
 	var ok bool
 	if d != nil {
@@ -70,7 +77,7 @@ func insertRootNode(ctx context.Context, provider catalog.Provider, planner Cata
 		if !ok || len(data) == 0 {
 			return nil, sdl.ErrorPosf(query.Position, "data argument should be an object")
 		}
-		data, err = checkMutationData(ctx, provider, query, d.Type, data)
+		data, err = checkMutationData(ctx, provider, query, d.Type, m, data)
 		if err != nil {
 			return nil, err
 		}
@@ -93,14 +100,6 @@ func insertRootNode(ctx context.Context, provider catalog.Provider, planner Cata
 	e, err := planner.Engine(catalog)
 	if err != nil {
 		return nil, err
-	}
-
-	m := sdl.MutationInfo(ctx, provider, query.Definition)
-	if m == nil {
-		return nil, sdl.ErrorPosf(query.Position, "mutation %s is not defined", query.Alias)
-	}
-	if m.Type != sdl.MutationTypeInsert {
-		return nil, sdl.ErrorPosf(query.Position, "mutation %s type is not insert", query.Alias)
 	}
 
 	node, sv, err := insertDataObjectNode(ctx, provider, e, m, data, "", sv, map[string]string{})

--- a/pkg/planner/node_insert.go
+++ b/pkg/planner/node_insert.go
@@ -247,6 +247,15 @@ func insertBeforeExec(e engines.Engine, m *sdl.Mutation, query *ast.Field, data 
 }
 
 func insertDataObjectNode(ctx context.Context, provider catalog.Provider, e engines.Engine, m *sdl.Mutation, data map[string]any, path string, sv seqValues, parentSeqVal map[string]string) (*QueryPlanNode, seqValues, error) {
+	// Enforce table-level (data-object) insert rules for THIS object before it
+	// is materialised. insertDataObjectNode recurses for every nested reference
+	// object, so each is enforced exactly once here — no separate traversal to
+	// drift out of sync (m2m junction rows are enforced at their insert site
+	// below).
+	if err := enforceDataObjectMutation(ctx, provider, m.ObjectDefinition, m.DataInputType(), perm.OpInsert, data); err != nil {
+		return nil, nil, err
+	}
+
 	refs := m.ReferencesFields()
 	m2mRefs := m.M2MReferencesFields()
 	// define queries nodes of that current query is depended (references data that should be inserted before)
@@ -428,6 +437,12 @@ func insertDataObjectNode(ctx context.Context, provider catalog.Provider, e engi
 			m2mInfo := sdl.DataObjectInfo(m2m)
 			if m2mInfo == nil {
 				return nil, nil, sdl.ErrorPosf(m.ObjectDefinition.Position, "object %s is not defined", ref.M2MName)
+			}
+			// the junction table is materialised here too and must honour a
+			// data-object:insert deny (its rows are the two foreign keys, so
+			// there is no client data to force-stamp)
+			if err := checkDataObjectInsertDisabled(ctx, m2mInfo.TypeName()); err != nil {
+				return nil, nil, err
 			}
 			m2mRef := m2mInfo.M2MReferencesQueryInfo(ctx, provider, ref.Name)
 			if m2mRef == nil {

--- a/pkg/planner/node_permissions.go
+++ b/pkg/planner/node_permissions.go
@@ -3,6 +3,7 @@ package planner
 import (
 	"context"
 	"maps"
+	"slices"
 
 	"github.com/hugr-lab/query-engine/pkg/auth"
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
@@ -11,7 +12,7 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
-func permissionFilterNode(ctx context.Context, defs base.DefinitionsSource, info *sdl.Object, query *ast.Field, prefix string, byAlias bool) (*QueryPlanNode, error) {
+func permissionFilterNode(ctx context.Context, defs base.DefinitionsSource, info *sdl.Object, query *ast.Field, prefix string, byAlias bool, op perm.Op) (*QueryPlanNode, error) {
 	p := perm.PermissionsFromCtx(ctx)
 	if p == nil {
 		return nil, nil
@@ -19,9 +20,24 @@ func permissionFilterNode(ctx context.Context, defs base.DefinitionsSource, info
 	if p.Disabled {
 		return nil, auth.ErrForbidden
 	}
+	// Table-level (data-object) permissions are keyed on the resolved target
+	// object, so they apply on every path the object is materialised through —
+	// top-level fields, _by_pk, relations, _join, aggregations, delete/update.
+	objType := info.TypeName()
+	if p.DataObjectDisabled(objType, op) {
+		return nil, auth.ErrForbidden
+	}
 	arg := p.FilterArgument(ctx, query.ObjectDefinition.Name, query.Name)
-	if arg == nil {
+	objArg := p.DataObjectFilter(ctx, objType, op)
+	switch {
+	case len(arg) == 0 && len(objArg) == 0:
 		return nil, nil
+	case len(arg) == 0:
+		arg = objArg
+	case len(objArg) != 0:
+		// both present: each term only narrows, the object filter is a hard
+		// floor a field-level rule cannot widen
+		arg = map[string]any{"_and": []any{arg, objArg}}
 	}
 	ftn := info.InputFilterName()
 	if ftn == "" {
@@ -51,7 +67,7 @@ func permissionFilterNode(ctx context.Context, defs base.DefinitionsSource, info
 	}, nil
 }
 
-func checkMutationData(ctx context.Context, defs base.DefinitionsSource, query *ast.Field, inputType *ast.Type, data map[string]any) (map[string]any, error) {
+func checkMutationData(ctx context.Context, defs base.DefinitionsSource, query *ast.Field, inputType *ast.Type, m *sdl.Mutation, data map[string]any) (map[string]any, error) {
 	// check permission
 	p := perm.PermissionsFromCtx(ctx)
 	if p == nil {
@@ -63,20 +79,97 @@ func checkMutationData(ctx context.Context, defs base.DefinitionsSource, query *
 		return nil, err
 	}
 
-	arg := p.DataArgument(ctx, query.ObjectDefinition.Name, query.Name)
-	if arg != nil {
-		return data, nil
+	// field-level data rule for the mutation field: injected over the client
+	// data (used to be skipped by an inverted early return)
+	if arg := p.DataArgument(ctx, query.ObjectDefinition.Name, query.Name); len(arg) != 0 {
+		values, err := sdl.ParseDataAsInputObject(ctx, defs, inputType, arg, false)
+		if err != nil {
+			return nil, err
+		}
+		if vm, ok := values.(map[string]any); ok {
+			maps.Copy(data, vm)
+		}
 	}
 
-	values, err := sdl.ParseDataAsInputObject(ctx, defs, inputType, arg, false)
-	if err != nil {
-		return nil, err
+	// table-level (data-object) rules: applied to the target object and every
+	// nested reference object in the data, after the field-level rule so the
+	// object-level values are the force-stamp floor
+	if m != nil {
+		op := perm.OpInsert
+		if m.Type == sdl.MutationTypeUpdate {
+			op = perm.OpUpdate
+		}
+		if err := applyDataObjectMutationRules(ctx, defs, p, m, inputType, op, data); err != nil {
+			return nil, err
+		}
 	}
-	if values == nil {
-		return data, nil
-	}
-
-	maps.Copy(data, values.(map[string]any))
 
 	return data, nil
+}
+
+// applyDataObjectMutationRules enforces data-object:insert / data-object:update
+// permission rows on the mutation data: the operation must not be disabled for
+// the target object, and the row's data values overwrite the client's
+// (force-stamp). Nested reference objects (nested inserts) are enforced
+// recursively, so a table-level rule cannot be bypassed by inserting through a
+// parent object.
+func applyDataObjectMutationRules(ctx context.Context, defs base.DefinitionsSource, p *perm.RolePermissions, m *sdl.Mutation, inputType *ast.Type, op perm.Op, data map[string]any) error {
+	if inputType.Elem != nil {
+		inputType = inputType.Elem
+	}
+	if m.ObjectDefinition != nil {
+		objType := m.ObjectDefinition.Name
+		if p.DataObjectDisabled(objType, op) {
+			return auth.ErrForbidden
+		}
+		if objArg := p.DataObjectData(ctx, objType, op); len(objArg) != 0 {
+			values, err := sdl.ParseDataAsInputObject(ctx, defs, inputType, objArg, false)
+			if err != nil {
+				return err
+			}
+			if vm, ok := values.(map[string]any); ok {
+				maps.Copy(data, vm)
+			}
+		}
+	}
+	inputDef := defs.ForName(ctx, inputType.Name())
+	if inputDef == nil {
+		return nil
+	}
+	refs := m.ReferencesFields()
+	if len(refs) == 0 {
+		return nil
+	}
+	for f, v := range data {
+		// only reference fields carry nested inserts; struct/JSON object
+		// values are plain data of the current object
+		if !slices.Contains(refs, f) {
+			continue
+		}
+		subMut := m.ReferencesMutation(f)
+		if subMut == nil {
+			continue
+		}
+		fd := inputDef.Fields.ForName(f)
+		if fd == nil {
+			continue
+		}
+		switch v := v.(type) {
+		case map[string]any:
+			if err := applyDataObjectMutationRules(ctx, defs, p, subMut, fd.Type, op, v); err != nil {
+				return err
+			}
+		case []any:
+			for _, item := range v {
+				im, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				if err := applyDataObjectMutationRules(ctx, defs, p, subMut, fd.Type, op, im); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/planner/node_permissions.go
+++ b/pkg/planner/node_permissions.go
@@ -3,7 +3,6 @@ package planner
 import (
 	"context"
 	"maps"
-	"slices"
 
 	"github.com/hugr-lab/query-engine/pkg/auth"
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
@@ -11,6 +10,14 @@ import (
 	"github.com/hugr-lab/query-engine/pkg/perm"
 	"github.com/vektah/gqlparser/v2/ast"
 )
+
+// permissionFilterNodeName is the plan-node name for the row-level-security
+// WHERE fragment. It is looked up by name wherever the filter must survive
+// node relocation (join pushdown in node_select.go, WHERE assembly in
+// node_select_params.go, delete/update in node_delete.go/node_update.go), so
+// it must stay a single shared constant — a missed literal silently drops the
+// filter with no compile error.
+const permissionFilterNodeName = "permission_filter"
 
 func permissionFilterNode(ctx context.Context, defs base.DefinitionsSource, info *sdl.Object, query *ast.Field, prefix string, byAlias bool, op perm.Op) (*QueryPlanNode, error) {
 	p := perm.PermissionsFromCtx(ctx)
@@ -58,7 +65,7 @@ func permissionFilterNode(ctx context.Context, defs base.DefinitionsSource, info
 		return nil, nil
 	}
 	return &QueryPlanNode{
-		Name:  "permission_filter",
+		Name:  permissionFilterNodeName,
 		Query: query,
 		Nodes: QueryPlanNodes{node},
 		CollectFunc: func(node *QueryPlanNode, children Results, params []any) (string, []any, error) {
@@ -73,6 +80,11 @@ func checkMutationData(ctx context.Context, defs base.DefinitionsSource, query *
 	if p == nil {
 		return data, nil
 	}
+	// m carries the mutation target; both call sites resolve it before calling,
+	// so a nil here is a planner bug — fail closed rather than skip enforcement.
+	if m == nil {
+		return nil, ErrInternalPlanner
+	}
 
 	inputTypeName := inputType.Name()
 	if err := p.CheckMutationInput(ctx, defs, inputTypeName, data); err != nil {
@@ -82,24 +94,19 @@ func checkMutationData(ctx context.Context, defs base.DefinitionsSource, query *
 	// field-level data rule for the mutation field: injected over the client
 	// data (used to be skipped by an inverted early return)
 	if arg := p.DataArgument(ctx, query.ObjectDefinition.Name, query.Name); len(arg) != 0 {
-		values, err := sdl.ParseDataAsInputObject(ctx, defs, inputType, arg, false)
-		if err != nil {
+		if err := stampPermissionData(ctx, defs, inputType, arg, data); err != nil {
 			return nil, err
-		}
-		if vm, ok := values.(map[string]any); ok {
-			maps.Copy(data, vm)
 		}
 	}
 
-	// table-level (data-object) rules: applied to the target object and every
-	// nested reference object in the data, after the field-level rule so the
-	// object-level values are the force-stamp floor
-	if m != nil {
-		op := perm.OpInsert
-		if m.Type == sdl.MutationTypeUpdate {
-			op = perm.OpUpdate
-		}
-		if err := applyDataObjectMutationRules(ctx, defs, p, m, inputType, op, data); err != nil {
+	// Table-level (data-object) enforcement. Insert (and its nested reference
+	// objects, incl. m2m junctions) is enforced during the insert walk in
+	// insertDataObjectNode, where every materialised object is visited exactly
+	// once — so here we only enforce the update target, which has no nested
+	// traversal. The object-level stamp runs after the field-level one so it is
+	// the force-stamp floor.
+	if m.Type == sdl.MutationTypeUpdate {
+		if err := enforceDataObjectMutation(ctx, defs, m.ObjectDefinition, inputType, perm.OpUpdate, data); err != nil {
 			return nil, err
 		}
 	}
@@ -107,69 +114,49 @@ func checkMutationData(ctx context.Context, defs base.DefinitionsSource, query *
 	return data, nil
 }
 
-// applyDataObjectMutationRules enforces data-object:insert / data-object:update
-// permission rows on the mutation data: the operation must not be disabled for
-// the target object, and the row's data values overwrite the client's
-// (force-stamp). Nested reference objects (nested inserts) are enforced
-// recursively, so a table-level rule cannot be bypassed by inserting through a
-// parent object.
-func applyDataObjectMutationRules(ctx context.Context, defs base.DefinitionsSource, p *perm.RolePermissions, m *sdl.Mutation, inputType *ast.Type, op perm.Op, data map[string]any) error {
+// enforceDataObjectMutation applies the data-object:insert/update rules for a
+// single object: it denies the operation when the object is disabled and
+// force-stamps the rule's data values over the client's. It does NOT recurse —
+// nested inserts are enforced by the insert walk visiting each object.
+func enforceDataObjectMutation(ctx context.Context, defs base.DefinitionsSource, objDef *ast.Definition, inputType *ast.Type, op perm.Op, data map[string]any) error {
+	p := perm.PermissionsFromCtx(ctx)
+	if p == nil || objDef == nil {
+		return nil
+	}
+	if p.DataObjectDisabled(objDef.Name, op) {
+		return auth.ErrForbidden
+	}
+	return stampPermissionData(ctx, defs, inputType, p.DataObjectData(ctx, objDef.Name, op), data)
+}
+
+// checkDataObjectInsertDisabled denies an insert into a data object whose
+// data-object:insert (or :query) rule is disabled. Used by the insert walk for
+// materialised objects that have no stampable data of their own — notably m2m
+// junction rows, whose values are the two foreign keys.
+func checkDataObjectInsertDisabled(ctx context.Context, objType string) error {
+	p := perm.PermissionsFromCtx(ctx)
+	if p != nil && p.DataObjectDisabled(objType, perm.OpInsert) {
+		return auth.ErrForbidden
+	}
+	return nil
+}
+
+// stampPermissionData overlays a permission rule's data values (field-level or
+// data-object) onto the mutation data, coercing them to the object's field
+// types via the input definition. Overwriting is the force-stamp guarantee.
+func stampPermissionData(ctx context.Context, defs base.DefinitionsSource, inputType *ast.Type, stamp map[string]any, data map[string]any) error {
+	if inputType == nil || len(stamp) == 0 {
+		return nil
+	}
 	if inputType.Elem != nil {
 		inputType = inputType.Elem
 	}
-	if m.ObjectDefinition != nil {
-		objType := m.ObjectDefinition.Name
-		if p.DataObjectDisabled(objType, op) {
-			return auth.ErrForbidden
-		}
-		if objArg := p.DataObjectData(ctx, objType, op); len(objArg) != 0 {
-			values, err := sdl.ParseDataAsInputObject(ctx, defs, inputType, objArg, false)
-			if err != nil {
-				return err
-			}
-			if vm, ok := values.(map[string]any); ok {
-				maps.Copy(data, vm)
-			}
-		}
+	values, err := sdl.ParseDataAsInputObject(ctx, defs, inputType, stamp, false)
+	if err != nil {
+		return err
 	}
-	inputDef := defs.ForName(ctx, inputType.Name())
-	if inputDef == nil {
-		return nil
-	}
-	refs := m.ReferencesFields()
-	if len(refs) == 0 {
-		return nil
-	}
-	for f, v := range data {
-		// only reference fields carry nested inserts; struct/JSON object
-		// values are plain data of the current object
-		if !slices.Contains(refs, f) {
-			continue
-		}
-		subMut := m.ReferencesMutation(f)
-		if subMut == nil {
-			continue
-		}
-		fd := inputDef.Fields.ForName(f)
-		if fd == nil {
-			continue
-		}
-		switch v := v.(type) {
-		case map[string]any:
-			if err := applyDataObjectMutationRules(ctx, defs, p, subMut, fd.Type, op, v); err != nil {
-				return err
-			}
-		case []any:
-			for _, item := range v {
-				im, ok := item.(map[string]any)
-				if !ok {
-					continue
-				}
-				if err := applyDataObjectMutationRules(ctx, defs, p, subMut, fd.Type, op, im); err != nil {
-					return err
-				}
-			}
-		}
+	if vm, ok := values.(map[string]any); ok {
+		maps.Copy(data, vm)
 	}
 	return nil
 }

--- a/pkg/planner/node_select.go
+++ b/pkg/planner/node_select.go
@@ -358,7 +358,7 @@ func selectDataObjectNode(ctx context.Context, defs base.DefinitionsSource, plan
 		}
 	}
 
-	pn, err := permissionFilterNode(ctx, defs, info, query, "_objects", false)
+	pn, err := permissionFilterNode(ctx, defs, info, query, "_objects", false, perm.OpQuery)
 	if err != nil {
 		return nil, false, err
 	}
@@ -370,10 +370,17 @@ func selectDataObjectNode(ctx context.Context, defs base.DefinitionsSource, plan
 		nodes = append(nodes, paramNodes...)
 	}
 	if len(joinCatalogNodes) != 0 || len(joinGeneralNodes) != 0 {
-		// if there are joins, we push down only where and vector search nodes
+		// if there are joins, we push down only where, permission and vector search nodes
 		whereNode := paramNodes.ForName("where")
 		if whereNode != nil {
 			nodes = append(nodes, whereNode)
+		}
+		// the permission filter must reach the base query WHERE even when the
+		// query selects joined references — dropping it here disabled row-level
+		// security on any root query with relation sub-selections
+		permNode := paramNodes.ForName("permission_filter")
+		if permNode != nil {
+			nodes = append(nodes, permNode)
 		}
 		vectorSearchNode := paramNodes.ForName(vectorDistanceNodeName)
 		if vectorSearchNode != nil {

--- a/pkg/planner/node_select.go
+++ b/pkg/planner/node_select.go
@@ -370,25 +370,15 @@ func selectDataObjectNode(ctx context.Context, defs base.DefinitionsSource, plan
 		nodes = append(nodes, paramNodes...)
 	}
 	if len(joinCatalogNodes) != 0 || len(joinGeneralNodes) != 0 {
-		// if there are joins, we push down only where, permission and vector search nodes
-		whereNode := paramNodes.ForName("where")
-		if whereNode != nil {
-			nodes = append(nodes, whereNode)
-		}
-		// the permission filter must reach the base query WHERE even when the
-		// query selects joined references — dropping it here disabled row-level
-		// security on any root query with relation sub-selections
-		permNode := paramNodes.ForName("permission_filter")
-		if permNode != nil {
-			nodes = append(nodes, permNode)
-		}
-		vectorSearchNode := paramNodes.ForName(vectorDistanceNodeName)
-		if vectorSearchNode != nil {
-			nodes = append(nodes, vectorSearchNode)
-		}
-		vectorLimitNode := paramNodes.ForName(vectorSearchLimitNodeName)
-		if vectorLimitNode != nil {
-			nodes = append(nodes, vectorLimitNode)
+		// When the query has joins, push down to the base query only the nodes
+		// that must constrain the base rows: the WHERE, the permission filter
+		// (omitting it dropped row-level security on any root query with
+		// relation sub-selections), and vector search. All must be looked up by
+		// their shared node-name constants so a rename can't silently drop one.
+		for _, name := range []string{"where", permissionFilterNodeName, vectorDistanceNodeName, vectorSearchLimitNodeName} {
+			if n := paramNodes.ForName(name); n != nil {
+				nodes = append(nodes, n)
+			}
 		}
 	}
 

--- a/pkg/planner/node_select_params.go
+++ b/pkg/planner/node_select_params.go
@@ -165,7 +165,7 @@ func selectStatementNode(query *ast.Field, nodes QueryPlanNodes, alias string, a
 				sql += " " + joins.Result
 			}
 			where := children.ForName("where")
-			perm := children.ForName("permission_filter")
+			perm := children.ForName(permissionFilterNodeName)
 			whereSQL := ""
 			if where != nil {
 				whereSQL = where.Result

--- a/pkg/planner/node_update.go
+++ b/pkg/planner/node_update.go
@@ -176,7 +176,7 @@ func updateRootNode(ctx context.Context, provider catalog.Provider, planner Cata
 			if where != nil {
 				whereSQL += where.Result
 			}
-			pf := children.ForName("permission_filter")
+			pf := children.ForName(permissionFilterNodeName)
 			if pf != nil {
 				if whereSQL != "" {
 					whereSQL += " AND "

--- a/pkg/planner/node_update.go
+++ b/pkg/planner/node_update.go
@@ -59,7 +59,7 @@ func updateRootNode(ctx context.Context, provider catalog.Provider, planner Cata
 		if !ok || len(data) == 0 && s == nil {
 			return nil, sdl.ErrorPosf(query.Position, "invalid data argument type")
 		}
-		data, err = checkMutationData(ctx, provider, query, v.Type, data)
+		data, err = checkMutationData(ctx, provider, query, v.Type, m, data)
 		if err != nil {
 			return nil, err
 		}
@@ -157,7 +157,7 @@ func updateRootNode(ctx context.Context, provider catalog.Provider, planner Cata
 		nodes = append(nodes, whereNode)
 	}
 
-	pf, err := permissionFilterNode(ctx, provider, info, query, "objects", false)
+	pf, err := permissionFilterNode(ctx, provider, info, query, "objects", false, perm.OpUpdate)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
PR-2 of the permission-system extension (`design/design-data-object-permissions.md`, item 1 of the integration asks — RLS did not compose through relation traversal). Builds on #128.

## The layer

Table-level permission rows reuse `core.permissions` with a synthetic `type_name` namespace, keyed on the data-object's **GraphQL type name** in `field_name` (or `"*"` for all objects). No schema migration — `:` cannot appear in GraphQL type names, so field-level rows are untouched.

| `type_name` | carries | applies to |
|---|---|---|
| `data-object:query` | `filter`, `disabled`, `hidden` | every read path + mutation WHERE fallback; `disabled` denies the table everywhere |
| `data-object:delete` / `data-object:update` | `filter` (+ `data` for update) | op WHERE (falls back to `:query` filter when absent) |
| `data-object:insert` / `data-object:update` | `data` | force-stamped over client data, recursively through nested reference inserts |

The planner already resolves the target `*sdl.Object` at every materialisation point and threads it into `permissionFilterNode` — the lookup now uses it (`info.TypeName()`), so **relations, `_join`, `_by_pk`, aggregations, delete and update WHERE all inherit the filter from one merge point**. Field-level and object-level filters combine via `_and` (the object filter is a floor a field rule cannot widen); mutation data overlays as `user < field-level < object-level`.

## Bugs found and fixed while wiring

- **`checkMutationData` inverted early-return** (`node_permissions.go`): field-level `data` rules were never applied — documented "Default Values for Mutations" was dead.
- **Root RLS dropped under joined references** (`node_select.go`): with relation sub-selections in the query, only the user's `where` node was pushed into the base query — the `permission_filter` node was silently discarded. Row-level security did not apply to any root query selecting references (pre-existing, hit field-level filters too).
- **`Mutation.ReferencesMutation` nil-deref** (`sdl/queries.go`) for non-reference object-valued fields (struct/JSON insert data).

## E2E permission tests (new)

`run.sh` now supports per-step `NN_name.headers` files (impersonation via `x-hugr-impersonated-*` — the seeded `admin` role has `can_impersonate`) and an `ONLY=<category>` filter. New `permissions` category, self-cleaning multistep cases run against both engines:

- `data_object_filter` — the acceptance repros: forward reference returns `null` for a filtered target, reverse edge excludes foreign rows, aggregation `_rows_count` and `_by_pk` respect the filter, top-level scoped list.
- `insert_stamp` — `data-object:insert/update` `data` overrides spoofed client values (`description` becomes the impersonated user id).
- `data_object_disabled` — `forbidden` on direct query, relation path, aggregation (planner-level deny), and insert.
- `readonly_role` — the shipped `('readonly','Mutation','*')` seed end-to-end: queries pass, mutations forbidden.

## Validation

- Unit sweep `-tags=duckdb_arrow`: green (pre-existing unrelated fails only: stale `TestFunctionFieldSurvivesAddRemoveAdd`, env-gated `integration-test/mcp`)
- Main E2E: **217 passed, 0 failed** (209 existing + 8 new)
- hugr-app E2E: **39 passed, 0 failed**

Next: PR-3 — docs site update (`hugr-lab.github.io`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)