### PR TITLE
perf(perm): drop duplicate permission load on the IPC query path

### DIFF
--- a/ipc-query.go
+++ b/ipc-query.go
@@ -60,12 +60,11 @@ func (s *Service) ipcMultiPartHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Service) queryIPC(ctx context.Context, mw *multipart.Writer, req types.Request) error {
-	// add permissions to context
-	ctx, err := s.perm.ContextWithPermissions(ctx)
-	if err != nil {
-		return err
-	}
-
+	// Permissions are already loaded into ctx by checkEndpointPermissionsMW
+	// (for the request's identity, including header-based impersonation), so we
+	// do not reload them here. The streaming path differs: it applies
+	// message-level impersonation and reloads permissions in
+	// applyMessageImpersonation.
 	op, err := s.schema.ParseQuery(ctx, req.Query, req.Variables, req.OperationName)
 	if err != nil {
 		if errs, ok := err.(gqlerror.List); ok {

--- a/middlewares.go
+++ b/middlewares.go
@@ -90,6 +90,15 @@ func (s *Service) checkEndpointPermissionsMW(next http.Handler) http.Handler {
 		}
 		perm := perm.PermissionsFromCtx(ctx)
 		if perm == nil {
+			// Currently unreachable: ContextWithPermissions above stores a
+			// non-nil *RolePermissions on success (and returns 403 when the
+			// request has no identity), and this middleware is only installed
+			// when perm enforcement is enabled. This middleware is the single
+			// source of permissions for the endpoint handlers (queryIPC,
+			// queryHandler no longer reload them), so if a future nil-perms
+			// path ever makes this branch reachable, the request would run with
+			// no permission checker — i.e. open access. Prefer failing closed
+			// (403) here if such a path is ever introduced.
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}

--- a/pkg/perm/permissions.go
+++ b/pkg/perm/permissions.go
@@ -8,9 +8,9 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/hugr-lab/query-engine/pkg/auth"
-	"github.com/hugr-lab/query-engine/pkg/engines"
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
 	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
+	"github.com/hugr-lab/query-engine/pkg/engines"
 )
 
 type RolePermissions struct {
@@ -53,7 +53,6 @@ func (r *RolePermissions) CheckQuery(query *ast.Field) error {
 
 	return nil
 }
-
 
 func (r *RolePermissions) CheckMutationInput(ctx context.Context, defs base.DefinitionsSource, inputName string, data map[string]any) error {
 	if r.Disabled {

--- a/pkg/perm/validation_rule.go
+++ b/pkg/perm/validation_rule.go
@@ -13,6 +13,9 @@ import (
 type PermissionFieldRule struct{}
 
 func (r *PermissionFieldRule) EnterField(ctx *validator.WalkContext, parentDef *ast.Definition, field *ast.Field) gqlerror.List {
+	if auth.IsFullAccess(ctx.Context) {
+		return nil
+	}
 	checker := PermissionsFromCtx(ctx.Context)
 	if checker == nil || parentDef == nil {
 		return nil


### PR DESCRIPTION
## What

- **Remove a duplicate role-permission load on the `/ipc` (non-streaming) query path.** The IPC handler is behind `checkEndpointPermissionsMW`, which already calls `ContextWithPermissions` and propagates the enriched ctx via `r.WithContext`. `queryIPC` reloaded permissions a second time — a redundant CoreDB round-trip on every IPC query. It now uses the permissions the middleware put in ctx.
- **Skip field-level permission validation for full-access requests** (`PermissionFieldRule.EnterField` short-circuits on `auth.IsFullAccess`). Full-access bypasses RLS in the planner, so field validation is moot for it. Only internal full-access queries (cluster / data-source / cache ops under `ContextWithFullAccess`) are affected — regular client requests are never full-access.

## Not touched: the streaming path

`ipc-stream.go`'s only `ContextWithPermissions` (in `applyMessageImpersonation`) is **not** a duplicate — it reloads permissions when a stream applies **message-level** impersonation (identity from the message body, not headers). Removing it would run impersonated stream messages under the original role's permissions. Left as-is.

## Correctness

- IPC-query impersonation comes from HTTP headers (`x-hugr-impersonated-*`) applied by the auth middleware; `types.Request` carries no impersonation fields. So the middleware's load already reflects the (possibly impersonated) identity — the removed call was purely redundant.

## Validation

- `integration-test/subscription` (Go client → `/ipc`, `types.AsUser` impersonation, secret-key admin = full-access): **all green** — `Admin_Query_AsUser`, `PublicRole_Query_Denied`, `Admin_UnknownRole_Forbidden`, `Anonymous_Query_AsUser`, subscribe variants.
- Full e2e (permissions + cluster forwarding): **225 passed, 0 failed**.
- Build + gofmt clean.

Rides v0.3.40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)