### PR TITLE
feat(auth): expose managed API-key claims; fix dev-server DB-key wiring

### DIFF
--- a/cmd/dev-server/auth.go
+++ b/cmd/dev-server/auth.go
@@ -75,6 +75,11 @@ func (c *AuthConfig) Configure() (*auth.Config, error) {
 		)
 	}
 
+	// Enable the managed (core-DB) API-key provider — the middleware adds it
+	// based on this flag. Without this the ALLOWED_DB_API_KEYS flag was read
+	// but never reached auth.Config, so managed keys never authenticated.
+	config.DBApiKeysEnabled = c.AllowedDBKeys
+
 	if len(config.Providers) == 0 {
 		return nil, nil
 	}

--- a/integration-test/e2e/docker-compose.yml
+++ b/integration-test/e2e/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       ADMIN_UI: "false"
       ALLOWED_ANONYMOUS: "true"
       ANONYMOUS_ROLE: "admin"
+      ALLOWED_DB_API_KEYS: "true"
     depends_on:
       postgres:
         condition: service_healthy
@@ -125,6 +126,7 @@ services:
       ADMIN_UI: "false"
       ALLOWED_ANONYMOUS: "true"
       ANONYMOUS_ROLE: "admin"
+      ALLOWED_DB_API_KEYS: "true"
     depends_on:
       core-postgres:
         condition: service_healthy

--- a/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/01_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/01_expected.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "core": {
+      "insert_api_keys": {
+        "name": "e2e-claim-key"
+      },
+      "insert_roles": {
+        "name": "e2e_apikey_role"
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/01_setup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/01_setup.graphql
@@ -1,0 +1,22 @@
+mutation {
+  core {
+    insert_roles(data: {
+      name: "e2e_apikey_role"
+      description: "E2E api-key custom-claim role"
+      permissions: [
+        { type_name: "data-object:query", field_name: "pg_store_products", filter: { description: { eq: "[$auth.desc_claim]" } } }
+      ]
+    }) {
+      name
+    }
+    insert_api_keys(data: {
+      name: "e2e-claim-key"
+      key: "e2e-claim-secret"
+      description: "E2E custom-claim key"
+      default_role: "e2e_apikey_role"
+      claims: { desc_claim: "High-performance laptop" }
+    }) {
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/02_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/02_expected.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "pg_store": {
+      "products": [
+        {
+          "description": "High-performance laptop",
+          "id": 1,
+          "name": "Laptop Pro"
+        }
+      ]
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/02_query.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/02_query.graphql
@@ -1,0 +1,13 @@
+# Authenticated with the managed API key. The key's claims column carries a
+# custom scalar claim (desc_claim); the role's data-object filter references it
+# as [$auth.desc_claim], so only the matching product is returned. Proves the
+# api_keys.claims column exposes arbitrary claims, not just role/user identity.
+{
+  pg_store {
+    products(order_by: [{ field: "id", direction: ASC }]) {
+      id
+      name
+      description
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/02_query.headers
+++ b/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/02_query.headers
@@ -1,0 +1,1 @@
+x-hugr-api-key: e2e-claim-secret

--- a/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/03_cleanup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/03_cleanup.graphql
@@ -1,0 +1,13 @@
+mutation {
+  core {
+    delete_api_keys(filter: { name: { eq: "e2e-claim-key" } }) {
+      success
+    }
+    delete_role_permissions(filter: { role: { eq: "e2e_apikey_role" } }) {
+      success
+    }
+    delete_roles(filter: { name: { eq: "e2e_apikey_role" } }) {
+      success
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/03_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/apikey_custom_claim/03_expected.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "core": {
+      "delete_api_keys": {
+        "success": true
+      },
+      "delete_role_permissions": {
+        "success": true
+      },
+      "delete_roles": {
+        "success": true
+      }
+    }
+  }
+}

--- a/pkg/auth/db_api_keys.go
+++ b/pkg/auth/db_api_keys.go
@@ -77,7 +77,11 @@ func (p *DBApiKey) Authenticate(r *http.Request) (*AuthInfo, error) {
 		IsTemporal  bool               `json:"is_temporal"`
 		ExpiresAt   string             `json:"expires_at"`
 		Headers     UserAuthInfoConfig `json:"headers"`
-		UserInfo    UserAuthInfoConfig `json:"claims"`
+		// Claims is the api_keys.claims JSON column. Its "role"/"user_id"/
+		// "user_name" keys set a static identity (as before); any other scalar
+		// keys are exposed as [$auth.<claim>] placeholders, so a managed API
+		// key can scope row-level security the same way a JWT claim does.
+		Claims map[string]any `json:"claims"`
 	}
 
 	err = res.ScanData("core.api_keys_by_key", &keyInfo)
@@ -101,12 +105,19 @@ func (p *DBApiKey) Authenticate(r *http.Request) (*AuthInfo, error) {
 			return nil, ErrForbidden
 		}
 	}
+	// identity carried directly on the key's claims (role/user_id/user_name)
+	userInfo := UserAuthInfoConfig{
+		Role:     claimString(keyInfo.Claims, "role"),
+		UserId:   claimString(keyInfo.Claims, "user_id"),
+		UserName: claimString(keyInfo.Claims, "user_name"),
+	}
+
 	role := keyInfo.DefaultRole
 	if keyInfo.Headers.Role != "" {
 		role = r.Header.Get(keyInfo.Headers.Role)
 	}
-	if keyInfo.UserInfo.Role != "" {
-		role = keyInfo.UserInfo.Role
+	if userInfo.Role != "" {
+		role = userInfo.Role
 	}
 	if keyInfo.Headers.UserId != "" {
 		keyInfo.Headers.UserId = "x-hugr-user-id"
@@ -115,16 +126,16 @@ func (p *DBApiKey) Authenticate(r *http.Request) (*AuthInfo, error) {
 		keyInfo.Headers.UserName = "x-hugr-user-name"
 	}
 	userId := r.Header.Get(keyInfo.Headers.UserId)
-	if keyInfo.UserInfo.UserId != "" {
-		userId = keyInfo.UserInfo.UserId
+	if userInfo.UserId != "" {
+		userId = userInfo.UserId
 	}
 	if userId == "" {
 		userId = "anonymous"
 	}
 
 	userName := r.Header.Get(keyInfo.Headers.UserName)
-	if keyInfo.UserInfo.UserName != "" {
-		userName = keyInfo.UserInfo.UserName
+	if userInfo.UserName != "" {
+		userName = userInfo.UserName
 	}
 	if userName == "" {
 		userName = "anonymous"
@@ -136,5 +147,12 @@ func (p *DBApiKey) Authenticate(r *http.Request) (*AuthInfo, error) {
 		Role:         role,
 		AuthType:     "db-api-key",
 		AuthProvider: p.name,
+		Claims:       ScalarClaims(keyInfo.Claims),
 	}, nil
+}
+
+// claimString returns the string value of a claim, or "" if absent/non-string.
+func claimString(m map[string]any, key string) string {
+	s, _ := m[key].(string)
+	return s
 }


### PR DESCRIPTION
Follow-up to #130 (custom token claims). Extends custom-claim support to core-DB-managed API keys, and fixes a latent bug that meant managed keys never authenticated in the dev-server.

## Findings

**1. `api_keys.claims` dropped everything but identity.** The managed API-key provider scanned the `claims` JSON column into a fixed `{role, user_id, user_name}` struct (`UserAuthInfoConfig`), silently discarding any other keys. So a managed key could set identity but not carry a `tenant_id`/`desc_claim`-style claim for row-level security.

**2. Managed API keys never authenticated in the dev-server.** `ALLOWED_DB_API_KEYS` was read into `AllowedDBKeys` but `Configure()` never propagated it to `auth.Config.DBApiKeysEnabled` — the field the middleware gates the provider on. A request with a managed-key header silently fell through to anonymous. (Pre-existing; surfaced writing this test.)

## Changes

- **`pkg/auth/db_api_keys.go`**: read `claims` as a general `map[string]any`. The `role`/`user_id`/`user_name` keys still set a static identity (backward-compatible); every other scalar claim is exposed as `[$auth.<claim>]` via `AuthInfo.Claims = ScalarClaims(...)`.
- **`cmd/dev-server/auth.go`**: set `config.DBApiKeysEnabled = c.AllowedDBKeys`.

## Test

New e2e `permissions/apikey_custom_claim`: a role with a `data-object:query` filter `{ description: { eq: "[$auth.desc_claim]" } }` and a managed key whose `claims` column carries `{ desc_claim: "High-performance laptop" }`. Querying with the key header returns only the matching product — proving the claim is exposed end-to-end. `ALLOWED_DB_API_KEYS` enabled on both core-DB engines.

Full e2e **221 passed, 0 failed**; build + auth/perm suites green.

Ships in the same release as #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)