### PR TITLE
feat(auth): expose custom token claims as [$auth.<claim>] placeholders

### DIFF
--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -1,6 +1,9 @@
 package auth
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+)
 
 type AuthInfo struct {
 	Role     string
@@ -11,9 +14,37 @@ type AuthInfo struct {
 	AuthProvider string
 	Token        string
 
+	// Claims holds the scalar claims carried by the authentication token
+	// (JWT/OIDC), exposed to permission filters and mutation data as
+	// [$auth.<claim>] placeholders. Nil for token-less auth (API key,
+	// anonymous) and for impersonated identities. Built-in placeholders
+	// (user_id, role, …) always take precedence over a same-named claim.
+	Claims map[string]any
+
 	// ImpersonatedBy holds the original admin identity when this request
 	// is running under impersonation. Nil means no impersonation.
 	ImpersonatedBy *AuthInfo
+}
+
+// ScalarClaims returns the subset of claims whose values are scalars
+// (string, bool, or number) — the only claims usable as [$auth.<claim>]
+// substitution values in filters and mutation data. Nested objects and
+// arrays are dropped. Returns nil when nothing scalar remains.
+func ScalarClaims(claims map[string]any) map[string]any {
+	if len(claims) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(claims))
+	for k, v := range claims {
+		switch v.(type) {
+		case string, bool, float64, float32, int, int64, int32, json.Number:
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 type authInfoKeyType string

--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -142,6 +142,7 @@ func (p *JwtProvider) Authenticate(r *http.Request) (*AuthInfo, error) {
 		AuthType:     "jwt",
 		AuthProvider: p.c.Issuer,
 		Token:        t.Raw,
+		Claims:       ScalarClaims(claims),
 	}, nil
 }
 

--- a/pkg/auth/jwt_test.go
+++ b/pkg/auth/jwt_test.go
@@ -98,6 +98,43 @@ func TestJwtConfig_PublicKey_Base64Delivered(t *testing.T) {
 	}
 }
 
+// The JWT provider must carry the token's scalar claims through on AuthInfo so
+// they are exposed as [$auth.<claim>] placeholders; nested/array claims are
+// dropped.
+func TestJwtProvider_CustomClaims(t *testing.T) {
+	p, err := NewJwt(&JwtConfig{Issuer: "rsa", PublicKey: rsaPubKey})
+	if err != nil {
+		t.Fatalf("NewJwt: %v", err)
+	}
+	tok, err := GenerateToken(rsaKey, jwt.MapClaims{
+		"sub":           "u",
+		"x-hugr-role":   "admin",
+		"tenant_id":     "acme",
+		"department_id": 7,
+		"nested":        map[string]any{"x": 1}, // must be dropped
+		"groups":        []any{"a", "b"},        // must be dropped
+		"exp":           time.Now().Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	ai, err := p.Authenticate(req)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if ai.Claims["tenant_id"] != "acme" {
+		t.Errorf("tenant_id claim = %v, want acme", ai.Claims["tenant_id"])
+	}
+	if _, ok := ai.Claims["nested"]; ok {
+		t.Error("nested object claim must be dropped")
+	}
+	if _, ok := ai.Claims["groups"]; ok {
+		t.Error("array claim must be dropped")
+	}
+}
+
 func TestJwtProvider_Authenticate(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/perm/permissions.go
+++ b/pkg/perm/permissions.go
@@ -204,14 +204,19 @@ func AuthVars(ctx context.Context) map[string]any {
 
 	userIdInt, _ := strconv.Atoi(ai.UserId)
 
-	vars := map[string]any{
-		"[$auth.user_name]":   ai.UserName,
-		"[$auth.user_id]":     ai.UserId,
-		"[$auth.user_id_int]": userIdInt,
-		"[$auth.role]":        ai.Role,
-		"[$auth.auth_type]":   ai.AuthType,
-		"[$auth.provider]":    ai.AuthProvider,
+	vars := make(map[string]any, len(ai.Claims)+9)
+	// Custom token claims first, so the built-in placeholders below always win
+	// on a name collision (a token claim named "role" cannot shadow the
+	// resolved role).
+	for k, v := range ai.Claims {
+		vars["[$auth."+k+"]"] = v
 	}
+	vars["[$auth.user_name]"] = ai.UserName
+	vars["[$auth.user_id]"] = ai.UserId
+	vars["[$auth.user_id_int]"] = userIdInt
+	vars["[$auth.role]"] = ai.Role
+	vars["[$auth.auth_type]"] = ai.AuthType
+	vars["[$auth.provider]"] = ai.AuthProvider
 	if ai.ImpersonatedBy != nil {
 		vars["[$auth.impersonated_by_role]"] = ai.ImpersonatedBy.Role
 		vars["[$auth.impersonated_by_user_id]"] = ai.ImpersonatedBy.UserId

--- a/pkg/perm/permissions_test.go
+++ b/pkg/perm/permissions_test.go
@@ -85,6 +85,45 @@ func TestApplyContextVariable_NoAuthContext(t *testing.T) {
 	}
 }
 
+// Custom token claims are exposed as [$auth.<claim>] and substituted in
+// filters, but a claim can never shadow a built-in placeholder.
+func TestAuthVars_CustomClaims(t *testing.T) {
+	ctx := auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{
+		Role:   "agent",
+		UserId: "42",
+		Claims: map[string]any{
+			"tenant_id":     "acme",
+			"department_id": float64(7),
+			"role":          "SHOULD_NOT_WIN", // collides with the built-in
+		},
+	})
+	vars := AuthVars(ctx)
+	if got := vars["[$auth.tenant_id]"]; got != "acme" {
+		t.Errorf("[$auth.tenant_id] = %v, want acme", got)
+	}
+	if got := vars["[$auth.department_id]"]; got != float64(7) {
+		t.Errorf("[$auth.department_id] = %v, want 7", got)
+	}
+	if got := vars["[$auth.role]"]; got != "agent" {
+		t.Errorf("[$auth.role] = %v, want agent (built-in must win over claim)", got)
+	}
+}
+
+// A filter using a custom claim placeholder is substituted end-to-end.
+func TestApplyContextVariable_CustomClaim(t *testing.T) {
+	ctx := auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{
+		Role:   "agent",
+		UserId: "42",
+		Claims: map[string]any{"tenant_id": "acme"},
+	})
+	in := map[string]any{"tenant_id": map[string]any{"eq": "[$auth.tenant_id]"}}
+	got := applyContextVariable(ctx, in, nil)
+	want := map[string]any{"tenant_id": map[string]any{"eq": "acme"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("applyContextVariable() = %#v, want %#v", got, want)
+	}
+}
+
 func deepCopyMap(m map[string]any) map[string]any {
 	res := make(map[string]any, len(m))
 	for k, v := range m {


### PR DESCRIPTION
Permission filters and mutation `data` could only reference a fixed set of `[$auth.*]` placeholders (`user_id`, `role`, `auth_type`, …). The access-control docs' custom-claim examples (`[$auth.tenant_id]`, `[$auth.department_id]`, `[$auth.user_region]`) never resolved — there was no custom-claims mechanism. This adds one.

## Change

- **`AuthInfo.Claims map[string]any`** carries the token's **scalar** claims (string/bool/number). Nested objects and arrays are dropped via the new exported helper `auth.ScalarClaims`. Nil for token-less auth (API key, anonymous) and for impersonated identities.
- **JWT provider** populates `Claims` from the verified token.
- **`AuthVars`** emits each claim as `[$auth.<claim>]`, **before** the built-ins — so a built-in (`role`, `user_id`, …) always wins over a same-named claim (a token cannot spoof its own role via a claim).

Flat syntax (`[$auth.tenant_id]`, not `[$auth.claims.tenant_id]`) was chosen so the documented examples become valid as written, with built-in precedence handling collisions.

No planner/schema change — placeholders already flow through `applyContextVariable`.

## Follow-ups (same release)

- hugr OIDC provider: populate `AuthInfo.Claims = auth.ScalarClaims(claims)` symmetrically (needs this released first).
- Docs: the `hugr-lab.github.io` "Custom Claim Variables" section is now accurate; the stale `[$auth.tenant_id]`/`user_region`/`department_id` examples become real. Separate docs PR.

## Tests

- `pkg/auth`: JWT carries scalar claims, drops nested/array.
- `pkg/perm`: `AuthVars` exposes claims, built-in wins on collision, end-to-end substitution in a filter.
- Full build + auth/perm/planner suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)