### PR TITLE
fix(views): address self-review of argless-view placeholder substitution

### DIFF
--- a/pkg/catalog/compiler/rules/validate_argless_view_test.go
+++ b/pkg/catalog/compiler/rules/validate_argless_view_test.go
@@ -1,0 +1,61 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func viewDef(name, sql string) *ast.Definition {
+	pos := argDefaultPos()
+	return &ast.Definition{
+		Kind:     ast.Object,
+		Name:     name,
+		Position: pos,
+		Directives: ast.DirectiveList{
+			{
+				Name:     base.ObjectViewDirectiveName,
+				Position: pos,
+				Arguments: ast.ArgumentList{
+					{Name: base.ArgName, Value: &ast.Value{Raw: name, Kind: ast.StringValue, Position: pos}, Position: pos},
+					{Name: base.ArgSQL, Value: &ast.Value{Raw: sql, Kind: ast.StringValue, Position: pos}, Position: pos},
+				},
+			},
+		},
+	}
+}
+
+func TestValidateArglessViewSQL(t *testing.T) {
+	valid := []struct {
+		name, sql string
+	}{
+		{"whitelisted auth placeholder", "SELECT id FROM t WHERE user_id = [$auth.user_id]"},
+		{"user_id_int", "SELECT id FROM t WHERE category_id = [$auth.user_id_int]"},
+		{"catalog system variable", "SELECT id FROM [$catalog].t"},
+		{"plain column reference", "SELECT [id], [name] FROM t"},
+		{"no placeholders", "SELECT id FROM t WHERE is_active = true"},
+	}
+	for _, tt := range valid {
+		t.Run("ok/"+tt.name, func(t *testing.T) {
+			if err := validateArglessViewSQL(viewDef("v", tt.sql)); err != nil {
+				t.Errorf("expected valid, got: %v", err)
+			}
+		})
+	}
+
+	invalid := []struct {
+		name, sql string
+	}{
+		{"custom claim not whitelisted", "SELECT id FROM t WHERE tenant = [$auth.tenant_id]"},
+		{"typo in placeholder", "SELECT id FROM t WHERE user_id = [$auth.user_ids]"},
+		{"unknown context var", "SELECT id FROM t WHERE x = [$some_arg]"},
+	}
+	for _, tt := range invalid {
+		t.Run("reject/"+tt.name, func(t *testing.T) {
+			if err := validateArglessViewSQL(viewDef("v", tt.sql)); err == nil {
+				t.Errorf("expected a compile error for %q, got nil", tt.sql)
+			}
+		})
+	}
+}

--- a/pkg/catalog/compiler/rules/validate_argless_view_test.go
+++ b/pkg/catalog/compiler/rules/validate_argless_view_test.go
@@ -44,12 +44,27 @@ func TestValidateArglessViewSQL(t *testing.T) {
 		})
 	}
 
+	// A [$...] token inside a SQL string literal is text, not a placeholder —
+	// it must not trip the validator (otherwise a whole source fails to load).
+	for _, sql := range []string{
+		"SELECT id FROM t WHERE note = 'ref [$auth.tenant_id] here'",
+		"SELECT id, 'has [$random] token' AS lbl FROM t WHERE user_id = [$auth.user_id]",
+		"SELECT id FROM t WHERE msg = 'it''s [$auth.user_ids]'",
+	} {
+		t.Run("ok/bracket in string literal", func(t *testing.T) {
+			if err := validateArglessViewSQL(viewDef("v", sql)); err != nil {
+				t.Errorf("[$...] inside a string literal must be ignored, got: %v (sql=%q)", err, sql)
+			}
+		})
+	}
+
 	invalid := []struct {
 		name, sql string
 	}{
 		{"custom claim not whitelisted", "SELECT id FROM t WHERE tenant = [$auth.tenant_id]"},
 		{"typo in placeholder", "SELECT id FROM t WHERE user_id = [$auth.user_ids]"},
 		{"unknown context var", "SELECT id FROM t WHERE x = [$some_arg]"},
+		{"real placeholder outside a nearby literal", "SELECT 'label' AS l FROM t WHERE tenant = [$auth.tenant_id]"},
 	}
 	for _, tt := range invalid {
 		t.Run("reject/"+tt.name, func(t *testing.T) {
@@ -57,5 +72,19 @@ func TestValidateArglessViewSQL(t *testing.T) {
 				t.Errorf("expected a compile error for %q, got nil", tt.sql)
 			}
 		})
+	}
+}
+
+func TestStripSQLStringLiterals(t *testing.T) {
+	cases := map[string]string{
+		"a = 'x' AND b = [$auth.user_id]":       "a = '' AND b = [$auth.user_id]",
+		"note = 'ref [$auth.tenant_id]'":        "note = ''",
+		"msg = 'it''s here' AND c = [$catalog]": "msg = '' AND c = [$catalog]",
+		"no literals here":                      "no literals here",
+	}
+	for in, want := range cases {
+		if got := stripSQLStringLiterals(in); got != want {
+			t.Errorf("stripSQLStringLiterals(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/pkg/catalog/compiler/rules/validate_definitions.go
+++ b/pkg/catalog/compiler/rules/validate_definitions.go
@@ -56,6 +56,12 @@ func (r *DefinitionValidator) ProcessAll(ctx base.CompilationContext) error {
 					return err
 				}
 			}
+			if ext.Directives.ForName(base.ObjectViewDirectiveName) != nil &&
+				ext.Directives.ForName(base.ViewArgsDirectiveName) == nil {
+				if err := validateArglessViewSQL(ext); err != nil {
+					return err
+				}
+			}
 			if err := validateArgDefaults(ext); err != nil {
 				return err
 			}
@@ -456,13 +462,6 @@ func validateFunctionSQL(def *ast.Definition) error {
 	return nil
 }
 
-// validateViewArgs validates @view + @args consistency:
-//   - The @args input type must exist and be INPUT_OBJECT
-//   - If @view has sql: argument, [$paramName] references must be either
-//     args input fields, known context placeholders ([$auth.*]), or [$catalog].
-//     Non-$-prefixed references like [table_name] are database table/view names
-//     resolved at runtime by Object.SQL() and are not validated here.
-//
 // validateArglessViewSQL validates the placeholder references in a @view(sql:)
 // template that has no @args. Only [$catalog] and the whitelisted [$auth.*]
 // context placeholders may appear — anything else (a custom token claim, a
@@ -470,13 +469,16 @@ func validateFunctionSQL(def *ast.Definition) error {
 // by Object.SQL() into invalid SQL, so it is rejected at compile time with a
 // clear message. (Views with @args are validated by validateViewArgs, which
 // additionally allows the view's own argument fields.)
+//
+// [$...] tokens inside SQL string literals are ignored — they are text, not
+// placeholders.
 func validateArglessViewSQL(def *ast.Definition) error {
 	viewDir := def.Directives.ForName(base.ObjectViewDirectiveName)
 	sql := base.DirectiveArgString(viewDir, base.ArgSQL)
 	if sql == "" {
 		return nil
 	}
-	for _, ref := range extractFieldsFromSQL(sql) {
+	for _, ref := range extractFieldsFromSQL(stripSQLStringLiterals(sql)) {
 		if !strings.HasPrefix(ref, "$") {
 			// No $ prefix → database table/column reference (e.g. [sales]).
 			continue
@@ -493,6 +495,38 @@ func validateArglessViewSQL(def *ast.Definition) error {
 	return nil
 }
 
+// stripSQLStringLiterals blanks the contents of single-quoted SQL string
+// literals (handling '' escapes) so that bracketed [$...] tokens appearing
+// inside text are not mistaken for placeholders. Structure outside the literals
+// is preserved.
+func stripSQLStringLiterals(sql string) string {
+	var b strings.Builder
+	b.Grow(len(sql))
+	inStr := false
+	for i := 0; i < len(sql); i++ {
+		c := sql[i]
+		if c == '\'' {
+			if inStr && i+1 < len(sql) && sql[i+1] == '\'' {
+				i++ // escaped quote inside a literal — stay inside
+				continue
+			}
+			inStr = !inStr
+			b.WriteByte(c)
+			continue
+		}
+		if !inStr {
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}
+
+// validateViewArgs validates @view + @args consistency:
+//   - The @args input type must exist and be INPUT_OBJECT
+//   - If @view has sql: argument, [$paramName] references must be either
+//     args input fields, known context placeholders ([$auth.*]), or [$catalog].
+//     Non-$-prefixed references like [table_name] are database table/view names
+//     resolved at runtime by Object.SQL() and are not validated here.
 func validateViewArgs(ctx base.CompilationContext, def *ast.Definition) error {
 	argsDir := def.Directives.ForName(base.ViewArgsDirectiveName)
 	argInputName := base.DirectiveArgString(argsDir, base.ArgName)

--- a/pkg/catalog/compiler/rules/validate_definitions.go
+++ b/pkg/catalog/compiler/rules/validate_definitions.go
@@ -30,9 +30,14 @@ func (r *DefinitionValidator) ProcessAll(ctx base.CompilationContext) error {
 				return err
 			}
 		}
-		// Validate @view + @args consistency
-		if def.Directives.ForName(base.ObjectViewDirectiveName) != nil && def.Directives.ForName(base.ViewArgsDirectiveName) != nil {
-			if err := validateViewArgs(ctx, def); err != nil {
+		// Validate @view SQL: @args consistency when the view declares @args,
+		// otherwise the context placeholders embedded in an argless @view(sql:).
+		if def.Directives.ForName(base.ObjectViewDirectiveName) != nil {
+			if def.Directives.ForName(base.ViewArgsDirectiveName) != nil {
+				if err := validateViewArgs(ctx, def); err != nil {
+					return err
+				}
+			} else if err := validateArglessViewSQL(def); err != nil {
 				return err
 			}
 		}
@@ -452,11 +457,42 @@ func validateFunctionSQL(def *ast.Definition) error {
 }
 
 // validateViewArgs validates @view + @args consistency:
-// - The @args input type must exist and be INPUT_OBJECT
-// - If @view has sql: argument, [$paramName] references must be either
-//   args input fields, known context placeholders ([$auth.*]), or [$catalog].
-//   Non-$-prefixed references like [table_name] are database table/view names
-//   resolved at runtime by Object.SQL() and are not validated here.
+//   - The @args input type must exist and be INPUT_OBJECT
+//   - If @view has sql: argument, [$paramName] references must be either
+//     args input fields, known context placeholders ([$auth.*]), or [$catalog].
+//     Non-$-prefixed references like [table_name] are database table/view names
+//     resolved at runtime by Object.SQL() and are not validated here.
+//
+// validateArglessViewSQL validates the placeholder references in a @view(sql:)
+// template that has no @args. Only [$catalog] and the whitelisted [$auth.*]
+// context placeholders may appear — anything else (a custom token claim, a
+// typo) would survive to runtime as an unresolved [$...] token and be mangled
+// by Object.SQL() into invalid SQL, so it is rejected at compile time with a
+// clear message. (Views with @args are validated by validateViewArgs, which
+// additionally allows the view's own argument fields.)
+func validateArglessViewSQL(def *ast.Definition) error {
+	viewDir := def.Directives.ForName(base.ObjectViewDirectiveName)
+	sql := base.DirectiveArgString(viewDir, base.ArgSQL)
+	if sql == "" {
+		return nil
+	}
+	for _, ref := range extractFieldsFromSQL(sql) {
+		if !strings.HasPrefix(ref, "$") {
+			// No $ prefix → database table/column reference (e.g. [sales]).
+			continue
+		}
+		if ref == base.CatalogSystemVariableName {
+			continue
+		}
+		if sdl.IsKnownPlaceholder("[" + ref + "]") {
+			continue
+		}
+		return gqlerror.ErrorPosf(viewDir.Position,
+			"@view on %q: sql references unknown placeholder \"[%s]\"; an argless view may only use [$catalog] and the built-in [$auth.*] placeholders", def.Name, ref)
+	}
+	return nil
+}
+
 func validateViewArgs(ctx base.CompilationContext, def *ast.Definition) error {
 	argsDir := def.Directives.ForName(base.ViewArgsDirectiveName)
 	argInputName := base.DirectiveArgString(argsDir, base.ArgName)

--- a/pkg/catalog/compiler/rules/validate_definitions.go
+++ b/pkg/catalog/compiler/rules/validate_definitions.go
@@ -496,7 +496,7 @@ func validateArglessViewSQL(def *ast.Definition) error {
 }
 
 // stripSQLStringLiterals blanks the contents of single-quoted SQL string
-// literals (handling '' escapes) so that bracketed [$...] tokens appearing
+// literals (handling ” escapes) so that bracketed [$...] tokens appearing
 // inside text are not mistaken for placeholders. Structure outside the literals
 // is preserved.
 func stripSQLStringLiterals(sql string) string {

--- a/pkg/catalog/sdl/objects.go
+++ b/pkg/catalog/sdl/objects.go
@@ -168,10 +168,11 @@ type sqlBuilder interface {
 
 func (info *Object) ApplyArguments(ctx context.Context, defs base.DefinitionsSource, args map[string]any, builder sqlBuilder, contextVars map[string]any) (err error) {
 	if !info.HasArguments() {
-		// A view without @args can still embed context placeholders
-		// ([$auth.*]) directly in its @view(sql:) template; resolve those even
-		// though there is no argument input type to iterate.
-		if info.sql != "" && sqlHasContextPlaceholder(info.sql) {
+		// A view without @args can still embed context placeholders ([$auth.*])
+		// directly in its @view(sql:) template; resolve those even though there
+		// is no argument input type to iterate. For a plain table info.sql is
+		// empty, so this is a no-op.
+		if info.sql != "" {
 			return info.substituteContextPlaceholders(builder, contextVars)
 		}
 		return nil
@@ -265,7 +266,15 @@ func (info *Object) substituteContextPlaceholders(builder sqlBuilder, contextVar
 		if !strings.Contains(info.sql, placeholder) {
 			continue
 		}
-		sv, sverr := builder.SQLValue(contextVars[placeholder])
+		// An empty context value (nil, "", or 0 — an unauthenticated request, or
+		// a non-numeric/absent user id for [$auth.user_id_int]) renders as NULL,
+		// so a "col = [$auth.*]" predicate matches nothing instead of silently
+		// matching col = 0. Mirrors the function/@arg_default path.
+		value := contextVars[placeholder]
+		if IsEmptyContextValue(value) {
+			value = nil
+		}
+		sv, sverr := builder.SQLValue(value)
 		if sverr != nil {
 			return ErrorPosf(info.def.Position, "wrong context value for placeholder %s: %s", placeholder, sverr.Error())
 		}
@@ -292,7 +301,8 @@ func inputHasArgDefault(def *ast.Definition) bool {
 }
 
 // sqlHasContextPlaceholder returns true if the SQL string contains any known
-// context placeholder ([$auth.*], [$catalog]).
+// context placeholder (the whitelisted [$auth.*] set). [$catalog] is resolved
+// separately by Object.SQL(), so it is intentionally not detected here.
 func sqlHasContextPlaceholder(sql string) bool {
 	if sql == "" {
 		return false

--- a/pkg/catalog/sdl/objects.go
+++ b/pkg/catalog/sdl/objects.go
@@ -202,6 +202,13 @@ func (info *Object) ApplyArguments(ctx context.Context, defs base.DefinitionsSou
 			}
 			placeholder := base.DirectiveArgString(d, base.ArgValue)
 			val := contextVars[placeholder]
+			// An empty server-injected value (nil/""/0 — e.g. an unauthenticated
+			// request or a non-numeric user id for [$auth.user_id_int]) becomes
+			// NULL, so "col = [$auth.*]" matches nothing instead of matching 0/''.
+			// Client-provided args below are left as-is (a client 0 means 0).
+			if IsEmptyContextValue(val) {
+				val = nil
+			}
 			if info.sql != "" {
 				sv, sverr := builder.SQLValue(val)
 				if sverr != nil {

--- a/pkg/catalog/sdl/objects_test.go
+++ b/pkg/catalog/sdl/objects_test.go
@@ -75,25 +75,48 @@ func TestSubstituteContextPlaceholders(t *testing.T) {
 	}
 }
 
-// An unauthenticated request has no value for the placeholder — it must render
-// as NULL, not be left as a literal placeholder string.
-func TestSubstituteContextPlaceholders_MissingValueIsNull(t *testing.T) {
-	v := newView("SELECT * FROM t WHERE user_id = [$auth.user_id]")
-	if err := v.substituteContextPlaceholders(mockSQLBuilder{}, nil); err != nil {
+// An empty context value (unauthenticated request → nil, empty string, or a
+// zero user_id_int from a non-numeric id) must render as NULL, not as a literal
+// placeholder string or a bare 0 — otherwise "col = [$auth.*]" would silently
+// match col = 0. Mirrors the function/@arg_default path.
+func TestSubstituteContextPlaceholders_EmptyValueIsNull(t *testing.T) {
+	cases := []struct {
+		name string
+		vars map[string]any
+	}{
+		{"nil vars (unauthenticated)", nil},
+		{"empty string user_id", map[string]any{"[$auth.user_id]": ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := newView("SELECT * FROM t WHERE user_id = [$auth.user_id]")
+			if err := v.substituteContextPlaceholders(mockSQLBuilder{}, tc.vars); err != nil {
+				t.Fatalf("substituteContextPlaceholders: %v", err)
+			}
+			if want := "SELECT * FROM t WHERE user_id = NULL"; v.sql != want {
+				t.Errorf("sql = %q, want %q", v.sql, want)
+			}
+		})
+	}
+
+	// zero user_id_int (non-numeric/absent id) must also coalesce to NULL,
+	// not render as literal 0.
+	v := newView("SELECT * FROM t WHERE category_id = [$auth.user_id_int]")
+	if err := v.substituteContextPlaceholders(mockSQLBuilder{}, map[string]any{"[$auth.user_id_int]": 0}); err != nil {
 		t.Fatalf("substituteContextPlaceholders: %v", err)
 	}
-	if want := "SELECT * FROM t WHERE user_id = NULL"; v.sql != want {
-		t.Errorf("sql = %q, want %q", v.sql, want)
+	if want := "SELECT * FROM t WHERE category_id = NULL"; v.sql != want {
+		t.Errorf("sql = %q, want %q (zero int must be NULL, not 0)", v.sql, want)
 	}
 }
 
 func TestSQLHasContextPlaceholder(t *testing.T) {
 	cases := map[string]bool{
-		"SELECT * FROM t WHERE user_id = [$auth.user_id]": true,
-		"SELECT * FROM t WHERE role = [$auth.role]":       true,
+		"SELECT * FROM t WHERE user_id = [$auth.user_id]":  true,
+		"SELECT * FROM t WHERE role = [$auth.role]":        true,
 		"SELECT * FROM t WHERE tenant = [$auth.tenant_id]": false, // custom claim
-		"SELECT * FROM t":                                  false,
-		"":                                                 false,
+		"SELECT * FROM t": false,
+		"":                false,
 	}
 	for sql, want := range cases {
 		if got := newView(sql).SQLHasContextPlaceholder(); got != want {

--- a/pkg/catalog/sdl/placeholders.go
+++ b/pkg/catalog/sdl/placeholders.go
@@ -29,3 +29,23 @@ var KnownArgPlaceholders = map[string]bool{
 func IsKnownPlaceholder(name string) bool {
 	return KnownArgPlaceholders[name]
 }
+
+// IsEmptyContextValue reports whether a context placeholder value is "empty"
+// for the purpose of NULL substitution. Treats nil, empty string, and zero
+// integer as empty — covers the [$auth.user_id_int] case where a non-numeric
+// or absent user id resolves to 0. Used by both the function/@arg_default path
+// and the @view(sql:) substitution so the same placeholder resolves to the
+// same SQL regardless of where it is embedded.
+func IsEmptyContextValue(v any) bool {
+	switch val := v.(type) {
+	case nil:
+		return true
+	case string:
+		return val == ""
+	case int:
+		return val == 0
+	case int64:
+		return val == 0
+	}
+	return false
+}

--- a/pkg/catalog/sdl/placeholders_test.go
+++ b/pkg/catalog/sdl/placeholders_test.go
@@ -2,6 +2,29 @@ package sdl
 
 import "testing"
 
+func TestIsEmptyContextValue(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		empty bool
+	}{
+		{"nil", nil, true},
+		{"empty string", "", true},
+		{"int zero", 0, true},
+		{"int64 zero", int64(0), true},
+		{"non-empty string", "alice", false},
+		{"int positive", 42, false},
+		{"int64 positive", int64(42), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsEmptyContextValue(tc.value); got != tc.empty {
+				t.Errorf("IsEmptyContextValue(%v) = %v, want %v", tc.value, got, tc.empty)
+			}
+		})
+	}
+}
+
 func TestIsKnownPlaceholder(t *testing.T) {
 	known := []string{
 		"[$auth.user_name]",
@@ -22,10 +45,10 @@ func TestIsKnownPlaceholder(t *testing.T) {
 
 	unknown := []string{
 		"",
-		"[$auth.userid]",  // typo
+		"[$auth.userid]", // typo
 		"[$auth]",
 		"[$random]",
-		"$auth.user_id",   // missing brackets
+		"$auth.user_id",  // missing brackets
 		"[$auth.user_id", // missing closing bracket
 		"user_id",
 		"[$catalog]", // intentionally NOT in @arg_default whitelist

--- a/pkg/planner/node_function_call.go
+++ b/pkg/planner/node_function_call.go
@@ -281,7 +281,7 @@ func functionCallSQL(ctx context.Context, defs base.DefinitionsSource, e engines
 		authVars := perm.AuthVars(ctx)
 		for argName, placeholder := range info.ArgDefaults {
 			value, ok := authVars[placeholder]
-			if !ok || isEmptyContextValue(value) {
+			if !ok || sdl.IsEmptyContextValue(value) {
 				sql = strings.ReplaceAll(sql, "["+argName+"]", "NULL")
 				continue
 			}
@@ -351,7 +351,7 @@ func substitutePlaceholders(ctx context.Context, sql string, params []any) (stri
 			continue
 		}
 		value, ok := authVars[placeholder]
-		if !ok || isEmptyContextValue(value) {
+		if !ok || sdl.IsEmptyContextValue(value) {
 			sql = strings.ReplaceAll(sql, placeholder, "NULL")
 			continue
 		}
@@ -359,23 +359,4 @@ func substitutePlaceholders(ctx context.Context, sql string, params []any) (stri
 		sql = strings.ReplaceAll(sql, placeholder, "$"+strconv.Itoa(len(params)))
 	}
 	return sql, params
-}
-
-// isEmptyContextValue reports whether a context placeholder value is "empty"
-// for the purpose of NULL substitution. Treats nil, empty string, and zero
-// integer as empty — covers the [$auth.user_id_int] case where strconv.Atoi
-// returns 0 for non-numeric/empty user IDs.
-func isEmptyContextValue(v any) bool {
-	if v == nil {
-		return true
-	}
-	switch val := v.(type) {
-	case string:
-		return val == ""
-	case int:
-		return val == 0
-	case int64:
-		return val == 0
-	}
-	return false
 }

--- a/pkg/planner/node_function_call_placeholders_test.go
+++ b/pkg/planner/node_function_call_placeholders_test.go
@@ -139,29 +139,6 @@ func TestSubstitutePlaceholders_UserIDIntZero(t *testing.T) {
 	}
 }
 
-func TestIsEmptyContextValue(t *testing.T) {
-	cases := []struct {
-		name  string
-		value any
-		empty bool
-	}{
-		{"nil", nil, true},
-		{"empty string", "", true},
-		{"int zero", 0, true},
-		{"int64 zero", int64(0), true},
-		{"non-empty string", "alice", false},
-		{"int positive", 42, false},
-		{"int64 positive", int64(42), false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isEmptyContextValue(tc.value); got != tc.empty {
-				t.Errorf("isEmptyContextValue(%v) = %v, want %v", tc.value, got, tc.empty)
-			}
-		})
-	}
-}
-
 func TestSubstitutePlaceholders_CatalogNotInWhitelist(t *testing.T) {
 	// [$catalog] is intentionally NOT in KnownArgPlaceholders. It is resolved
 	// upstream by Function.SQL() before substitutePlaceholders runs, so the


### PR DESCRIPTION
Self-review (workflow, high effort) of #132 — 8 finder angles × independent verify, 7 confirmed. Fixes below; the known cache-key follow-up (`@cache` + `[$auth.user_id]` shared across same-role users) is tracked separately and not addressed here.

## Correctness

**NULL-coalescing parity (findings #1/#2).** The `@view(sql:)` substitution passed the raw context value to `SQLValue`, so an empty identity — `[$auth.user_id_int]=0` for a non-numeric/absent user id, or an unauthenticated request — rendered as literal `0` and matched `category_id = 0` rows, while the function/`@arg_default` path rendered `NULL`. The same placeholder produced different SQL depending on where it was embedded. Both paths now share `sdl.IsEmptyContextValue` (moved from the planner), so an empty value → `NULL` everywhere and `col = [$auth.*]` matches nothing.

**Compile-time validation for argless views (findings #3/#4).** `validateViewArgs` only ran for `@view + @args`. An argless `@view(sql:)` embedding a custom claim (`[$auth.tenant_id]`) or a typo'd placeholder compiled fine, then produced **mangled SQL at runtime** (`Object.SQL()` rewrites an unresolved `[$...]` token into invalid SQL). New `validateArglessViewSQL` rejects any non-whitelisted `[$...]` token at compile time with a clear message — only `[$catalog]` and the built-in `[$auth.*]` set are allowed. (Arg-views were already validated by `validateViewArgs`.) This is also the clean enforcement of "custom claims are not usable in view SQL".

## Cleanup (findings #5/#6/#7)

- Dropped a redundant per-request SQL scan in `ApplyArguments` (was scanning the template 3×).
- Corrected stale `[$catalog]` doc comments.
- gofmt'd the new test map literal.

## Tests

- `objects_test.go`: empty/zero context value → `NULL` in view substitution.
- `validate_argless_view_test.go`: validation accepts whitelisted `[$auth.*]`/`[$catalog]`/plain columns, rejects custom claims and typos.
- `TestIsEmptyContextValue` moved to `sdl` alongside the function.
- Full e2e **223 passed, 0 failed**; golden + planner + sdl suites green.

Rides v0.3.40 with #132 and the cache-key follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)