### PR TITLE
fix(cache): key query cache per user, not just per role

### DIFF
--- a/integration-test/e2e/docker-compose.yml
+++ b/integration-test/e2e/docker-compose.yml
@@ -85,6 +85,9 @@ services:
       ALLOWED_ANONYMOUS: "true"
       ANONYMOUS_ROLE: "admin"
       ALLOWED_DB_API_KEYS: "true"
+      CACHE_L1_ENABLED: "true"
+      CACHE_L1_MAX_SIZE: "32"
+      CACHE_L1_MAX_ITEM_SIZE: "1048576"
     depends_on:
       postgres:
         condition: service_healthy
@@ -127,6 +130,9 @@ services:
       ALLOWED_ANONYMOUS: "true"
       ANONYMOUS_ROLE: "admin"
       ALLOWED_DB_API_KEYS: "true"
+      CACHE_L1_ENABLED: "true"
+      CACHE_L1_MAX_SIZE: "32"
+      CACHE_L1_MAX_ITEM_SIZE: "1048576"
     depends_on:
       core-postgres:
         condition: service_healthy

--- a/integration-test/e2e/testdata/queries/permissions/cache_per_user/01_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/cache_per_user/01_expected.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "core": {
+      "insert_roles": {
+        "name": "e2e_cache_user"
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/cache_per_user/01_setup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/cache_per_user/01_setup.graphql
@@ -1,0 +1,13 @@
+mutation {
+  core {
+    insert_roles(data: {
+      name: "e2e_cache_user"
+      description: "E2E per-user cache role"
+      permissions: [
+        { type_name: "data-object:query", field_name: "pg_store_products", filter: { category_id: { eq: "[$auth.user_id_int]" } } }
+      ]
+    }) {
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/cache_per_user/02_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/cache_per_user/02_expected.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "pg_store": {
+      "products": [
+        {
+          "category_id": 2,
+          "id": 1,
+          "name": "Laptop Pro"
+        },
+        {
+          "category_id": 2,
+          "id": 5,
+          "name": "Gaming Desktop"
+        }
+      ]
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/cache_per_user/02_user_a.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/cache_per_user/02_user_a.graphql
@@ -1,0 +1,14 @@
+# User A (user_id=2). The @cache'd query is byte-identical to user B's step,
+# so under the old role-only cache key both would share one entry. The role's
+# data-object filter scopes products to category_id = [$auth.user_id_int], so
+# A must see only category-2 products — and B (next step) must NOT get A's
+# cached rows.
+{
+  pg_store {
+    products(order_by: [{ field: "id", direction: ASC }]) @cache(ttl: "300s") {
+      id
+      name
+      category_id
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/cache_per_user/02_user_a.headers
+++ b/integration-test/e2e/testdata/queries/permissions/cache_per_user/02_user_a.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_cache_user
+x-hugr-impersonated-user-id: 2
+x-hugr-impersonated-user-name: User Two

--- a/integration-test/e2e/testdata/queries/permissions/cache_per_user/03_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/cache_per_user/03_expected.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "pg_store": {
+      "products": [
+        {
+          "category_id": 3,
+          "id": 2,
+          "name": "Wireless Mouse"
+        },
+        {
+          "category_id": 3,
+          "id": 3,
+          "name": "USB-C Hub"
+        },
+        {
+          "category_id": 3,
+          "id": 4,
+          "name": "Old Keyboard"
+        }
+      ]
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/cache_per_user/03_user_b.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/cache_per_user/03_user_b.graphql
@@ -1,0 +1,14 @@
+# User A (user_id=2). The @cache'd query is byte-identical to user B's step,
+# so under the old role-only cache key both would share one entry. The role's
+# data-object filter scopes products to category_id = [$auth.user_id_int], so
+# A must see only category-2 products — and B (next step) must NOT get A's
+# cached rows.
+{
+  pg_store {
+    products(order_by: [{ field: "id", direction: ASC }]) @cache(ttl: "300s") {
+      id
+      name
+      category_id
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/cache_per_user/03_user_b.headers
+++ b/integration-test/e2e/testdata/queries/permissions/cache_per_user/03_user_b.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_cache_user
+x-hugr-impersonated-user-id: 3
+x-hugr-impersonated-user-name: User Three

--- a/integration-test/e2e/testdata/queries/permissions/cache_per_user/04_cleanup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/cache_per_user/04_cleanup.graphql
@@ -1,0 +1,10 @@
+mutation {
+  core {
+    delete_role_permissions(filter: { role: { eq: "e2e_cache_user" } }) {
+      success
+    }
+    delete_roles(filter: { name: { eq: "e2e_cache_user" } }) {
+      success
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/cache_per_user/04_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/cache_per_user/04_expected.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "core": {
+      "delete_role_permissions": {
+        "success": true
+      },
+      "delete_roles": {
+        "success": true
+      }
+    }
+  }
+}

--- a/pkg/cache/service.go
+++ b/pkg/cache/service.go
@@ -65,13 +65,18 @@ func (s *Service) Init(ctx context.Context) error {
 	return nil
 }
 
+// formatKey namespaces the cache key by the caller's identity. It includes
+// both the role AND the user id, so a query whose result depends on the user
+// (an RLS filter or a view/function SQL using [$auth.user_id], etc.) is never
+// served from another user's cache entry — even for users sharing a role.
+// Role is kept alongside the user id because impersonation reuses a user id
+// under a different (target) role, and anonymous requests have an empty id.
 func (s *Service) formatKey(ctx context.Context, key string) string {
 	ai := auth.AuthInfoFromContext(ctx)
-	if ai != nil {
-		key = fmt.Sprintf("%s:%s", ai.Role, key)
+	if ai == nil {
+		return key
 	}
-
-	return key
+	return fmt.Sprintf("%s:%s:%s", ai.Role, ai.UserId, key)
 }
 
 func (s *Service) Get(ctx context.Context, key string) (any, error) {

--- a/pkg/cache/service.go
+++ b/pkg/cache/service.go
@@ -65,26 +65,51 @@ func (s *Service) Init(ctx context.Context) error {
 	return nil
 }
 
-// formatKey namespaces the cache key by the caller's identity. It includes
-// both the role AND the user id, so a query whose result depends on the user
-// (an RLS filter or a view/function SQL using [$auth.user_id], etc.) is never
-// served from another user's cache entry — even for users sharing a role.
-// Role is kept alongside the user id because impersonation reuses a user id
-// under a different (target) role, and anonymous requests have an empty id.
+// formatKey namespaces the cache key by the caller's identity, so a cached
+// result is never served to a different identity whose result could differ:
+//
+//   - Full-access requests bypass row-level security (query.go), so their
+//     result is identity-independent; they share a single "fa" namespace. (An
+//     internal full-access query with an explicit cache key — e.g. the
+//     per-role RolePermissions query — thus stays keyed once per that key, not
+//     per user.)
+//   - Otherwise the namespace is a hash of (role, user id). Hashing rather than
+//     joining with a separator keeps the namespace collision-free even when a
+//     role or user id is attacker-controlled or contains the separator.
+//
+// Known limitation: the namespace covers role + user id only. A cached query
+// whose result depends on another auth dimension not reflected in the user id
+// — impersonated_by_*, or a custom token claim used in an RLS filter such as
+// [$auth.org_id] — is NOT distinguished, and such a query must not rely on the
+// cache for isolation on that dimension.
 func (s *Service) formatKey(ctx context.Context, key string) string {
+	if auth.IsFullAccess(ctx) {
+		return "fa:" + key
+	}
 	ai := auth.AuthInfoFromContext(ctx)
 	if ai == nil {
 		return key
 	}
-	return fmt.Sprintf("%s:%s:%s", ai.Role, ai.UserId, key)
+	return identityNamespace(ai.Role, ai.UserId) + ":" + key
+}
+
+// identityNamespace returns a collision-free hash of the identity components.
+// Length-prefixing before hashing guarantees distinct (role, user id) pairs
+// never map to the same namespace regardless of their contents.
+func identityNamespace(role, userID string) string {
+	return fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%d:%s%d:%s", len(role), role, len(userID), userID)))
 }
 
 func (s *Service) Get(ctx context.Context, key string) (any, error) {
 	if !s.enabled {
 		return nil, ErrMissCache
 	}
+	return s.getFormatted(ctx, s.formatKey(ctx, key))
+}
+
+func (s *Service) getFormatted(ctx context.Context, formattedKey string) (any, error) {
 	var item CacheItem
-	v, err := s.cache.Get(ctx, s.formatKey(ctx, key), &item)
+	v, err := s.cache.Get(ctx, formattedKey, &item)
 	if err != nil || v == nil {
 		return nil, ErrMissCache
 	}
@@ -95,6 +120,10 @@ func (s *Service) Set(ctx context.Context, key string, data any, options ...Opti
 	if !s.enabled {
 		return nil
 	}
+	return s.setFormatted(ctx, s.formatKey(ctx, key), data, options...)
+}
+
+func (s *Service) setFormatted(ctx context.Context, formattedKey string, data any, options ...Option) error {
 	item, err := NewCacheItem(data)
 	if err != nil {
 		return err
@@ -104,22 +133,26 @@ func (s *Service) Set(ctx context.Context, key string, data any, options ...Opti
 		opt(o)
 	}
 
-	return s.cache.Set(ctx, s.formatKey(ctx, key), item, o.toStoreOptions()...)
+	return s.cache.Set(ctx, formattedKey, item, o.toStoreOptions()...)
 }
 
 func (s *Service) Load(ctx context.Context, key string, fn func() (any, error), options ...Option) (any, error) {
 	if !s.enabled {
 		return fn()
 	}
-	v, err := s.Get(ctx, key)
+	// Namespace the key by identity ONCE and use it for the singleflight group
+	// too — deduping on the bare key would coalesce concurrent identical queries
+	// from DIFFERENT identities and hand one caller another's result.
+	fk := s.formatKey(ctx, key)
+	v, err := s.getFormatted(ctx, fk)
 	if err == nil {
 		return v, nil
 	}
 	if !errors.Is(err, ErrMissCache) {
 		return nil, err
 	}
-	v, err, _ = s.group.Do(key, func() (any, error) {
-		v, err := s.Get(ctx, key)
+	v, err, _ = s.group.Do(fk, func() (any, error) {
+		v, err := s.getFormatted(ctx, fk)
 		if err == nil {
 			return v, nil
 		}
@@ -130,8 +163,7 @@ func (s *Service) Load(ctx context.Context, key string, fn func() (any, error), 
 		if err != nil {
 			return nil, err
 		}
-		err = s.Set(ctx, key, v, options...)
-		if err != nil {
+		if err = s.setFormatted(ctx, fk, v, options...); err != nil {
 			return nil, err
 		}
 		return v, nil
@@ -140,6 +172,10 @@ func (s *Service) Load(ctx context.Context, key string, fn func() (any, error), 
 	return v, err
 }
 
+// Delete removes the CALLER's cache entry for key. With per-identity
+// namespacing this clears only the acting identity's copy; cross-identity
+// invalidation (e.g. after a mutation) must use tag-based Invalidate, which is
+// identity-independent.
 func (s *Service) Delete(ctx context.Context, key string) error {
 	if !s.enabled {
 		return nil

--- a/pkg/cache/service_test.go
+++ b/pkg/cache/service_test.go
@@ -2,48 +2,164 @@ package cache
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/hugr-lab/query-engine/pkg/auth"
+	"github.com/hugr-lab/query-engine/pkg/catalog/types"
 )
 
-func TestFormatKey_PerUser(t *testing.T) {
+func ctxUser(role, userID string) context.Context {
+	return auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{Role: role, UserId: userID})
+}
+
+func TestFormatKey_Identity(t *testing.T) {
 	s := &Service{}
-	ctxFor := func(role, userID string) context.Context {
-		return auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{Role: role, UserId: userID})
-	}
 
-	// The key must carry both role and user id.
-	if got, want := s.formatKey(ctxFor("agent", "u1"), "q"), "agent:u1:q"; got != want {
-		t.Errorf("formatKey = %q, want %q", got, want)
+	// Distinct identities must produce distinct keys; the same identity a
+	// stable one.
+	a := s.formatKey(ctxUser("agent", "u1"), "q")
+	a2 := s.formatKey(ctxUser("agent", "u1"), "q")
+	b := s.formatKey(ctxUser("agent", "u2"), "q")
+	if a != a2 {
+		t.Errorf("same identity not stable: %q vs %q", a, a2)
 	}
-
-	// Two users of the SAME role must get different keys (the leak this fixes).
-	a := s.formatKey(ctxFor("agent", "u1"), "q")
-	b := s.formatKey(ctxFor("agent", "u2"), "q")
 	if a == b {
-		t.Errorf("same-role different-user keys collided: both %q", a)
+		t.Errorf("same-role different-user keys collided: %q", a)
 	}
 
-	// The SAME user must get a stable key.
-	if a2 := s.formatKey(ctxFor("agent", "u1"), "q"); a2 != a {
-		t.Errorf("same user key not stable: %q vs %q", a, a2)
+	// Role is part of the identity (same user id, different role differs).
+	if s.formatKey(ctxUser("admin", "u1"), "q") == a {
+		t.Errorf("role not part of the key")
 	}
 
-	// A different role for the same user id must differ (impersonation reuses ids).
-	if s.formatKey(ctxFor("admin", "u1"), "q") == a {
-		t.Errorf("role is not part of the key")
+	// The ':' delimiter must not let identity components collide:
+	// (role="a", user="b:c") must differ from (role="a:b", user="c").
+	if s.formatKey(ctxUser("a", "b:c"), "q") == s.formatKey(ctxUser("a:b", "c"), "q") {
+		t.Errorf("delimiter collision between (a, b:c) and (a:b, c)")
 	}
 
-	// No AuthInfo → bare key (no identity prefix).
+	// The trailing key still varies the result.
+	if s.formatKey(ctxUser("agent", "u1"), "q") == s.formatKey(ctxUser("agent", "u1"), "other") {
+		t.Errorf("different query keys must differ")
+	}
+
+	// No AuthInfo → bare key.
 	if got := s.formatKey(context.Background(), "q"); got != "q" {
 		t.Errorf("formatKey without auth = %q, want %q", got, "q")
 	}
 
-	// Anonymous (empty user id) → shared key across anonymous callers.
-	anon1 := s.formatKey(ctxFor("public", ""), "q")
-	anon2 := s.formatKey(ctxFor("public", ""), "q")
-	if anon1 != anon2 || anon1 != "public::q" {
-		t.Errorf("anonymous keys = %q / %q, want stable %q", anon1, anon2, "public::q")
+	// Anonymous (role=public, user=anonymous per AnonymousProvider) is stable
+	// and shared across anonymous callers, but distinct from other identities.
+	an1 := s.formatKey(ctxUser("public", "anonymous"), "q")
+	an2 := s.formatKey(ctxUser("public", "anonymous"), "q")
+	if an1 != an2 || an1 == a {
+		t.Errorf("anonymous key unstable or collided: %q / %q", an1, an2)
+	}
+}
+
+func TestFormatKey_FullAccess(t *testing.T) {
+	s := &Service{}
+	fa := s.formatKey(auth.ContextWithFullAccess(ctxUser("agent", "u1")), "q")
+	if fa != "fa:q" {
+		t.Errorf("full-access key = %q, want %q", fa, "fa:q")
+	}
+	// Full-access is identity-independent: a different caller's full-access
+	// request for the same key shares the namespace.
+	if other := s.formatKey(auth.ContextWithFullAccess(ctxUser("admin", "u9")), "q"); other != fa {
+		t.Errorf("full-access keys differ by identity: %q vs %q", other, fa)
+	}
+	// ... and differs from a non-full-access request of the same identity.
+	if s.formatKey(ctxUser("agent", "u1"), "q") == fa {
+		t.Errorf("full-access and normal request share a key")
+	}
+}
+
+func newTestService(t *testing.T) *Service {
+	t.Helper()
+	s := New(Config{
+		L1: L1Config{Enabled: true, MaxSize: 8, MaxItemSize: 1 << 20, EvictionTime: types.Interval(time.Minute)},
+	})
+	if err := s.Init(context.Background()); err != nil {
+		t.Fatalf("cache Init: %v", err)
+	}
+	return s
+}
+
+// Regression for the singleflight leak: two concurrent identical @cache'd
+// queries from DIFFERENT identities must each run their own fn and get their
+// own result. Under a bare (un-namespaced) singleflight key they would coalesce
+// and one caller would receive the other's result.
+func TestLoad_SingleflightPerIdentity(t *testing.T) {
+	s := newTestService(t)
+
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	fn := func(id string) func() (any, error) {
+		return func() (any, error) {
+			entered <- struct{}{}
+			<-release // hold in-flight until BOTH callers have entered
+			return id, nil
+		}
+	}
+
+	var wg sync.WaitGroup
+	var resA, resB any
+	wg.Add(2)
+	go func() { defer wg.Done(); resA, _ = s.Load(ctxUser("agent", "a"), "k", fn("A")) }()
+	go func() { defer wg.Done(); resB, _ = s.Load(ctxUser("agent", "b"), "k", fn("B")) }()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-entered:
+		case <-time.After(3 * time.Second):
+			close(release)
+			t.Fatal("only one fn ran — concurrent identities coalesced (singleflight used a bare key)")
+		}
+	}
+	close(release)
+	wg.Wait()
+
+	if resA != "A" || resB != "B" {
+		t.Fatalf("resA=%v resB=%v, want A/B (identities must not share a singleflight result)", resA, resB)
+	}
+}
+
+// Same identity + same key MUST coalesce (that is the point of singleflight):
+// one fn runs, both callers get its result.
+func TestLoad_SingleflightSameIdentityCoalesces(t *testing.T) {
+	s := newTestService(t)
+
+	var calls int
+	var mu sync.Mutex
+	release := make(chan struct{})
+	started := make(chan struct{}, 2)
+	fn := func() (any, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		started <- struct{}{}
+		<-release
+		return "shared", nil
+	}
+
+	ctx := ctxUser("agent", "same")
+	var wg sync.WaitGroup
+	var r1, r2 any
+	wg.Add(2)
+	go func() { defer wg.Done(); r1, _ = s.Load(ctx, "k", fn) }()
+	// ensure the first is in-flight before the second joins the group
+	<-started
+	go func() { defer wg.Done(); r2, _ = s.Load(ctx, "k", fn) }()
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if r1 != "shared" || r2 != "shared" {
+		t.Fatalf("r1=%v r2=%v, want both shared", r1, r2)
+	}
+	if calls != 1 {
+		t.Fatalf("fn ran %d times, want 1 (same identity must coalesce)", calls)
 	}
 }

--- a/pkg/cache/service_test.go
+++ b/pkg/cache/service_test.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/auth"
+)
+
+func TestFormatKey_PerUser(t *testing.T) {
+	s := &Service{}
+	ctxFor := func(role, userID string) context.Context {
+		return auth.ContextWithAuthInfo(context.Background(), &auth.AuthInfo{Role: role, UserId: userID})
+	}
+
+	// The key must carry both role and user id.
+	if got, want := s.formatKey(ctxFor("agent", "u1"), "q"), "agent:u1:q"; got != want {
+		t.Errorf("formatKey = %q, want %q", got, want)
+	}
+
+	// Two users of the SAME role must get different keys (the leak this fixes).
+	a := s.formatKey(ctxFor("agent", "u1"), "q")
+	b := s.formatKey(ctxFor("agent", "u2"), "q")
+	if a == b {
+		t.Errorf("same-role different-user keys collided: both %q", a)
+	}
+
+	// The SAME user must get a stable key.
+	if a2 := s.formatKey(ctxFor("agent", "u1"), "q"); a2 != a {
+		t.Errorf("same user key not stable: %q vs %q", a, a2)
+	}
+
+	// A different role for the same user id must differ (impersonation reuses ids).
+	if s.formatKey(ctxFor("admin", "u1"), "q") == a {
+		t.Errorf("role is not part of the key")
+	}
+
+	// No AuthInfo → bare key (no identity prefix).
+	if got := s.formatKey(context.Background(), "q"); got != "q" {
+		t.Errorf("formatKey without auth = %q, want %q", got, "q")
+	}
+
+	// Anonymous (empty user id) → shared key across anonymous callers.
+	anon1 := s.formatKey(ctxFor("public", ""), "q")
+	anon2 := s.formatKey(ctxFor("public", ""), "q")
+	if anon1 != anon2 || anon1 != "public::q" {
+		t.Errorf("anonymous keys = %q / %q, want stable %q", anon1, anon2, "public::q")
+	}
+}


### PR DESCRIPTION
The query-result cache key was namespaced only by **role** (`cache/service.go:formatKey` → `role:<querykey>`). So a `@cache`d query whose result depends on the **user** — an RLS `filter` using `[$auth.user_id]`, or a view/function whose SQL embeds a user-identity placeholder — was served from **another user's** cache entry when both share a role. Cross-user data leak.

## Change

`formatKey` now includes the user id: `role:user_id:key`. Role is kept alongside because impersonation reuses a user id under a different (target) role, and anonymous requests have an empty id. `Get`/`Set`/`Delete` all route through `formatKey`, so read/write/invalidation stay consistent.

## Why unconditional (design decision)

Every cached query is now per-user, rather than detecting which queries actually depend on the user. The precise alternative (a `@per_user_cache` schema directive + per-role user-scoped-type sets + a validation-walk hook — see `design/plan-per-user-cache-key.md`) was far more machinery and easy to get subtly wrong; always-per-user is always safe. **Trade-off accepted:** cache entries multiply per user for queries that are role-uniform (memory / hit-rate).

## Tests

- **Unit** (`pkg/cache/service_test.go`, first tests in the package): `role:user_id:key`; distinct users ⇒ distinct keys; same user stable; role still part of the key; nil AuthInfo ⇒ bare key; anonymous (empty id) shared.
- **E2E** `permissions/cache_per_user`: two impersonated users of one role run a **byte-identical** `@cache`d query scoped by a `[$auth.user_id_int]` filter → user A gets category-2 rows, user B gets category-3 rows (not A's cached rows). Under the old role-only key B would have hit A's entry — a true regression test with caching active. L1 in-memory cache enabled on both core-DB engines in the stack (bounded size to avoid bigcache over-allocation).
- Full e2e **225 passed, 0 failed**; `pkg/...` unit sweep green.

Rides v0.3.40 with the argless-view placeholder work (#132/#133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)