### PR TITLE
feat(introspection): _catalog logical-model meta queries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-21
 - N/A — the fix is entirely in-memory stream parsing. No schema migrations, no persisted state. (001-openai-responses-fc-args)
 - Go 1.26 (CGo via `duckdb-go/v2`, `duckdb_arrow` build tag — applies to engine/planner code; pure-Go constraint for `types/` and `client/` sub-modules). + stdlib (`encoding/json`, `reflect`, `sync`), `github.com/apache/arrow-go/v18`, `github.com/paulmach/orb` (+ `orb/geojson`, `orb/encoding/wkb`, `orb/encoding/wkt`), `github.com/duckdb/duckdb-go/v2` (CGo — engine layer only), `github.com/vektah/gqlparser/v2` (already present, used for AST walk in geometry-info extraction). (001-unified-scan)
 - None new. Planner schema/metadata storage unchanged. DuckDB runtime unchanged. (001-unified-scan)
+- Go 1.26 (`iter.Seq`, range-over-func), build tag `duckdb_arrow`, CGo via + `vektah/gqlparser/v2` (GraphQL AST — only dependency this feature (001-catalog-introspection)
+- N/A — reads the compiled schema through the existing `catalog.Provider` (static (001-catalog-introspection)
 
 ## Project Structure
 
@@ -55,6 +57,6 @@ Go 1.26: Follow standard conventions
 <!-- MANUAL ADDITIONS END -->
 
 ## Recent Changes
+- 001-catalog-introspection: Added Go 1.26 (`iter.Seq`, range-over-func), build tag `duckdb_arrow`, CGo via + `vektah/gqlparser/v2` (GraphQL AST — only dependency this feature
 - 001-unified-scan: Added Go 1.26 (CGo via `duckdb-go/v2`, `duckdb_arrow` build tag — applies to engine/planner code; pure-Go constraint for `types/` and `client/` sub-modules). + stdlib (`encoding/json`, `reflect`, `sync`), `github.com/apache/arrow-go/v18`, `github.com/paulmach/orb` (+ `orb/geojson`, `orb/encoding/wkb`, `orb/encoding/wkt`), `github.com/duckdb/duckdb-go/v2` (CGo — engine layer only), `github.com/vektah/gqlparser/v2` (already present, used for AST walk in geometry-info extraction).
 - 001-openai-responses-fc-args: Added Go 1.26 (via `duckdb_arrow` build tag; same as rest of `pkg/data-sources/sources/llm/`) + standard library only for the fix (`encoding/json`, `bufio`, `strings`, `io`); test paths use `github.com/stretchr/testify/require`, `assert`, and the existing subscription harness in `integration-test/models`.
-- 001-arrow-scanner: Added Go 1.26 (with `iter.Seq`, range-over-func)

--- a/integration-test/compiler/testdata/01_basic_table/expected/schema.graphql
+++ b/integration-test/compiler/testdata/01_basic_table/expected/schema.graphql
@@ -554,6 +554,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Widget_aggregation_bucket] @aggregation_query(name: "Widget", is_bucket: true) @catalog(name: "widgets", engine: "duckdb")
   Widget_by_pk(id: Int!): Widget @query(name: "Widget", type: SELECT_ONE) @catalog(name: "widgets", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -857,6 +876,230 @@ input Widget_mut_input_data @data_input(name: "Widget") @catalog(name: "widgets"
   id: Int
   name: String
   price: Float
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Widget_aggregation @aggregation(name: "Widget", is_bucket: false, level: 1) @catalog(name: "widgets", engine: "duckdb") {
   _created_at_part(

--- a/integration-test/compiler/testdata/01_basic_table/expected/schema.graphql
+++ b/integration-test/compiler/testdata/01_basic_table/expected/schema.graphql
@@ -573,6 +573,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1100,6 +1108,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 type _Widget_aggregation @aggregation(name: "Widget", is_bucket: false, level: 1) @catalog(name: "widgets", engine: "duckdb") {
   _created_at_part(

--- a/integration-test/compiler/testdata/02_table_with_default/expected/schema.graphql
+++ b/integration-test/compiler/testdata/02_table_with_default/expected/schema.graphql
@@ -628,6 +628,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1176,6 +1184,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/02_table_with_default/expected/schema.graphql
+++ b/integration-test/compiler/testdata/02_table_with_default/expected/schema.graphql
@@ -609,6 +609,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Item_aggregation_bucket] @aggregation_query(name: "Item", is_bucket: true) @catalog(name: "items", engine: "duckdb")
   Item_by_pk(id: Int!): Item @query(name: "Item", type: SELECT_ONE) @catalog(name: "items", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -854,6 +873,124 @@ input VectorSearchInput @system {
   """
   vector: Vector!
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
 type _Item_aggregation @aggregation(name: "Item", is_bucket: false, level: 1) @catalog(name: "items", engine: "duckdb") {
   _created_at_part(
     """
@@ -933,6 +1070,112 @@ type _Item_aggregation_sub_aggregation @aggregation(name: "_Item_aggregation", i
   id: IntSubAggregation @field_aggregation(name: "id")
   quantity: IntSubAggregation @field_aggregation(name: "quantity")
   status: StringSubAggregation @field_aggregation(name: "status")
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/03_table_with_unique/expected/schema.graphql
+++ b/integration-test/compiler/testdata/03_table_with_unique/expected/schema.graphql
@@ -575,6 +575,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1074,6 +1082,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 type _User_aggregation @aggregation(name: "User", is_bucket: false, level: 1) @catalog(name: "users", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/03_table_with_unique/expected/schema.graphql
+++ b/integration-test/compiler/testdata/03_table_with_unique/expected/schema.graphql
@@ -556,6 +556,25 @@ type Query @system {
   User_by_pk(id: Int!): User @query(name: "User", type: SELECT_ONE) @catalog(name: "users", engine: "duckdb")
   User_email(email: String!): User @query(name: "User", type: SELECT_ONE) @catalog(name: "users", engine: "duckdb")
   User_username(username: String!): User @query(name: "User", type: SELECT_ONE) @catalog(name: "users", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -831,6 +850,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _User_aggregation @aggregation(name: "User", is_bucket: false, level: 1) @catalog(name: "users", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/04_table_references/expected/schema.graphql
+++ b/integration-test/compiler/testdata/04_table_references/expected/schema.graphql
@@ -874,6 +874,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1587,6 +1595,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/04_table_references/expected/schema.graphql
+++ b/integration-test/compiler/testdata/04_table_references/expected/schema.graphql
@@ -855,6 +855,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Employee_aggregation_bucket] @aggregation_query(name: "Employee", is_bucket: true) @catalog(name: "hr", engine: "duckdb")
   Employee_by_pk(id: Int!): Employee @query(name: "Employee", type: SELECT_ONE) @catalog(name: "hr", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1100,6 +1119,83 @@ input VectorSearchInput @system {
   """
   vector: Vector!
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
 type _Department_aggregation @aggregation(name: "Department", is_bucket: false, level: 1) @catalog(name: "hr", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
   _rows_count: BigInt
@@ -1344,6 +1440,153 @@ type _Employee_aggregation_sub_aggregation @aggregation(name: "_Employee_aggrega
 }
 type _Employee_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Employee_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "hr", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/05_table_m2m/expected/schema.graphql
+++ b/integration-test/compiler/testdata/05_table_m2m/expected/schema.graphql
@@ -926,6 +926,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -2027,6 +2035,16 @@ type _Student_aggregation_sub_aggregation @aggregation(name: "_Student_aggregati
 }
 type _Student_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Student_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "school", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/05_table_m2m/expected/schema.graphql
+++ b/integration-test/compiler/testdata/05_table_m2m/expected/schema.graphql
@@ -907,6 +907,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Student_aggregation_bucket] @aggregation_query(name: "Student", is_bucket: true) @catalog(name: "school", engine: "duckdb")
   Student_by_pk(id: Int!): Student @query(name: "Student", type: SELECT_ONE) @catalog(name: "school", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1550,6 +1569,230 @@ type _Course_aggregation_sub_aggregation @aggregation(name: "_Course_aggregation
 }
 type _Course_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Course_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "school", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _StudentCourse_aggregation @aggregation(name: "StudentCourse", is_bucket: false, level: 1) @catalog(name: "school", engine: "duckdb") {
   _rows_count: BigInt

--- a/integration-test/compiler/testdata/06_view_simple/expected/schema.graphql
+++ b/integration-test/compiler/testdata/06_view_simple/expected/schema.graphql
@@ -611,6 +611,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1157,6 +1165,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/06_view_simple/expected/schema.graphql
+++ b/integration-test/compiler/testdata/06_view_simple/expected/schema.graphql
@@ -592,6 +592,25 @@ type Query @system {
     distinct_on: [String]
   ): [_ActiveUser_aggregation_bucket] @aggregation_query(name: "ActiveUser", is_bucket: true) @catalog(name: "reports", engine: "duckdb")
   ActiveUser_by_pk(id: Int!): ActiveUser @query(name: "ActiveUser", type: SELECT_ONE) @catalog(name: "reports", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -914,6 +933,230 @@ type _ActiveUser_aggregation_sub_aggregation @aggregation(name: "_ActiveUser_agg
     bucket_interval: Interval
   ): TimestampSubAggregation @field_aggregation(name: "last_login")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/07_view_parameterized/expected/schema.graphql
+++ b/integration-test/compiler/testdata/07_view_parameterized/expected/schema.graphql
@@ -695,6 +695,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1243,6 +1251,16 @@ type _SalesReport_aggregation_sub_aggregation @aggregation(name: "_SalesReport_a
   order_count: BigIntSubAggregation @field_aggregation(name: "order_count")
   product_id: IntSubAggregation @field_aggregation(name: "product_id")
   total_sales: FloatSubAggregation @field_aggregation(name: "total_sales")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 type _UserOrders_aggregation @aggregation(name: "UserOrders", is_bucket: false, level: 1) @catalog(name: "reports", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/07_view_parameterized/expected/schema.graphql
+++ b/integration-test/compiler/testdata/07_view_parameterized/expected/schema.graphql
@@ -676,6 +676,25 @@ type Query @system {
     """
     args: UserOrdersArgs
   order_id: Int!): UserOrders @query(name: "UserOrders", type: SELECT_ONE) @catalog(name: "reports", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -964,6 +983,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _SalesReport_aggregation @aggregation(name: "SalesReport", is_bucket: false, level: 1) @catalog(name: "reports", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/08_function/expected/schema.graphql
+++ b/integration-test/compiler/testdata/08_function/expected/schema.graphql
@@ -669,6 +669,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "airports")
@@ -1272,6 +1280,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/08_function/expected/schema.graphql
+++ b/integration-test/compiler/testdata/08_function/expected/schema.graphql
@@ -650,6 +650,25 @@ type Query @system {
   ): [_Airport_aggregation_bucket] @aggregation_query(name: "Airport", is_bucket: true) @catalog(name: "airports", engine: "duckdb")
   Airport_by_pk(iata_code: String!): Airport @query(name: "Airport", type: SELECT_ONE) @catalog(name: "airports", engine: "duckdb")
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "airports")
@@ -1029,6 +1048,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   ): GeometrySubAggregation @field_aggregation(name: "geom")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/09_module_nested/expected/schema.graphql
+++ b/integration-test/compiler/testdata/09_module_nested/expected/schema.graphql
@@ -564,6 +564,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1210,6 +1218,16 @@ type _Ship_aggregation_sub_aggregation @aggregation(name: "_Ship_aggregation", i
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
   tonnage: FloatSubAggregation @field_aggregation(name: "tonnage")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/09_module_nested/expected/schema.graphql
+++ b/integration-test/compiler/testdata/09_module_nested/expected/schema.graphql
@@ -545,6 +545,25 @@ enum OrderDirection @system {
   DESC
 }
 type Query @system {
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -854,6 +873,83 @@ type _Bus_aggregation_sub_aggregation @aggregation(name: "_Bus_aggregation", is_
   id: IntSubAggregation @field_aggregation(name: "id")
   route: StringSubAggregation @field_aggregation(name: "route")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
 type _Flight_aggregation @aggregation(name: "Flight", is_bucket: false, level: 1) @catalog(name: "transport", engine: "duckdb") {
   _departure_part(
     """
@@ -931,6 +1027,153 @@ type _Flight_aggregation_sub_aggregation @aggregation(name: "_Flight_aggregation
   ): TimestampSubAggregation @field_aggregation(name: "departure")
   flight_number: StringSubAggregation @field_aggregation(name: "flight_number")
   id: IntSubAggregation @field_aggregation(name: "id")
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Ship_aggregation @aggregation(name: "Ship", is_bucket: false, level: 1) @catalog(name: "transport", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/10_as_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/10_as_module/expected/schema.graphql
@@ -564,6 +564,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1210,6 +1218,16 @@ type _Ship_aggregation_sub_aggregation @aggregation(name: "_Ship_aggregation", i
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
   tonnage: FloatSubAggregation @field_aggregation(name: "tonnage")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/10_as_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/10_as_module/expected/schema.graphql
@@ -545,6 +545,25 @@ enum OrderDirection @system {
   DESC
 }
 type Query @system {
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -854,6 +873,83 @@ type _Bus_aggregation_sub_aggregation @aggregation(name: "_Bus_aggregation", is_
   id: IntSubAggregation @field_aggregation(name: "id")
   route: StringSubAggregation @field_aggregation(name: "route")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
 type _Flight_aggregation @aggregation(name: "Flight", is_bucket: false, level: 1) @catalog(name: "transport_db", engine: "duckdb") {
   _departure_part(
     """
@@ -931,6 +1027,153 @@ type _Flight_aggregation_sub_aggregation @aggregation(name: "_Flight_aggregation
   ): TimestampSubAggregation @field_aggregation(name: "departure")
   flight_number: StringSubAggregation @field_aggregation(name: "flight_number")
   id: IntSubAggregation @field_aggregation(name: "id")
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Ship_aggregation @aggregation(name: "Ship", is_bucket: false, level: 1) @catalog(name: "transport_db", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/11_read_only/expected/schema.graphql
+++ b/integration-test/compiler/testdata/11_read_only/expected/schema.graphql
@@ -613,6 +613,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1161,6 +1169,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/11_read_only/expected/schema.graphql
+++ b/integration-test/compiler/testdata/11_read_only/expected/schema.graphql
@@ -594,6 +594,25 @@ type Query @system {
     distinct_on: [String]
   ): [_LogEntry_aggregation_bucket] @aggregation_query(name: "LogEntry", is_bucket: true) @catalog(name: "logs", engine: "duckdb")
   LogEntry_by_pk(id: BigInt!): LogEntry @query(name: "LogEntry", type: SELECT_ONE) @catalog(name: "logs", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -839,6 +858,124 @@ input VectorSearchInput @system {
   """
   vector: Vector!
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
 type _LogEntry_aggregation @aggregation(name: "LogEntry", is_bucket: false, level: 1) @catalog(name: "logs", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
   _rows_count: BigInt
@@ -918,6 +1055,112 @@ type _LogEntry_aggregation_sub_aggregation @aggregation(name: "_LogEntry_aggrega
     """
     bucket_interval: Interval
   ): TimestampSubAggregation @field_aggregation(name: "timestamp")
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/12_table_with_join/expected/schema.graphql
+++ b/integration-test/compiler/testdata/12_table_with_join/expected/schema.graphql
@@ -832,6 +832,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1487,6 +1495,16 @@ type _Route_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation",
   dst_airport: StringSubAggregation @field_aggregation(name: "dst_airport")
   id: IntSubAggregation @field_aggregation(name: "id")
   src_airport: StringSubAggregation @field_aggregation(name: "src_airport")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/12_table_with_join/expected/schema.graphql
+++ b/integration-test/compiler/testdata/12_table_with_join/expected/schema.graphql
@@ -813,6 +813,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Route_aggregation_bucket] @aggregation_query(name: "Route", is_bucket: true) @catalog(name: "flights", engine: "duckdb")
   Route_by_pk(id: Int!): Route @query(name: "Route", type: SELECT_ONE) @catalog(name: "flights", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1206,6 +1225,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   city: StringSubAggregation @field_aggregation(name: "city")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Route_aggregation @aggregation(name: "Route", is_bucket: false, level: 1) @catalog(name: "flights", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/13_cube/expected/schema.graphql
+++ b/integration-test/compiler/testdata/13_cube/expected/schema.graphql
@@ -554,6 +554,25 @@ type Query @system {
     distinct_on: [String]
   ): [_SalesCube_aggregation_bucket] @aggregation_query(name: "SalesCube", is_bucket: true) @catalog(name: "analytics", engine: "duckdb")
   SalesCube_by_pk(id: Int!): SalesCube @query(name: "SalesCube", type: SELECT_ONE) @catalog(name: "analytics", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -843,6 +862,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _SalesCube_aggregation @aggregation(name: "SalesCube", is_bucket: false, level: 1) @catalog(name: "analytics", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/13_cube/expected/schema.graphql
+++ b/integration-test/compiler/testdata/13_cube/expected/schema.graphql
@@ -573,6 +573,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1146,6 +1154,16 @@ type _SalesCube_aggregation_sub_aggregation @aggregation(name: "_SalesCube_aggre
     """
     measurement_func: FloatMeasurementAggregation
   ): FloatSubAggregation @field_aggregation(name: "revenue")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/14_hypertable/expected/schema.graphql
+++ b/integration-test/compiler/testdata/14_hypertable/expected/schema.graphql
@@ -554,6 +554,25 @@ type Query @system {
     distinct_on: [String]
   ): [_SensorReading_aggregation_bucket] @aggregation_query(name: "SensorReading", is_bucket: true) @catalog(name: "metrics", engine: "postgres")
   SensorReading_by_pk(id: Int!): SensorReading @query(name: "SensorReading", type: SELECT_ONE) @catalog(name: "metrics", engine: "postgres")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -862,6 +881,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _SensorReading_aggregation @aggregation(name: "SensorReading", is_bucket: false, level: 1) @catalog(name: "metrics", engine: "postgres") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/14_hypertable/expected/schema.graphql
+++ b/integration-test/compiler/testdata/14_hypertable/expected/schema.graphql
@@ -573,6 +573,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1197,6 +1205,16 @@ type _SensorReading_aggregation_sub_aggregation @aggregation(name: "_SensorReadi
   ): TimestampSubAggregation @field_aggregation(name: "recorded_at")
   sensor_name: StringSubAggregation @field_aggregation(name: "sensor_name")
   temperature: FloatSubAggregation @field_aggregation(name: "temperature")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/15_view_with_function_call/expected/schema.graphql
+++ b/integration-test/compiler/testdata/15_view_with_function_call/expected/schema.graphql
@@ -574,6 +574,25 @@ type Query @system {
   ): [_City_aggregation_bucket] @aggregation_query(name: "City", is_bucket: true) @catalog(name: "enriched", engine: "duckdb")
   City_by_pk(id: Int!): City @query(name: "City", type: SELECT_ONE) @catalog(name: "enriched", engine: "duckdb")
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "enriched")
@@ -860,6 +879,230 @@ type _City_aggregation_sub_aggregation @aggregation(name: "_City_aggregation", i
   name: StringSubAggregation @field_aggregation(name: "name")
   population: IntSubAggregation @field_aggregation(name: "population")
   weather: StringSubAggregation @field_aggregation(name: "weather")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/15_view_with_function_call/expected/schema.graphql
+++ b/integration-test/compiler/testdata/15_view_with_function_call/expected/schema.graphql
@@ -593,6 +593,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "enriched")
@@ -1103,6 +1111,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/16_vector/expected/schema.graphql
+++ b/integration-test/compiler/testdata/16_vector/expected/schema.graphql
@@ -633,6 +633,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1159,6 +1167,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/16_vector/expected/schema.graphql
+++ b/integration-test/compiler/testdata/16_vector/expected/schema.graphql
@@ -614,6 +614,25 @@ type Query @system {
     similarity: VectorSearchInput
   ): [_Document_aggregation_bucket] @aggregation_query(name: "Document", is_bucket: true) @catalog(name: "docs", engine: "duckdb")
   Document_by_pk(id: Int!): Document @query(name: "Document", type: SELECT_ONE) @catalog(name: "docs", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -859,6 +878,83 @@ input VectorSearchInput @system {
   """
   vector: Vector!
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
 type _Document_aggregation @aggregation(name: "Document", is_bucket: false, level: 1) @catalog(name: "docs", engine: "duckdb") {
   _embedding_distance(
     """
@@ -916,6 +1012,153 @@ type _Document_aggregation_sub_aggregation @aggregation(name: "_Document_aggrega
   content: StringSubAggregation @field_aggregation(name: "content")
   id: IntSubAggregation @field_aggregation(name: "id")
   title: StringSubAggregation @field_aggregation(name: "title")
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/17_vector_embeddings/expected/schema.graphql
+++ b/integration-test/compiler/testdata/17_vector_embeddings/expected/schema.graphql
@@ -667,6 +667,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1194,6 +1202,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/17_vector_embeddings/expected/schema.graphql
+++ b/integration-test/compiler/testdata/17_vector_embeddings/expected/schema.graphql
@@ -648,6 +648,25 @@ type Query @system {
     semantic: SemanticSearchInput
   ): [_Article_aggregation_bucket] @aggregation_query(name: "Article", is_bucket: true) @catalog(name: "knowledge", engine: "duckdb")
   Article_by_pk(id: Int!): Article @query(name: "Article", type: SELECT_ONE) @catalog(name: "knowledge", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -951,6 +970,230 @@ type _Article_aggregation_sub_aggregation @aggregation(name: "_Article_aggregati
   body: StringSubAggregation @field_aggregation(name: "body")
   id: IntSubAggregation @field_aggregation(name: "id")
   title: StringSubAggregation @field_aggregation(name: "title")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/18_at_directive/expected/schema.graphql
+++ b/integration-test/compiler/testdata/18_at_directive/expected/schema.graphql
@@ -588,6 +588,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1188,6 +1196,16 @@ type _Snapshot_aggregation_sub_aggregation @aggregation(name: "_Snapshot_aggrega
   ): TimestampSubAggregation @field_aggregation(name: "created_at")
   data: StringSubAggregation @field_aggregation(name: "data")
   id: IntSubAggregation @field_aggregation(name: "id")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/18_at_directive/expected/schema.graphql
+++ b/integration-test/compiler/testdata/18_at_directive/expected/schema.graphql
@@ -569,6 +569,25 @@ type Query @system {
   Versioned table with @at directive for time travel
   """
   Snapshot_by_pk(id: Int!): Snapshot @query(name: "Snapshot", type: SELECT_ONE) @catalog(name: "versioned", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -867,6 +886,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Snapshot_aggregation @aggregation(name: "Snapshot", is_bucket: false, level: 1) @catalog(name: "versioned", engine: "duckdb") {
   _created_at_part(

--- a/integration-test/compiler/testdata/20_multi_catalog_basic/expected/schema.graphql
+++ b/integration-test/compiler/testdata/20_multi_catalog_basic/expected/schema.graphql
@@ -745,6 +745,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1339,6 +1347,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/20_multi_catalog_basic/expected/schema.graphql
+++ b/integration-test/compiler/testdata/20_multi_catalog_basic/expected/schema.graphql
@@ -726,6 +726,25 @@ type Query @system {
     distinct_on: [String]
   ): [_DataSourceInfo_aggregation_bucket] @aggregation_query(name: "DataSourceInfo", is_bucket: true) @catalog(name: "meta", engine: "duckdb")
   DataSourceInfo_by_pk(name: String!): DataSourceInfo @query(name: "DataSourceInfo", type: SELECT_ONE) @catalog(name: "meta", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1061,6 +1080,83 @@ type _CacheEntry_aggregation_sub_aggregation @aggregation(name: "_CacheEntry_agg
     struct: JSON
   ): JSONSubAggregation @field_aggregation(name: "value")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
 type _DataSourceInfo_aggregation @aggregation(name: "DataSourceInfo", is_bucket: false, level: 1) @catalog(name: "meta", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
   _rows_count: BigInt
@@ -1096,6 +1192,153 @@ type _DataSourceInfo_aggregation_sub_aggregation @aggregation(name: "_DataSource
   is_active: BooleanSubAggregation @field_aggregation(name: "is_active")
   name: StringSubAggregation @field_aggregation(name: "name")
   type: StringSubAggregation @field_aggregation(name: "type")
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/21_multi_catalog_overlapping_modules/expected/schema.graphql
+++ b/integration-test/compiler/testdata/21_multi_catalog_overlapping_modules/expected/schema.graphql
@@ -680,6 +680,25 @@ input Order_mut_input_data @data_input(name: "Order") @catalog(name: "pg_crm", e
   total: Float
 }
 type Query @system {
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   crm: _module_crm_query @module_catalog(name: "pg_crm") @module_catalog(name: "support")
   function: Function @system
   """
@@ -1153,6 +1172,175 @@ type _Customer_aggregation_sub_aggregation @aggregation(name: "_Customer_aggrega
     nested_offset: Int
   ): _Order_aggregation_sub_aggregation_sub_aggregation @field_aggregation(name: "orders_aggregation")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
 type _Order_aggregation @aggregation(name: "Order", is_bucket: false, level: 1) @catalog(name: "pg_crm", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
   _rows_count: BigInt
@@ -1197,6 +1385,61 @@ type _Order_aggregation_sub_aggregation @aggregation(name: "_Order_aggregation",
 }
 type _Order_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Order_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "pg_crm", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Ticket_aggregation @aggregation(name: "Ticket", is_bucket: false, level: 1) @catalog(name: "support", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/21_multi_catalog_overlapping_modules/expected/schema.graphql
+++ b/integration-test/compiler/testdata/21_multi_catalog_overlapping_modules/expected/schema.graphql
@@ -699,6 +699,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   crm: _module_crm_query @module_catalog(name: "pg_crm") @module_catalog(name: "support")
   function: Function @system
   """
@@ -1476,6 +1484,16 @@ type _Ticket_aggregation_sub_aggregation @aggregation(name: "_Ticket_aggregation
   id: IntSubAggregation @field_aggregation(name: "id")
   priority: IntSubAggregation @field_aggregation(name: "priority")
   subject: StringSubAggregation @field_aggregation(name: "subject")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/22_multi_catalog_cross_ref/expected/schema.graphql
+++ b/integration-test/compiler/testdata/22_multi_catalog_cross_ref/expected/schema.graphql
@@ -872,6 +872,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1585,6 +1593,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/22_multi_catalog_cross_ref/expected/schema.graphql
+++ b/integration-test/compiler/testdata/22_multi_catalog_cross_ref/expected/schema.graphql
@@ -853,6 +853,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Flight_aggregation_bucket] @aggregation_query(name: "Flight", is_bucket: true) @catalog(name: "flights", engine: "duckdb")
   Flight_by_pk(id: Int!): Flight @query(name: "Flight", type: SELECT_ONE) @catalog(name: "flights", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1298,6 +1317,83 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
 type _Flight_aggregation @aggregation(name: "Flight", is_bucket: false, level: 1) @catalog(name: "flights", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
   _rows_count: BigInt
@@ -1342,6 +1438,153 @@ type _Flight_aggregation_sub_aggregation @aggregation(name: "_Flight_aggregation
 }
 type _Flight_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Flight_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "flights", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/23_multi_catalog_with_extension/expected/schema.graphql
+++ b/integration-test/compiler/testdata/23_multi_catalog_with_extension/expected/schema.graphql
@@ -950,6 +950,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Route_aggregation_bucket] @aggregation_query(name: "Route", is_bucket: true) @catalog(name: "base", engine: "duckdb")
   Route_by_pk(id: Int!): Route @query(name: "Route", type: SELECT_ONE) @catalog(name: "base", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1546,6 +1565,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   ): GeometrySubAggregation @field_aggregation(name: "geom")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _RouteMetrics_aggregation @aggregation(name: "RouteMetrics", is_bucket: false, level: 1) @catalog(name: "route_ext", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join") @dependency(name: "route_ext")

--- a/integration-test/compiler/testdata/23_multi_catalog_with_extension/expected/schema.graphql
+++ b/integration-test/compiler/testdata/23_multi_catalog_with_extension/expected/schema.graphql
@@ -969,6 +969,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1870,6 +1878,16 @@ type _Route_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation",
 }
 type _Route_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "base", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/24_multi_catalog_modules_mixed/expected/schema.graphql
+++ b/integration-test/compiler/testdata/24_multi_catalog_modules_mixed/expected/schema.graphql
@@ -565,6 +565,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   analytics: _module_analytics_query @module_catalog(name: "analytics")
   function: Function @system
   """
@@ -1149,6 +1157,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/24_multi_catalog_modules_mixed/expected/schema.graphql
+++ b/integration-test/compiler/testdata/24_multi_catalog_modules_mixed/expected/schema.graphql
@@ -546,6 +546,25 @@ enum OrderDirection @system {
   DESC
 }
 type Query @system {
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   analytics: _module_analytics_query @module_catalog(name: "analytics")
   function: Function @system
   """
@@ -829,6 +848,83 @@ type _Customer_aggregation_sub_aggregation @aggregation(name: "_Customer_aggrega
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
 type _Event_aggregation @aggregation(name: "Event", is_bucket: false, level: 1) @catalog(name: "analytics", engine: "duckdb") {
   _created_at_part(
     """
@@ -906,6 +1002,153 @@ type _Event_aggregation_sub_aggregation @aggregation(name: "_Event_aggregation",
   ): TimestampSubAggregation @field_aggregation(name: "created_at")
   event_type: StringSubAggregation @field_aggregation(name: "event_type")
   id: BigIntSubAggregation @field_aggregation(name: "id")
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/25_complex_airport/expected/schema.graphql
+++ b/integration-test/compiler/testdata/25_complex_airport/expected/schema.graphql
@@ -1889,6 +1889,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   fn_transport: _module_fn_transport_query @module_catalog(name: "fn_transport")
   """
   Functions
@@ -3981,6 +3989,16 @@ type _Route_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation",
 }
 type _Route_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "base", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/25_complex_airport/expected/schema.graphql
+++ b/integration-test/compiler/testdata/25_complex_airport/expected/schema.graphql
@@ -1870,6 +1870,25 @@ type Query @system {
   ): [_Passenger_aggregation_bucket] @aggregation_query(name: "Passenger", is_bucket: true) @catalog(name: "base", engine: "duckdb")
   Passenger_by_pk(id: Int!): Passenger @query(name: "Passenger", type: SELECT_ONE) @catalog(name: "base", engine: "duckdb")
   Passenger_email(email: String!): Passenger @query(name: "Passenger", type: SELECT_ONE) @catalog(name: "base", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   fn_transport: _module_fn_transport_query @module_catalog(name: "fn_transport")
   """
   Functions
@@ -2922,6 +2941,83 @@ type _BookingPassenger_aggregation_sub_aggregation @aggregation(name: "_BookingP
   airline_icao: StringSubAggregation @field_aggregation(name: "airline_icao")
   passenger_id: IntSubAggregation @field_aggregation(name: "passenger_id")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
 type _FlightLog_aggregation @aggregation(name: "FlightLog", is_bucket: false, level: 1) @catalog(name: "base", engine: "duckdb") {
   _departure_part(
     """
@@ -3134,6 +3230,47 @@ type _FnAirport_aggregation_sub_aggregation @aggregation(name: "_FnAirport_aggre
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
   status: StringSubAggregation @field_aggregation(name: "status")
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
 }
 type _Hotel_aggregation @aggregation(name: "Hotel", is_bucket: false, level: 1) @catalog(name: "hotels", engine: "duckdb") {
   _geom_measurement(
@@ -3432,6 +3569,57 @@ type _Hotel_aggregation_sub_aggregation @aggregation(name: "_Hotel_aggregation",
   ): _Review_aggregation_sub_aggregation_sub_aggregation @field_aggregation(name: "reviews_aggregation")
   stars: IntSubAggregation @field_aggregation(name: "stars")
 }
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
 type _Passenger_aggregation @aggregation(name: "Passenger", is_bucket: false, level: 1) @catalog(name: "base", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
   _rows_count: BigInt
@@ -3636,6 +3824,61 @@ type _Passenger_aggregation_sub_aggregation @aggregation(name: "_Passenger_aggre
 }
 type _Passenger_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Passenger_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "base", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Review_aggregation @aggregation(name: "Review", is_bucket: false, level: 1) @catalog(name: "hotels", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/26_extension_cross_catalog_bridge/expected/schema.graphql
+++ b/integration-test/compiler/testdata/26_extension_cross_catalog_bridge/expected/schema.graphql
@@ -1704,6 +1704,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -3087,6 +3095,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/26_extension_cross_catalog_bridge/expected/schema.graphql
+++ b/integration-test/compiler/testdata/26_extension_cross_catalog_bridge/expected/schema.graphql
@@ -1685,6 +1685,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Product_aggregation_bucket] @aggregation_query(name: "Product", is_bucket: true) @catalog(name: "products", engine: "duckdb")
   Product_by_pk(id: Int!): Product @query(name: "Product", type: SELECT_ONE) @catalog(name: "products", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -2492,6 +2511,175 @@ type _Customer_aggregation_sub_aggregation @aggregation(name: "_Customer_aggrega
     nested_offset: Int
   ): _Order_aggregation_sub_aggregation_sub_aggregation @field_aggregation(name: "orders_aggregation")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
 type _OrderProduct_aggregation @aggregation(name: "OrderProduct", is_bucket: false, level: 1) @catalog(name: "bridge", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join") @dependency(name: "bridge")
   _rows_count: BigInt
@@ -2844,6 +3032,61 @@ type _Product_aggregation_sub_aggregation @aggregation(name: "_Product_aggregati
 }
 type _Product_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Product_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "products", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/27_same_schema_different_prefixes/expected/schema.graphql
+++ b/integration-test/compiler/testdata/27_same_schema_different_prefixes/expected/schema.graphql
@@ -478,6 +478,25 @@ enum OrderDirection @system {
   DESC
 }
 type Query @system {
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   eu_Employee(
     """
     Filter
@@ -1062,6 +1081,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/27_same_schema_different_prefixes/expected/schema.graphql
+++ b/integration-test/compiler/testdata/27_same_schema_different_prefixes/expected/schema.graphql
@@ -497,6 +497,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   eu_Employee(
     """
     Filter
@@ -1305,6 +1313,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/28_function_with_modules/expected/schema.graphql
+++ b/integration-test/compiler/testdata/28_function_with_modules/expected/schema.graphql
@@ -585,6 +585,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport")
@@ -1252,6 +1260,16 @@ type _Station_aggregation_sub_aggregation @aggregation(name: "_Station_aggregati
   city: StringSubAggregation @field_aggregation(name: "city")
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/28_function_with_modules/expected/schema.graphql
+++ b/integration-test/compiler/testdata/28_function_with_modules/expected/schema.graphql
@@ -566,6 +566,25 @@ enum OrderDirection @system {
 }
 type Query @system {
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport")
@@ -973,6 +992,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   ): GeometrySubAggregation @field_aggregation(name: "geom")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Station_aggregation @aggregation(name: "Station", is_bucket: false, level: 1) @catalog(name: "transport", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/29_function_with_modules_as_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/29_function_with_modules_as_module/expected/schema.graphql
@@ -563,6 +563,25 @@ enum OrderDirection @system {
 }
 type Query @system {
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport_db")
@@ -970,6 +989,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   ): GeometrySubAggregation @field_aggregation(name: "geom")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Station_aggregation @aggregation(name: "Station", is_bucket: false, level: 1) @catalog(name: "transport_db", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/29_function_with_modules_as_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/29_function_with_modules_as_module/expected/schema.graphql
@@ -582,6 +582,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport_db")
@@ -1249,6 +1257,16 @@ type _Station_aggregation_sub_aggregation @aggregation(name: "_Station_aggregati
   city: StringSubAggregation @field_aggregation(name: "city")
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/38_internal_extensions/expected/schema.graphql
+++ b/integration-test/compiler/testdata/38_internal_extensions/expected/schema.graphql
@@ -585,6 +585,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport")
@@ -1262,6 +1270,16 @@ type _Station_aggregation_sub_aggregation @aggregation(name: "_Station_aggregati
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
   name_upper: StringSubAggregation @field_aggregation(name: "name_upper")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/38_internal_extensions/expected/schema.graphql
+++ b/integration-test/compiler/testdata/38_internal_extensions/expected/schema.graphql
@@ -566,6 +566,25 @@ enum OrderDirection @system {
 }
 type Query @system {
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport")
@@ -981,6 +1000,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   ): GeometrySubAggregation @field_aggregation(name: "geom")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Station_aggregation @aggregation(name: "Station", is_bucket: false, level: 1) @catalog(name: "transport", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/39_internal_extensions_with_prefix/expected/schema.graphql
+++ b/integration-test/compiler/testdata/39_internal_extensions_with_prefix/expected/schema.graphql
@@ -473,6 +473,25 @@ enum OrderDirection @system {
 }
 type Query @system {
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport")
@@ -720,6 +739,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/39_internal_extensions_with_prefix/expected/schema.graphql
+++ b/integration-test/compiler/testdata/39_internal_extensions_with_prefix/expected/schema.graphql
@@ -492,6 +492,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport")
@@ -963,6 +971,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/40_table_struct_aggregation/expected/schema.graphql
+++ b/integration-test/compiler/testdata/40_table_struct_aggregation/expected/schema.graphql
@@ -1137,6 +1137,25 @@ type Query @system {
   ): [_Product_aggregation_bucket] @aggregation_query(name: "Product", is_bucket: true) @catalog(name: "store", engine: "duckdb")
   Product_by_pk(id: Int!): Product @query(name: "Product", type: SELECT_ONE) @catalog(name: "store", engine: "duckdb")
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "store")
@@ -1605,6 +1624,124 @@ type _Category_aggregation_sub_aggregation @aggregation(name: "_Category_aggrega
     nested_offset: Int
   ): _Product_aggregation_sub_aggregation_sub_aggregation @field_aggregation(name: "products_aggregation")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
 type _Metadata_aggregation @aggregation(name: "Metadata", is_bucket: false, level: 1) @catalog(name: "store", engine: "duckdb") {
   _rows_count: BigInt
   origin: StringAggregation @field_aggregation(name: "origin")
@@ -1614,6 +1751,57 @@ type _Metadata_aggregation_sub_aggregation @aggregation(name: "_Metadata_aggrega
   _rows_count: BigIntAggregation @field_aggregation(name: "aggregation_field")
   origin: StringSubAggregation @field_aggregation(name: "origin")
   warranty_years: IntSubAggregation @field_aggregation(name: "warranty_years")
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
 }
 type _Product_aggregation @aggregation(name: "Product", is_bucket: false, level: 1) @catalog(name: "store", engine: "duckdb") {
   _created_at_part(
@@ -1902,6 +2090,61 @@ type _Product_aggregation_sub_aggregation @aggregation(name: "_Product_aggregati
 }
 type _Product_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Product_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "store", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Specs_aggregation @aggregation(name: "Specs", is_bucket: false, level: 1) @catalog(name: "store", engine: "duckdb") {
   _rows_count: BigInt

--- a/integration-test/compiler/testdata/40_table_struct_aggregation/expected/schema.graphql
+++ b/integration-test/compiler/testdata/40_table_struct_aggregation/expected/schema.graphql
@@ -1156,6 +1156,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "store")
@@ -2157,6 +2165,16 @@ type _Specs_aggregation_sub_aggregation @aggregation(name: "_Specs_aggregation",
   cpu: StringSubAggregation @field_aggregation(name: "cpu")
   ram_gb: IntSubAggregation @field_aggregation(name: "ram_gb")
   storage_gb: IntSubAggregation @field_aggregation(name: "storage_gb")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/41_extension_join/expected/schema.graphql
+++ b/integration-test/compiler/testdata/41_extension_join/expected/schema.graphql
@@ -974,6 +974,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1632,6 +1640,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/41_extension_join/expected/schema.graphql
+++ b/integration-test/compiler/testdata/41_extension_join/expected/schema.graphql
@@ -955,6 +955,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Order_aggregation_bucket] @aggregation_query(name: "Order", is_bucket: true) @catalog(name: "base", engine: "duckdb")
   Order_by_pk(id: Int!): Order @query(name: "Order", type: SELECT_ONE) @catalog(name: "base", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1354,6 +1373,175 @@ type _Customer_aggregation_sub_aggregation @aggregation(name: "_Customer_aggrega
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
 type _Order_aggregation @aggregation(name: "Order", is_bucket: false, level: 1) @catalog(name: "base", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
   _rows_count: BigInt
@@ -1389,6 +1577,61 @@ type _Order_aggregation_sub_aggregation @aggregation(name: "_Order_aggregation",
   customer_id: IntSubAggregation @field_aggregation(name: "customer_id")
   id: IntSubAggregation @field_aggregation(name: "id")
   total: FloatSubAggregation @field_aggregation(name: "total")
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/42_extension_function_call/expected/schema.graphql
+++ b/integration-test/compiler/testdata/42_extension_function_call/expected/schema.graphql
@@ -585,6 +585,25 @@ type Query @system {
   ): [_Product_aggregation_bucket] @aggregation_query(name: "Product", is_bucket: true) @catalog(name: "base", engine: "duckdb")
   Product_by_pk(id: Int!): Product @query(name: "Product", type: SELECT_ONE) @catalog(name: "base", engine: "duckdb")
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "base")
@@ -832,6 +851,175 @@ input VectorSearchInput @system {
   """
   vector: Vector!
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
 type _Product_aggregation @aggregation(name: "Product", is_bucket: false, level: 1) @catalog(name: "base", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
   _rows_count: BigInt
@@ -868,6 +1056,61 @@ type _Product_aggregation_sub_aggregation @aggregation(name: "_Product_aggregati
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
   price: FloatSubAggregation @field_aggregation(name: "price")
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/42_extension_function_call/expected/schema.graphql
+++ b/integration-test/compiler/testdata/42_extension_function_call/expected/schema.graphql
@@ -604,6 +604,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "base")
@@ -1111,6 +1119,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/43_extension_table_function_call_join/expected/schema.graphql
+++ b/integration-test/compiler/testdata/43_extension_table_function_call_join/expected/schema.graphql
@@ -618,6 +618,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "base")
@@ -1128,6 +1136,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/43_extension_table_function_call_join/expected/schema.graphql
+++ b/integration-test/compiler/testdata/43_extension_table_function_call_join/expected/schema.graphql
@@ -599,6 +599,25 @@ type Query @system {
   ): [_Airport_aggregation_bucket] @aggregation_query(name: "Airport", is_bucket: true) @catalog(name: "base", engine: "duckdb")
   Airport_by_pk(id: Int!): Airport @query(name: "Airport", type: SELECT_ONE) @catalog(name: "base", engine: "duckdb")
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "base")
@@ -885,6 +904,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   latitude: FloatSubAggregation @field_aggregation(name: "latitude")
   longitude: FloatSubAggregation @field_aggregation(name: "longitude")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/44_extension_references/expected/schema.graphql
+++ b/integration-test/compiler/testdata/44_extension_references/expected/schema.graphql
@@ -900,6 +900,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1657,6 +1665,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/44_extension_references/expected/schema.graphql
+++ b/integration-test/compiler/testdata/44_extension_references/expected/schema.graphql
@@ -881,6 +881,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Order_aggregation_bucket] @aggregation_query(name: "Order", is_bucket: true) @catalog(name: "orders", engine: "duckdb")
   Order_by_pk(id: Int!): Order @query(name: "Order", type: SELECT_ONE) @catalog(name: "orders", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1326,6 +1345,175 @@ type _Customer_aggregation_sub_aggregation @aggregation(name: "_Customer_aggrega
     nested_offset: Int
   ): _Order_aggregation_sub_aggregation_sub_aggregation @field_aggregation(name: "orders_aggregation") @dependency(name: "ext_bridge")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
 type _Order_aggregation @aggregation(name: "Order", is_bucket: false, level: 1) @catalog(name: "orders", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
   _ordered_at_part(
@@ -1414,6 +1602,61 @@ type _Order_aggregation_sub_aggregation @aggregation(name: "_Order_aggregation",
 }
 type _Order_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Order_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "orders", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/45_extension_with_prefix/expected/schema.graphql
+++ b/integration-test/compiler/testdata/45_extension_with_prefix/expected/schema.graphql
@@ -491,6 +491,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1129,6 +1137,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/45_extension_with_prefix/expected/schema.graphql
+++ b/integration-test/compiler/testdata/45_extension_with_prefix/expected/schema.graphql
@@ -472,6 +472,25 @@ enum OrderDirection @system {
   DESC
 }
 type Query @system {
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -886,6 +905,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/46_extension_prefixed_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/46_extension_prefixed_module/expected/schema.graphql
@@ -493,6 +493,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "rest_api")
@@ -965,6 +973,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/46_extension_prefixed_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/46_extension_prefixed_module/expected/schema.graphql
@@ -474,6 +474,25 @@ enum OrderDirection @system {
 }
 type Query @system {
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "rest_api")
@@ -722,6 +741,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/47_incremental_add_type/expected/schema.graphql
+++ b/integration-test/compiler/testdata/47_incremental_add_type/expected/schema.graphql
@@ -715,6 +715,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Widget_aggregation_bucket] @aggregation_query(name: "Widget", is_bucket: true) @catalog(name: "test", engine: "duckdb")
   Widget_by_pk(id: Int!): Widget @query(name: "Widget", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -991,6 +1010,124 @@ input Widget_mut_input_data @data_input(name: "Widget") @catalog(name: "test", e
   name: String
   price: Float
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
 type _Gadget_aggregation @aggregation(name: "Gadget", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _created_at_part(
     """
@@ -1070,6 +1207,112 @@ type _Gadget_aggregation_sub_aggregation @aggregation(name: "_Gadget_aggregation
   id: IntSubAggregation @field_aggregation(name: "id")
   label: StringSubAggregation @field_aggregation(name: "label")
   weight: FloatSubAggregation @field_aggregation(name: "weight")
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Widget_aggregation @aggregation(name: "Widget", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join") @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/47_incremental_add_type/expected/schema.graphql
+++ b/integration-test/compiler/testdata/47_incremental_add_type/expected/schema.graphql
@@ -734,6 +734,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1313,6 +1321,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 type _Widget_aggregation @aggregation(name: "Widget", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join") @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/48_incremental_drop_type/expected/schema.graphql
+++ b/integration-test/compiler/testdata/48_incremental_drop_type/expected/schema.graphql
@@ -554,6 +554,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Widget_aggregation_bucket] @aggregation_query(name: "Widget", is_bucket: true) @catalog(name: "test", engine: "duckdb")
   Widget_by_pk(id: Int!): Widget @query(name: "Widget", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -829,6 +848,230 @@ input Widget_mut_input_data @data_input(name: "Widget") @catalog(name: "test", e
   id: Int
   name: String
   price: Float
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Widget_aggregation @aggregation(name: "Widget", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/48_incremental_drop_type/expected/schema.graphql
+++ b/integration-test/compiler/testdata/48_incremental_drop_type/expected/schema.graphql
@@ -573,6 +573,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1072,6 +1080,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 type _Widget_aggregation @aggregation(name: "Widget", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/49_incremental_replace_type/expected/schema.graphql
+++ b/integration-test/compiler/testdata/49_incremental_replace_type/expected/schema.graphql
@@ -573,6 +573,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1094,6 +1102,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 type _Widget_aggregation @aggregation(name: "Widget", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/49_incremental_replace_type/expected/schema.graphql
+++ b/integration-test/compiler/testdata/49_incremental_replace_type/expected/schema.graphql
@@ -554,6 +554,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Widget_aggregation_bucket] @aggregation_query(name: "Widget", is_bucket: true) @catalog(name: "test", engine: "duckdb")
   Widget_by_pk(id: Int!): Widget @query(name: "Widget", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -851,6 +870,230 @@ input Widget_mut_input_data @data_input(name: "Widget") @catalog(name: "test", e
   name: String
   price: Float
   updated_at: Timestamp
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Widget_aggregation @aggregation(name: "Widget", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/50_incremental_add_with_refs/expected/schema.graphql
+++ b/integration-test/compiler/testdata/50_incremental_add_with_refs/expected/schema.graphql
@@ -1091,6 +1091,25 @@ type Query @system {
   Route between airports, added incrementally with references
   """
   Route_by_pk(id: Int!): Route @query(name: "Route", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1794,6 +1813,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   ): _Route_aggregation_sub_aggregation_sub_aggregation @field_aggregation(name: "departing_routes_aggregation")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Route_aggregation @aggregation(name: "Route", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/50_incremental_add_with_refs/expected/schema.graphql
+++ b/integration-test/compiler/testdata/50_incremental_add_with_refs/expected/schema.graphql
@@ -1110,6 +1110,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -2092,6 +2100,16 @@ type _Route_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation",
 }
 type _Route_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "test", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/51_incremental_add_with_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/51_incremental_add_with_module/expected/schema.graphql
@@ -494,6 +494,25 @@ enum OrderDirection @system {
   DESC
 }
 type Query @system {
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -805,6 +824,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   city: StringSubAggregation @field_aggregation(name: "city")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Station_aggregation @aggregation(name: "Station", is_bucket: false, level: 1) @catalog(name: "transport", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/51_incremental_add_with_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/51_incremental_add_with_module/expected/schema.graphql
@@ -513,6 +513,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1084,6 +1092,16 @@ type _Station_aggregation_sub_aggregation @aggregation(name: "_Station_aggregati
   city: StringSubAggregation @field_aggregation(name: "city")
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/52_incremental_with_prefix/expected/schema.graphql
+++ b/integration-test/compiler/testdata/52_incremental_with_prefix/expected/schema.graphql
@@ -481,6 +481,25 @@ enum OrderDirection @system {
   DESC
 }
 type Query @system {
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   ext_Hotel(
     """
     Filter
@@ -901,6 +920,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/52_incremental_with_prefix/expected/schema.graphql
+++ b/integration-test/compiler/testdata/52_incremental_with_prefix/expected/schema.graphql
@@ -500,6 +500,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   ext_Hotel(
     """
     Filter
@@ -1144,6 +1152,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/53_incremental_multi_source/expected/schema.graphql
+++ b/integration-test/compiler/testdata/53_incremental_multi_source/expected/schema.graphql
@@ -967,6 +967,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   ext_Hotel(
     """
     Filter
@@ -1844,6 +1852,16 @@ type _Route_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation",
 }
 type _Route_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "base", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/53_incremental_multi_source/expected/schema.graphql
+++ b/integration-test/compiler/testdata/53_incremental_multi_source/expected/schema.graphql
@@ -948,6 +948,25 @@ type Query @system {
   Route added incrementally to base catalog
   """
   Route_by_pk(id: Int!): Route @query(name: "Route", type: SELECT_ONE) @catalog(name: "base", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   ext_Hotel(
     """
     Filter
@@ -1556,6 +1575,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   ): _Route_aggregation_sub_aggregation_sub_aggregation @field_aggregation(name: "departing_routes_aggregation")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Route_aggregation @aggregation(name: "Route", is_bucket: false, level: 1) @catalog(name: "base", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/54_incremental_drop_with_refs/expected/schema.graphql
+++ b/integration-test/compiler/testdata/54_incremental_drop_with_refs/expected/schema.graphql
@@ -600,6 +600,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1104,6 +1112,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/54_incremental_drop_with_refs/expected/schema.graphql
+++ b/integration-test/compiler/testdata/54_incremental_drop_with_refs/expected/schema.graphql
@@ -581,6 +581,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Airport_aggregation_bucket] @aggregation_query(name: "Airport", is_bucket: true) @catalog(name: "test", engine: "duckdb")
   Airport_by_pk(iata_code: String!): Airport @query(name: "Airport", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -861,6 +880,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   city: StringSubAggregation @field_aggregation(name: "city")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/55_incremental_drop_readd_refs/expected/schema.graphql
+++ b/integration-test/compiler/testdata/55_incremental_drop_readd_refs/expected/schema.graphql
@@ -976,6 +976,25 @@ type Query @system {
   Step 2: Re-add Route — Airport should regain its back-reference fields
   """
   Route_by_pk(id: Int!): Route @query(name: "Route", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1639,6 +1658,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   ): _Route_aggregation_sub_aggregation_sub_aggregation @field_aggregation(name: "departing_routes_aggregation")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Route_aggregation @aggregation(name: "Route", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/55_incremental_drop_readd_refs/expected/schema.graphql
+++ b/integration-test/compiler/testdata/55_incremental_drop_readd_refs/expected/schema.graphql
@@ -995,6 +995,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1935,6 +1943,16 @@ type _Route_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation",
 }
 type _Route_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "test", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/56_incremental_field_add/expected/schema.graphql
+++ b/integration-test/compiler/testdata/56_incremental_field_add/expected/schema.graphql
@@ -611,6 +611,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Product_aggregation_bucket] @aggregation_query(name: "Product", is_bucket: true) @catalog(name: "test", engine: "duckdb")
   Product_by_pk(id: Int!): Product @query(name: "Product", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -856,6 +875,175 @@ input VectorSearchInput @system {
   """
   vector: Vector!
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
 type _Product_aggregation @aggregation(name: "Product", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _created_at_part(
     """
@@ -941,6 +1129,61 @@ type _Product_aggregation_sub_aggregation @aggregation(name: "_Product_aggregati
   name: StringSubAggregation @field_aggregation(name: "name")
   price: FloatSubAggregation @field_aggregation(name: "price")
   weight: FloatSubAggregation @field_aggregation(name: "weight")
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/56_incremental_field_add/expected/schema.graphql
+++ b/integration-test/compiler/testdata/56_incremental_field_add/expected/schema.graphql
@@ -630,6 +630,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1184,6 +1192,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/57_incremental_field_drop/expected/schema.graphql
+++ b/integration-test/compiler/testdata/57_incremental_field_drop/expected/schema.graphql
@@ -628,6 +628,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1176,6 +1184,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/57_incremental_field_drop/expected/schema.graphql
+++ b/integration-test/compiler/testdata/57_incremental_field_drop/expected/schema.graphql
@@ -609,6 +609,25 @@ type Query @system {
     distinct_on: [String]
   ): [_Article_aggregation_bucket] @aggregation_query(name: "Article", is_bucket: true) @catalog(name: "test", engine: "duckdb")
   Article_by_pk(id: Int!): Article @query(name: "Article", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -933,6 +952,230 @@ type _Article_aggregation_sub_aggregation @aggregation(name: "_Article_aggregati
   id: IntSubAggregation @field_aggregation(name: "id")
   published: BooleanSubAggregation @field_aggregation(name: "published")
   title: StringSubAggregation @field_aggregation(name: "title")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/58_incremental_add_reference_field/expected/schema.graphql
+++ b/integration-test/compiler/testdata/58_incremental_add_reference_field/expected/schema.graphql
@@ -866,6 +866,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1621,6 +1629,16 @@ type _Route_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation",
 }
 type _Route_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "test", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/58_incremental_add_reference_field/expected/schema.graphql
+++ b/integration-test/compiler/testdata/58_incremental_add_reference_field/expected/schema.graphql
@@ -847,6 +847,25 @@ type Query @system {
   Route between airports
   """
   Route_by_pk(id: Int!): Route @query(name: "Route", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1333,6 +1352,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   ): _Route_aggregation_sub_aggregation_sub_aggregation @field_aggregation(name: "departing_routes_aggregation")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Route_aggregation @aggregation(name: "Route", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/59_incremental_drop_reference_field/expected/schema.graphql
+++ b/integration-test/compiler/testdata/59_incremental_drop_reference_field/expected/schema.graphql
@@ -867,6 +867,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1623,6 +1631,16 @@ type _Route_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation",
 }
 type _Route_aggregation_sub_aggregation_sub_aggregation @aggregation(name: "_Route_aggregation_sub_aggregation", is_bucket: false, level: 3) @catalog(name: "test", engine: "duckdb") {
   _rows_count: BigIntSubAggregation @field_aggregation(name: "aggregation_field")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/59_incremental_drop_reference_field/expected/schema.graphql
+++ b/integration-test/compiler/testdata/59_incremental_drop_reference_field/expected/schema.graphql
@@ -848,6 +848,25 @@ type Query @system {
   Route between airports
   """
   Route_by_pk(id: Int!): Route @query(name: "Route", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -1335,6 +1354,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   city: StringSubAggregation @field_aggregation(name: "city")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Route_aggregation @aggregation(name: "Route", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/60_incremental_field_with_prefix/expected/schema.graphql
+++ b/integration-test/compiler/testdata/60_incremental_field_with_prefix/expected/schema.graphql
@@ -498,6 +498,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Airport
   """
   ext_Airport(
@@ -1056,6 +1064,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/60_incremental_field_with_prefix/expected/schema.graphql
+++ b/integration-test/compiler/testdata/60_incremental_field_with_prefix/expected/schema.graphql
@@ -479,6 +479,25 @@ enum OrderDirection @system {
 }
 type Query @system {
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Airport
   """
   ext_Airport(
@@ -813,6 +832,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/61_incremental_directive_change/expected/schema.graphql
+++ b/integration-test/compiler/testdata/61_incremental_directive_change/expected/schema.graphql
@@ -622,6 +622,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   function: Function @system
   """
   H3 aggregation query
@@ -1128,6 +1136,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/61_incremental_directive_change/expected/schema.graphql
+++ b/integration-test/compiler/testdata/61_incremental_directive_change/expected/schema.graphql
@@ -603,6 +603,25 @@ type Query @system {
   Airport
   """
   Airport_by_pk(iata_code: String!): Airport @query(name: "Airport", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   function: Function @system
   """
   H3 aggregation query
@@ -885,6 +904,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   country: StringSubAggregation @field_aggregation(name: "country")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/62_incremental_ref_field_with_prefix/expected/schema.graphql
+++ b/integration-test/compiler/testdata/62_incremental_ref_field_with_prefix/expected/schema.graphql
@@ -491,6 +491,25 @@ enum OrderDirection @system {
 }
 type Query @system {
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Airport
   """
   ext_Airport(
@@ -916,6 +935,230 @@ input VectorSearchInput @system {
   The vector to search
   """
   vector: Vector!
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/62_incremental_ref_field_with_prefix/expected/schema.graphql
+++ b/integration-test/compiler/testdata/62_incremental_ref_field_with_prefix/expected/schema.graphql
@@ -510,6 +510,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Airport
   """
   ext_Airport(
@@ -1159,6 +1167,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/63_incremental_comprehensive/expected/schema.graphql
+++ b/integration-test/compiler/testdata/63_incremental_comprehensive/expected/schema.graphql
@@ -570,6 +570,25 @@ input Product_mut_input_data @data_input(name: "Product") @catalog(name: "test",
   price: Float
 }
 type Query @system {
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   analytics: _module_analytics_query @module_catalog(name: "test")
   commerce: _module_commerce_query @module_catalog(name: "test")
   """
@@ -855,6 +874,175 @@ type _Category_aggregation_sub_aggregation @aggregation(name: "_Category_aggrega
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
 type _Order_aggregation @aggregation(name: "Order", is_bucket: false, level: 1) @catalog(name: "test", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
   _rows_count: BigInt
@@ -933,6 +1121,61 @@ type _Product_aggregation_sub_aggregation @aggregation(name: "_Product_aggregati
   name: StringSubAggregation @field_aggregation(name: "name")
   name_upper: StringSubAggregation @field_aggregation(name: "name_upper")
   price: FloatSubAggregation @field_aggregation(name: "price")
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/63_incremental_comprehensive/expected/schema.graphql
+++ b/integration-test/compiler/testdata/63_incremental_comprehensive/expected/schema.graphql
@@ -589,6 +589,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   analytics: _module_analytics_query @module_catalog(name: "test")
   commerce: _module_commerce_query @module_catalog(name: "test")
   """
@@ -1176,6 +1184,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/64_incremental_function_add/expected/schema.graphql
+++ b/integration-test/compiler/testdata/64_incremental_function_add/expected/schema.graphql
@@ -606,6 +606,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "test") @module_catalog(name: "test")
@@ -1112,6 +1120,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/64_incremental_function_add/expected/schema.graphql
+++ b/integration-test/compiler/testdata/64_incremental_function_add/expected/schema.graphql
@@ -587,6 +587,25 @@ type Query @system {
   ): [_Airport_aggregation_bucket] @aggregation_query(name: "Airport", is_bucket: true) @catalog(name: "test", engine: "duckdb")
   Airport_by_pk(iata_code: String!): Airport @query(name: "Airport", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "test") @module_catalog(name: "test")
@@ -869,6 +888,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   city: StringSubAggregation @field_aggregation(name: "city")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/65_incremental_function_drop/expected/schema.graphql
+++ b/integration-test/compiler/testdata/65_incremental_function_drop/expected/schema.graphql
@@ -603,6 +603,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "test")
@@ -1109,6 +1117,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/65_incremental_function_drop/expected/schema.graphql
+++ b/integration-test/compiler/testdata/65_incremental_function_drop/expected/schema.graphql
@@ -584,6 +584,25 @@ type Query @system {
   ): [_Airport_aggregation_bucket] @aggregation_query(name: "Airport", is_bucket: true) @catalog(name: "test", engine: "duckdb")
   Airport_by_pk(iata_code: String!): Airport @query(name: "Airport", type: SELECT_ONE) @catalog(name: "test", engine: "duckdb")
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "test")
@@ -866,6 +885,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   city: StringSubAggregation @field_aggregation(name: "city")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/66_incremental_function_with_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/66_incremental_function_with_module/expected/schema.graphql
@@ -500,6 +500,25 @@ enum OrderDirection @system {
 }
 type Query @system {
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "test") @module_catalog(name: "test")
@@ -783,6 +802,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   city: StringSubAggregation @field_aggregation(name: "city")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/66_incremental_function_with_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/66_incremental_function_with_module/expected/schema.graphql
@@ -519,6 +519,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "test") @module_catalog(name: "test")
@@ -1026,6 +1034,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/67_incremental_function_as_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/67_incremental_function_as_module/expected/schema.graphql
@@ -500,6 +500,25 @@ enum OrderDirection @system {
 }
 type Query @system {
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport") @module_catalog(name: "transport")
@@ -783,6 +802,230 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   city: StringSubAggregation @field_aggregation(name: "city")
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/67_incremental_function_as_module/expected/schema.graphql
+++ b/integration-test/compiler/testdata/67_incremental_function_as_module/expected/schema.graphql
@@ -519,6 +519,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport") @module_catalog(name: "transport")
@@ -1026,6 +1034,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/68_incremental_as_module_comprehensive/expected/schema.graphql
+++ b/integration-test/compiler/testdata/68_incremental_as_module_comprehensive/expected/schema.graphql
@@ -532,6 +532,25 @@ enum OrderDirection @system {
 }
 type Query @system {
   """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport") @module_catalog(name: "transport")
@@ -845,6 +864,83 @@ type _Airport_aggregation_sub_aggregation @aggregation(name: "_Airport_aggregati
   iata_code: StringSubAggregation @field_aggregation(name: "iata_code")
   name: StringSubAggregation @field_aggregation(name: "name")
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
 type _Flight_aggregation @aggregation(name: "Flight", is_bucket: false, level: 1) @catalog(name: "transport", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join") @field_aggregation(name: "_join") @field_aggregation(name: "_join")
   _rows_count: BigInt
@@ -880,6 +976,153 @@ type _Flight_aggregation_sub_aggregation @aggregation(name: "_Flight_aggregation
   flight_number: StringSubAggregation @field_aggregation(name: "flight_number")
   id: IntSubAggregation @field_aggregation(name: "id")
   origin_code: StringSubAggregation @field_aggregation(name: "origin_code")
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 type _Ship_aggregation @aggregation(name: "Ship", is_bucket: false, level: 1) @catalog(name: "transport", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")

--- a/integration-test/compiler/testdata/68_incremental_as_module_comprehensive/expected/schema.graphql
+++ b/integration-test/compiler/testdata/68_incremental_as_module_comprehensive/expected/schema.graphql
@@ -551,6 +551,14 @@ type Query @system {
   """
   _module(name: String!): _Module @system
   """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
+  """
   Functions
   """
   function: Function @system @module_catalog(name: "transport") @module_catalog(name: "transport")
@@ -1159,6 +1167,16 @@ type _Ship_aggregation_sub_aggregation @aggregation(name: "_Ship_aggregation", i
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
   tonnage: FloatSubAggregation @field_aggregation(name: "tonnage")
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/69_subscription_basic/expected/schema.graphql
+++ b/integration-test/compiler/testdata/69_subscription_basic/expected/schema.graphql
@@ -513,6 +513,14 @@ type Query @system {
   Logical-model introspection: direct module lookup; "" = the root module.
   """
   _module(name: String!): _Module @system
+  """
+  Logical-model introspection: GraphQL type definitions of the logical
+  model. SOURCE (default) lists the residual base types defined by data
+  sources — structural objects, inputs, enums — excluding data objects,
+  module roots and compiler-generated helper types; SYSTEM lists the
+  engine-defined types (scalars, introspection and hugr system SDL).
+  """
+  _types(scope: _TypeScope = SOURCE): [__Type!] @system
   events: _module_events_query @module_catalog(name: "events")
   function: Function @system
   """
@@ -1019,6 +1027,16 @@ enum _RelationKind @system {
   FK
   JOIN
   M2M
+}
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+  SOURCE
+  SYSTEM
 }
 """
 Value distribution data type

--- a/integration-test/compiler/testdata/69_subscription_basic/expected/schema.graphql
+++ b/integration-test/compiler/testdata/69_subscription_basic/expected/schema.graphql
@@ -494,6 +494,25 @@ enum OrderDirection @system {
   DESC
 }
 type Query @system {
+  """
+  Logical-model introspection: the root module tree (name "").
+  Resolved on the metadata path, like __schema/__type.
+  """
+  _catalog: _Module @system
+  """
+  Logical-model introspection: data object by GraphQL type name;
+  null for non-data-object types.
+  """
+  _dataObject(name: String!): _DataObject @system
+  """
+  Logical-model introspection: callable member (function/mutation/subscription)
+  of a module; module "" = root-level functions.
+  """
+  _function(module: String!, name: String!): _Function @system
+  """
+  Logical-model introspection: direct module lookup; "" = the root module.
+  """
+  _module(name: String!): _Module @system
   events: _module_events_query @module_catalog(name: "events")
   function: Function @system
   """
@@ -741,6 +760,83 @@ input VectorSearchInput @system {
   """
   vector: Vector!
 }
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+  """
+  Parameterized-view arguments; null when the object is not parameterized.
+  """
+  args: [__InputValue!]
+  """
+  The OWNING data source.
+  """
+  dataSourceName: String!
+  """
+  All contributing sources: owner + declarers of extension-added fields.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The object's fields (permission-filtered, same rules as __Type.fields).
+  """
+  fields: [__Field!]
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for the root module.
+  """
+  moduleName: String!
+  """
+  GraphQL type name (source-prefixed, globally unique).
+  """
+  name: String!
+  """
+  Field names carrying @pk; empty when the object has no primary key.
+  """
+  primaryKey: [String!]!
+  properties: _DataObjectProperties!
+  """
+  Logical links to other data objects (both directions; hidden endpoints excluded).
+  """
+  relations: [_Relation!]
+  type: _DataObjectType!
+}
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+  """
+  Has Vector-typed fields (semantic search capable).
+  """
+  hasVectors: Boolean!
+  """
+  Declared as an aggregation cube (@cube).
+  """
+  isCube: Boolean!
+  """
+  A hypertable (@hypertable).
+  """
+  isHypertable: Boolean!
+  """
+  A many-to-many junction table (@table(is_m2m: true)).
+  """
+  isM2M: Boolean!
+  """
+  Soft-delete semantics enabled (@table(soft_delete: true)).
+  """
+  softDelete: Boolean!
+}
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+  TABLE
+  VIEW
+}
 type _Event_aggregation @aggregation(name: "Event", is_bucket: false, level: 1) @catalog(name: "events", engine: "duckdb") {
   _join(fields: [String!]!): _join_aggregation @field_aggregation(name: "_join")
   _rows_count: BigInt
@@ -776,6 +872,153 @@ type _Event_aggregation_sub_aggregation @aggregation(name: "_Event_aggregation",
   data: StringSubAggregation @field_aggregation(name: "data")
   id: IntSubAggregation @field_aggregation(name: "id")
   name: StringSubAggregation @field_aggregation(name: "name")
+}
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+  """
+  Client-facing arguments; server-injected @arg_default arguments are excluded.
+  """
+  args: [__InputValue!]
+  """
+  The owning data source.
+  """
+  dataSourceName: String
+  description: String
+  """
+  True when the function returns a row set (table function) rather than a scalar.
+  """
+  isTable: Boolean!
+  longDescription: String
+  """
+  Owning module (recursive back-reference, depth-budgeted).
+  """
+  module: _Module
+  """
+  Owning module's dotted name; empty string for root-level functions.
+  """
+  moduleName: String!
+  """
+  Field name on the module's function/mutation-function/subscription root type.
+  """
+  name: String!
+  returns: __Type
+  type: _FunctionType!
+}
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+  FUNCTION
+  MUTATION
+  SUBSCRIPTION
+}
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+  """
+  Data objects whose @module is this module (root: objects without @module).
+  """
+  dataObjects: [_DataObject!]
+  """
+  Distinct data sources contributing this module's direct members.
+  """
+  dataSources: [String!]!
+  description: String
+  """
+  The module's generated function root type (root module: Function).
+  """
+  functionType: __Type
+  """
+  All callable members, including SUBSCRIPTION kind.
+  """
+  functions: [_Function!]
+  """
+  Curated/summarized long description.
+  """
+  longDescription: String
+  """
+  Direct child modules only; children with no visible content are omitted.
+  """
+  modules: [_Module!]
+  """
+  The module's generated mutation-function root type (root module: MutationFunction).
+  """
+  mutationFunctionType: __Type
+  """
+  The module's generated mutation root type (root module: Mutation).
+  """
+  mutationType: __Type
+  """
+  Full dotted module name; empty string for the root module.
+  """
+  name: String!
+  """
+  The module's generated query root type (root module: Query).
+  """
+  queryType: __Type
+  """
+  The module's generated subscription root type (root module: Subscription).
+  """
+  subscriptionType: __Type
+}
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+  """
+  The FAR data object (for M2M: the far leg, not the junction).
+  """
+  dataObject: _DataObject
+  """
+  The data source declaring this edge (cross-source edges are visible).
+  """
+  dataSource: String
+  """
+  Per-endpoint description (same perspective rule as fieldName).
+  """
+  description: String
+  """
+  Key field mappings on the destination side (M2M: the destination junction leg).
+  """
+  destinationKeys: [String!]!
+  direction: _RelationDirection!
+  """
+  The field on the VIEWED object that materializes this edge.
+  """
+  fieldName: String
+  kind: _RelationKind!
+  """
+  Relation name (@references(name:)) or the join field name.
+  """
+  name: String!
+  """
+  Key field mappings on the source side (M2M: the source junction leg).
+  """
+  sourceKeys: [String!]!
+  """
+  M2M only: the junction data object; null otherwise.
+  """
+  through: _DataObject
+}
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+  BACK
+  FORWARD
+}
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+  FK
+  JOIN
+  M2M
 }
 """
 Value distribution data type

--- a/integration-test/e2e/testdata/queries/metadata/catalog_relations/expected.json
+++ b/integration-test/e2e/testdata/queries/metadata/catalog_relations/expected.json
@@ -1,0 +1,94 @@
+{
+  "data": {
+    "categories": {
+      "name": "pg_store_categories",
+      "relations": [
+        {
+          "dataObject": {
+            "name": "pg_store_categories"
+          },
+          "direction": "FORWARD",
+          "fieldName": "parent",
+          "kind": "FK",
+          "name": "pg_store_categories_parent_id"
+        },
+        {
+          "dataObject": {
+            "name": "pg_store_products"
+          },
+          "direction": "BACK",
+          "fieldName": "products",
+          "kind": "FK",
+          "name": "pg_store_categories_category_id"
+        }
+      ]
+    },
+    "products": {
+      "name": "pg_store_products",
+      "relations": [
+        {
+          "dataObject": {
+            "name": "pg_store_categories"
+          },
+          "destinationKeys": [
+            "id"
+          ],
+          "direction": "FORWARD",
+          "fieldName": "category",
+          "kind": "FK",
+          "name": "pg_store_categories_category_id",
+          "sourceKeys": [
+            "category_id"
+          ],
+          "through": null
+        },
+        {
+          "dataObject": {
+            "name": "pg_store_tags"
+          },
+          "destinationKeys": [
+            "product_id"
+          ],
+          "direction": "FORWARD",
+          "fieldName": "product_tags",
+          "kind": "M2M",
+          "name": "pg_store_products_product_id",
+          "sourceKeys": [
+            "id"
+          ],
+          "through": {
+            "name": "pg_store_product_tags"
+          }
+        },
+        {
+          "dataObject": {
+            "name": "local_db_items"
+          },
+          "destinationKeys": [
+            "id"
+          ],
+          "direction": "FORWARD",
+          "fieldName": "matching_items",
+          "kind": "JOIN",
+          "name": "matching_items",
+          "sourceKeys": [
+            "id"
+          ],
+          "through": null
+        }
+      ]
+    },
+    "view": {
+      "args": [
+        {
+          "name": "min_price"
+        },
+        {
+          "name": "max_price"
+        }
+      ],
+      "name": "pg_store_products_in_price_range",
+      "type": "VIEW"
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/metadata/catalog_relations/expected.json
+++ b/integration-test/e2e/testdata/queries/metadata/catalog_relations/expected.json
@@ -5,27 +5,43 @@
       "relations": [
         {
           "dataObject": {
-            "name": "pg_store_categories"
-          },
-          "direction": "FORWARD",
-          "fieldName": "parent",
-          "kind": "FK",
-          "name": "pg_store_categories_parent_id"
-        },
-        {
-          "dataObject": {
             "name": "pg_store_products"
           },
           "direction": "BACK",
           "fieldName": "products",
           "kind": "FK",
           "name": "pg_store_categories_category_id"
+        },
+        {
+          "dataObject": {
+            "name": "pg_store_categories"
+          },
+          "direction": "FORWARD",
+          "fieldName": "parent",
+          "kind": "FK",
+          "name": "pg_store_categories_parent_id"
         }
       ]
     },
     "products": {
       "name": "pg_store_products",
       "relations": [
+        {
+          "dataObject": {
+            "name": "local_db_items"
+          },
+          "destinationKeys": [
+            "id"
+          ],
+          "direction": "FORWARD",
+          "fieldName": "matching_items",
+          "kind": "JOIN",
+          "name": "matching_items",
+          "sourceKeys": [
+            "id"
+          ],
+          "through": null
+        },
         {
           "dataObject": {
             "name": "pg_store_categories"
@@ -59,22 +75,6 @@
           "through": {
             "name": "pg_store_product_tags"
           }
-        },
-        {
-          "dataObject": {
-            "name": "local_db_items"
-          },
-          "destinationKeys": [
-            "id"
-          ],
-          "direction": "FORWARD",
-          "fieldName": "matching_items",
-          "kind": "JOIN",
-          "name": "matching_items",
-          "sourceKeys": [
-            "id"
-          ],
-          "through": null
         }
       ]
     },

--- a/integration-test/e2e/testdata/queries/metadata/catalog_relations/query.graphql
+++ b/integration-test/e2e/testdata/queries/metadata/catalog_relations/query.graphql
@@ -1,0 +1,41 @@
+# Relations graph: FK both directions, M2M with junction, parameterized-view
+# args. pg_store: products -> categories (FK), products <-> tags through
+# product_tags (M2M), categories self-reference (parent).
+{
+  products: _dataObject(name: "pg_store_products") {
+    name
+    relations {
+      name
+      direction
+      kind
+      fieldName
+      dataObject {
+        name
+      }
+      through {
+        name
+      }
+      sourceKeys
+      destinationKeys
+    }
+  }
+  categories: _dataObject(name: "pg_store_categories") {
+    name
+    relations {
+      name
+      direction
+      kind
+      fieldName
+      dataObject {
+        name
+      }
+    }
+  }
+  view: _dataObject(name: "pg_store_products_in_price_range") {
+    name
+    type
+    args {
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/metadata/catalog_tree/expected.json
+++ b/integration-test/e2e/testdata/queries/metadata/catalog_tree/expected.json
@@ -24,14 +24,21 @@
     "pg": {
       "dataObjects": [
         {
-          "name": "pg_store_products_in_price_range",
+          "name": "pg_store_active_products",
           "properties": {
             "isM2M": false
           },
           "type": "VIEW"
         },
         {
-          "name": "pg_store_product_details",
+          "name": "pg_store_categories",
+          "properties": {
+            "isM2M": false
+          },
+          "type": "TABLE"
+        },
+        {
+          "name": "pg_store_locations",
           "properties": {
             "isM2M": false
           },
@@ -45,14 +52,7 @@
           "type": "TABLE"
         },
         {
-          "name": "pg_store_products",
-          "properties": {
-            "isM2M": false
-          },
-          "type": "TABLE"
-        },
-        {
-          "name": "pg_store_categories",
+          "name": "pg_store_product_details",
           "properties": {
             "isM2M": false
           },
@@ -66,21 +66,21 @@
           "type": "TABLE"
         },
         {
-          "name": "pg_store_locations",
+          "name": "pg_store_products",
           "properties": {
             "isM2M": false
           },
           "type": "TABLE"
         },
         {
-          "name": "pg_store_active_products",
+          "name": "pg_store_products_for_current_user",
           "properties": {
             "isM2M": false
           },
           "type": "VIEW"
         },
         {
-          "name": "pg_store_products_for_current_user",
+          "name": "pg_store_products_in_price_range",
           "properties": {
             "isM2M": false
           },

--- a/integration-test/e2e/testdata/queries/metadata/catalog_tree/expected.json
+++ b/integration-test/e2e/testdata/queries/metadata/catalog_tree/expected.json
@@ -1,0 +1,112 @@
+{
+  "data": {
+    "fn": {
+      "isTable": false,
+      "moduleName": "core",
+      "name": "load_data_source",
+      "type": "MUTATION"
+    },
+    "missing": null,
+    "missingObj": null,
+    "obj": {
+      "dataSourceName": "pg_store",
+      "dataSources": [
+        "local_db",
+        "pg_store"
+      ],
+      "moduleName": "pg_store",
+      "name": "pg_store_products",
+      "primaryKey": [
+        "id"
+      ],
+      "type": "TABLE"
+    },
+    "pg": {
+      "dataObjects": [
+        {
+          "name": "pg_store_products_in_price_range",
+          "properties": {
+            "isM2M": false
+          },
+          "type": "VIEW"
+        },
+        {
+          "name": "pg_store_product_details",
+          "properties": {
+            "isM2M": false
+          },
+          "type": "TABLE"
+        },
+        {
+          "name": "pg_store_price_ranges",
+          "properties": {
+            "isM2M": false
+          },
+          "type": "TABLE"
+        },
+        {
+          "name": "pg_store_products",
+          "properties": {
+            "isM2M": false
+          },
+          "type": "TABLE"
+        },
+        {
+          "name": "pg_store_categories",
+          "properties": {
+            "isM2M": false
+          },
+          "type": "TABLE"
+        },
+        {
+          "name": "pg_store_product_tags",
+          "properties": {
+            "isM2M": true
+          },
+          "type": "TABLE"
+        },
+        {
+          "name": "pg_store_locations",
+          "properties": {
+            "isM2M": false
+          },
+          "type": "TABLE"
+        },
+        {
+          "name": "pg_store_active_products",
+          "properties": {
+            "isM2M": false
+          },
+          "type": "VIEW"
+        },
+        {
+          "name": "pg_store_products_for_current_user",
+          "properties": {
+            "isM2M": false
+          },
+          "type": "VIEW"
+        },
+        {
+          "name": "pg_store_tags",
+          "properties": {
+            "isM2M": false
+          },
+          "type": "TABLE"
+        }
+      ],
+      "dataSources": [
+        "pg_store"
+      ],
+      "mutationType": {
+        "name": "_module_pg_store_mutation"
+      },
+      "name": "pg_store",
+      "queryType": {
+        "name": "_module_pg_store_query"
+      }
+    },
+    "root": {
+      "name": ""
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/metadata/catalog_tree/query.graphql
+++ b/integration-test/e2e/testdata/queries/metadata/catalog_tree/query.graphql
@@ -1,0 +1,45 @@
+# Logical-model introspection: targeted point lookups on the multi-source
+# stack (full-tree recursion is covered by unit tests; the root module list
+# depends on which optional sources the stack enables).
+{
+  root: _catalog {
+    name
+  }
+  pg: _module(name: "pg_store") {
+    name
+    dataSources
+    dataObjects {
+      name
+      type
+      properties {
+        isM2M
+      }
+    }
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+  }
+  fn: _function(module: "core", name: "load_data_source") {
+    name
+    type
+    isTable
+    moduleName
+  }
+  obj: _dataObject(name: "pg_store_products") {
+    name
+    type
+    moduleName
+    dataSourceName
+    dataSources
+    primaryKey
+  }
+  missing: _module(name: "nope") {
+    name
+  }
+  missingObj: _dataObject(name: "nope") {
+    name
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/catalog_visibility/01_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/catalog_visibility/01_expected.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "core": {
+      "insert_roles": {
+        "name": "e2e_catalog_vis"
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/catalog_visibility/01_setup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/catalog_visibility/01_setup.graphql
@@ -1,0 +1,14 @@
+mutation {
+  core {
+    insert_roles(data: {
+      name: "e2e_catalog_vis"
+      description: "E2E catalog introspection visibility: hidden absent, disabled visible"
+      permissions: [
+        { type_name: "data-object:query", field_name: "pg_store_products", hidden: true }
+        { type_name: "data-object:query", field_name: "pg_store_categories", disabled: true }
+      ]
+    }) {
+      name
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/catalog_visibility/02_catalog.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/catalog_visibility/02_catalog.graphql
@@ -1,0 +1,26 @@
+# Under the restricted role: hidden pg_store_products is absent from the
+# module listing, from direct lookup, and from other objects' relations; the
+# disabled-but-visible pg_store_categories stays listed.
+{
+  pg: _module(name: "pg_store") {
+    dataObjects {
+      name
+    }
+  }
+  hidden: _dataObject(name: "pg_store_products") {
+    name
+  }
+  disabled: _dataObject(name: "pg_store_categories") {
+    name
+    type
+  }
+  rels: _dataObject(name: "pg_store_product_details") {
+    relations {
+      name
+      kind
+      dataObject {
+        name
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/catalog_visibility/02_catalog.headers
+++ b/integration-test/e2e/testdata/queries/permissions/catalog_visibility/02_catalog.headers
@@ -1,0 +1,3 @@
+x-hugr-impersonated-role: e2e_catalog_vis
+x-hugr-impersonated-user-id: cv-1
+x-hugr-impersonated-user-name: Catalog Vis

--- a/integration-test/e2e/testdata/queries/permissions/catalog_visibility/02_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/catalog_visibility/02_expected.json
@@ -1,0 +1,43 @@
+{
+  "data": {
+    "disabled": {
+      "name": "pg_store_categories",
+      "type": "TABLE"
+    },
+    "hidden": null,
+    "pg": {
+      "dataObjects": [
+        {
+          "name": "pg_store_locations"
+        },
+        {
+          "name": "pg_store_products_in_price_range"
+        },
+        {
+          "name": "pg_store_product_details"
+        },
+        {
+          "name": "pg_store_price_ranges"
+        },
+        {
+          "name": "pg_store_product_tags"
+        },
+        {
+          "name": "pg_store_active_products"
+        },
+        {
+          "name": "pg_store_products_for_current_user"
+        },
+        {
+          "name": "pg_store_categories"
+        },
+        {
+          "name": "pg_store_tags"
+        }
+      ]
+    },
+    "rels": {
+      "relations": []
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/catalog_visibility/02_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/catalog_visibility/02_expected.json
@@ -8,28 +8,28 @@
     "pg": {
       "dataObjects": [
         {
+          "name": "pg_store_active_products"
+        },
+        {
+          "name": "pg_store_categories"
+        },
+        {
           "name": "pg_store_locations"
-        },
-        {
-          "name": "pg_store_products_in_price_range"
-        },
-        {
-          "name": "pg_store_product_details"
         },
         {
           "name": "pg_store_price_ranges"
         },
         {
-          "name": "pg_store_product_tags"
+          "name": "pg_store_product_details"
         },
         {
-          "name": "pg_store_active_products"
+          "name": "pg_store_product_tags"
         },
         {
           "name": "pg_store_products_for_current_user"
         },
         {
-          "name": "pg_store_categories"
+          "name": "pg_store_products_in_price_range"
         },
         {
           "name": "pg_store_tags"

--- a/integration-test/e2e/testdata/queries/permissions/catalog_visibility/03_cleanup.graphql
+++ b/integration-test/e2e/testdata/queries/permissions/catalog_visibility/03_cleanup.graphql
@@ -1,0 +1,6 @@
+mutation {
+  core {
+    delete_role_permissions(filter: { role: { eq: "e2e_catalog_vis" } }) { success }
+    delete_roles(filter: { name: { eq: "e2e_catalog_vis" } }) { success }
+  }
+}

--- a/integration-test/e2e/testdata/queries/permissions/catalog_visibility/03_expected.json
+++ b/integration-test/e2e/testdata/queries/permissions/catalog_visibility/03_expected.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "core": {
+      "delete_role_permissions": {
+        "success": true
+      },
+      "delete_roles": {
+        "success": true
+      }
+    }
+  }
+}

--- a/pkg/catalog/compiler/base/query_request.go
+++ b/pkg/catalog/compiler/base/query_request.go
@@ -32,5 +32,14 @@ const (
 	MetadataTypeQuery     = "__type"
 	MetadataTypeNameQuery = "__typename"
 
+	// Logical-model introspection (catalog) meta queries. Single "_" prefix:
+	// GraphQL hard-reserves "__" names (graphql-js rejects them even in
+	// introspection results), so these are ordinary system fields on Query —
+	// like jq/h3 — dispatched to the metadata path by name.
+	MetadataCatalogQuery    = "_catalog"
+	MetadataModuleQuery     = "_module"
+	MetadataDataObjectQuery = "_dataObject"
+	MetadataFunctionQuery   = "_function"
+
 	JQTransformQueryName = "jq"
 )

--- a/pkg/catalog/compiler/base/query_request.go
+++ b/pkg/catalog/compiler/base/query_request.go
@@ -40,6 +40,7 @@ const (
 	MetadataModuleQuery     = "_module"
 	MetadataDataObjectQuery = "_dataObject"
 	MetadataFunctionQuery   = "_function"
+	MetadataTypesQuery      = "_types"
 
 	JQTransformQueryName = "jq"
 )

--- a/pkg/catalog/compiler/base/system_types.graphql
+++ b/pkg/catalog/compiler/base/system_types.graphql
@@ -69,6 +69,29 @@ type Query @system {
 		"""
 		resolution: Int!
 	): [_h3_query] @system
+
+	"""
+	Logical-model introspection: the root module tree (name "").
+	Resolved on the metadata path, like __schema/__type.
+	"""
+	_catalog: _Module @system
+
+	"""
+	Logical-model introspection: direct module lookup; "" = the root module.
+	"""
+	_module(name: String!): _Module @system
+
+	"""
+	Logical-model introspection: data object by GraphQL type name;
+	null for non-data-object types.
+	"""
+	_dataObject(name: String!): _DataObject @system
+
+	"""
+	Logical-model introspection: callable member (function/mutation/subscription)
+	of a module; module "" = root-level functions.
+	"""
+	_function(module: String!, name: String!): _Function @system
 }
 
 type Mutation @system {
@@ -278,4 +301,164 @@ type _distribution_by_bucket_aggregation @system {
 	denominator: FloatAggregation
 	# total value for the denominator, used for ratio calculation
 	denominator_total: FloatAggregation
+}
+
+# --- hugr logical-model introspection (_catalog meta-query family) ---
+# The root meta queries (_catalog / _module / _dataObject / _function) are
+# declared on the Query type above; they are resolved on the metadata path,
+# like __schema/__type, and never planned as data queries.
+
+"""
+The kind of a data object.
+"""
+enum _DataObjectType @system {
+	TABLE
+	VIEW
+}
+
+"""
+The kind of a callable module member.
+"""
+enum _FunctionType @system {
+	FUNCTION
+	MUTATION
+	SUBSCRIPTION
+}
+
+"""
+The perspective of a relation entry: FORWARD — the viewed object is the source
+of the edge; BACK — the viewed object is the destination.
+"""
+enum _RelationDirection @system {
+	FORWARD
+	BACK
+}
+
+"""
+The nature of a relation edge. JOIN edges are one-directional (always FORWARD).
+"""
+enum _RelationKind @system {
+	FK
+	M2M
+	JOIN
+}
+
+"""
+A node in hugr's logical module tree. The root module has name "" and owns
+everything attached directly to Query/Mutation/Subscription/Function/MutationFunction.
+"""
+type _Module @system {
+	"""Full dotted module name; empty string for the root module."""
+	name: String!
+	description: String
+	"""Curated/summarized long description."""
+	longDescription: String
+	"""Distinct data sources contributing this module's direct members."""
+	dataSources: [String!]!
+	"""Direct child modules only; children with no visible content are omitted."""
+	modules: [_Module!]
+	"""Data objects whose @module is this module (root: objects without @module)."""
+	dataObjects: [_DataObject!]
+	"""All callable members, including SUBSCRIPTION kind."""
+	functions: [_Function!]
+	"""The module's generated query root type (root module: Query)."""
+	queryType: __Type
+	"""The module's generated mutation root type (root module: Mutation)."""
+	mutationType: __Type
+	"""The module's generated subscription root type (root module: Subscription)."""
+	subscriptionType: __Type
+	"""The module's generated function root type (root module: Function)."""
+	functionType: __Type
+	"""The module's generated mutation-function root type (root module: MutationFunction)."""
+	mutationFunctionType: __Type
+}
+
+"""
+Extensible property flags of a data object. Adding a flag is a backward-compatible change.
+"""
+type _DataObjectProperties @system {
+	"""Declared as an aggregation cube (@cube)."""
+	isCube: Boolean!
+	"""A many-to-many junction table (@table(is_m2m: true))."""
+	isM2M: Boolean!
+	"""A hypertable (@hypertable)."""
+	isHypertable: Boolean!
+	"""Soft-delete semantics enabled (@table(soft_delete: true))."""
+	softDelete: Boolean!
+	"""Has Vector-typed fields (semantic search capable)."""
+	hasVectors: Boolean!
+}
+
+"""
+A table or view as a logical entity of the hugr data model.
+"""
+type _DataObject @system {
+	"""GraphQL type name (source-prefixed, globally unique)."""
+	name: String!
+	type: _DataObjectType!
+	properties: _DataObjectProperties!
+	description: String
+	longDescription: String
+	"""Owning module's dotted name; empty string for the root module."""
+	moduleName: String!
+	"""Owning module (recursive back-reference, depth-budgeted)."""
+	module: _Module
+	"""Field names carrying @pk; empty when the object has no primary key."""
+	primaryKey: [String!]!
+	"""Parameterized-view arguments; null when the object is not parameterized."""
+	args: [__InputValue!]
+	"""The object's fields (permission-filtered, same rules as __Type.fields)."""
+	fields: [__Field!]
+	"""Logical links to other data objects (both directions; hidden endpoints excluded)."""
+	relations: [_Relation!]
+	"""The OWNING data source."""
+	dataSourceName: String!
+	"""All contributing sources: owner + declarers of extension-added fields."""
+	dataSources: [String!]!
+}
+
+"""
+One perspective on a logical edge between two data objects. Relation SQL is never exposed.
+"""
+type _Relation @system {
+	"""Relation name (@references(name:)) or the join field name."""
+	name: String!
+	direction: _RelationDirection!
+	kind: _RelationKind!
+	"""The field on the VIEWED object that materializes this edge."""
+	fieldName: String
+	"""Per-endpoint description (same perspective rule as fieldName)."""
+	description: String
+	"""The FAR data object (for M2M: the far leg, not the junction)."""
+	dataObject: _DataObject
+	"""M2M only: the junction data object; null otherwise."""
+	through: _DataObject
+	"""Key field mappings on the source side (M2M: the source junction leg)."""
+	sourceKeys: [String!]!
+	"""Key field mappings on the destination side (M2M: the destination junction leg)."""
+	destinationKeys: [String!]!
+	"""The data source declaring this edge (cross-source edges are visible)."""
+	dataSource: String
+}
+
+"""
+A callable member of a module: a query function, a mutation, or a subscription.
+"""
+type _Function @system {
+	"""Field name on the module's function/mutation-function/subscription root type."""
+	name: String!
+	type: _FunctionType!
+	description: String
+	longDescription: String
+	"""Owning module's dotted name; empty string for root-level functions."""
+	moduleName: String!
+	"""Owning module (recursive back-reference, depth-budgeted)."""
+	module: _Module
+	"""Client-facing arguments; server-injected @arg_default arguments are excluded."""
+	args: [__InputValue!]
+	returns: __Type
+	"""True when the function returns a row set (table function) rather than a scalar."""
+	isTable: Boolean!
+	"""The owning data source."""
+	dataSourceName: String
 }

--- a/pkg/catalog/compiler/base/system_types.graphql
+++ b/pkg/catalog/compiler/base/system_types.graphql
@@ -92,6 +92,15 @@ type Query @system {
 	of a module; module "" = root-level functions.
 	"""
 	_function(module: String!, name: String!): _Function @system
+
+	"""
+	Logical-model introspection: GraphQL type definitions of the logical
+	model. SOURCE (default) lists the residual base types defined by data
+	sources — structural objects, inputs, enums — excluding data objects,
+	module roots and compiler-generated helper types; SYSTEM lists the
+	engine-defined types (scalars, introspection and hugr system SDL).
+	"""
+	_types(scope: _TypeScope = SOURCE): [__Type!] @system
 }
 
 type Mutation @system {
@@ -307,6 +316,17 @@ type _distribution_by_bucket_aggregation @system {
 # The root meta queries (_catalog / _module / _dataObject / _function) are
 # declared on the Query type above; they are resolved on the metadata path,
 # like __schema/__type, and never planned as data queries.
+
+"""
+The scope of logical-model type listings: SOURCE — residual base types
+defined by data sources; SYSTEM — engine-defined types. Compiler-derived
+types (filters, aggregations, mutation inputs, module roots) belong to
+neither scope.
+"""
+enum _TypeScope @system {
+	SOURCE
+	SYSTEM
+}
 
 """
 The kind of a data object.

--- a/pkg/catalog/logical.go
+++ b/pkg/catalog/logical.go
@@ -93,12 +93,31 @@ type LogicalModel interface {
 	Functions(ctx context.Context, module string) iter.Seq[*FunctionEntry]
 	// Relations iterates the logical edges of a data object, both directions.
 	Relations(ctx context.Context, object string) iter.Seq[*RelationInfo]
+	// Type resolves a GraphQL type definition by name; nil when absent.
+	// (Entity storage: the ForName resolution chain.)
+	Type(ctx context.Context, name string) *ast.Definition
+	// SourceTypes iterates the residual base types DEFINED BY SOURCES —
+	// structural objects, inputs (incl. @args), enums, interfaces, unions
+	// that are not data objects, module roots, or compiler-generated
+	// helpers (filters, mutation inputs, aggregations). This is exactly
+	// the content of the future entity-storage types table.
+	SourceTypes(ctx context.Context) iter.Seq2[string, *ast.Definition]
+	// SystemTypes iterates engine-defined types: scalars, the introspection
+	// and hugr system SDL, scalar filter/aggregation inputs — the future
+	// binary-owned static prelude. Compiler-DERIVED types (filters,
+	// aggregations, mutation inputs, module roots) belong to neither set.
+	SystemTypes(ctx context.Context) iter.Seq2[string, *ast.Definition]
 }
 
 // LogicalModelFromProvider adapts a compiled-schema Provider to the
 // LogicalModel interface via top-down point lookups (module root types →
 // fields → base definitions) — no full-type enumeration on any path.
+// A provider that already implements LogicalModel natively (the future
+// entity-storage catalog) is returned as-is, without the walk adapter.
 func LogicalModelFromProvider(p Provider) LogicalModel {
+	if lp, ok := p.(LogicalModel); ok {
+		return lp
+	}
 	return &providerLogicalModel{p: p}
 }
 
@@ -142,6 +161,7 @@ func (m *providerLogicalModel) Module(ctx context.Context, name string) *ModuleI
 func (m *providerLogicalModel) Modules(ctx context.Context, parent string) iter.Seq[*ModuleInfo] {
 	return func(yield func(*ModuleInfo) bool) {
 		seen := map[string]struct{}{}
+		var children []string
 		for _, kind := range moduleKinds {
 			root := m.p.ForName(ctx, sdl.ModuleTypeName(parent, kind))
 			if root == nil {
@@ -156,13 +176,21 @@ func (m *providerLogicalModel) Modules(ctx context.Context, parent string) iter.
 					continue
 				}
 				seen[child] = struct{}{}
-				info := m.Module(ctx, child)
-				if info == nil {
-					continue
-				}
-				if !yield(info) {
-					return
-				}
+				children = append(children, child)
+			}
+		}
+		// Deterministic listing order: the compiled root-type field order is
+		// not stable across compilations (unsorted map iteration in the
+		// assembler), so sort by name — matching the future entity-storage
+		// ORDER BY contract.
+		slices.Sort(children)
+		for _, child := range children {
+			info := m.Module(ctx, child)
+			if info == nil {
+				continue
+			}
+			if !yield(info) {
+				return
 			}
 		}
 	}
@@ -200,6 +228,7 @@ func (m *providerLogicalModel) DataObjects(ctx context.Context, module string) i
 			return
 		}
 		seen := map[string]struct{}{}
+		var names []string
 		for _, f := range root.Fields {
 			if !sdl.IsSelectQueryDefinition(f) {
 				continue
@@ -209,6 +238,11 @@ func (m *providerLogicalModel) DataObjects(ctx context.Context, module string) i
 				continue
 			}
 			seen[tn] = struct{}{}
+			names = append(names, tn)
+		}
+		// Deterministic listing order (see Modules).
+		slices.Sort(names)
+		for _, tn := range names {
 			info := m.DataObject(ctx, tn)
 			if info == nil {
 				continue
@@ -231,11 +265,25 @@ func (m *providerLogicalModel) Function(ctx context.Context, module, name string
 
 func (m *providerLogicalModel) Functions(ctx context.Context, module string) iter.Seq[*FunctionEntry] {
 	return func(yield func(*FunctionEntry) bool) {
+		// Deterministic listing order (see Modules): fixed kind order, fields
+		// sorted by name within each kind.
+		yieldSorted := func(entries []*FunctionEntry) bool {
+			slices.SortFunc(entries, func(a, b *FunctionEntry) int {
+				return strings.Compare(a.Field.Name, b.Field.Name)
+			})
+			for _, entry := range entries {
+				if !yield(entry) {
+					return false
+				}
+			}
+			return true
+		}
 		for _, kind := range []sdl.ModuleObjectType{sdl.ModuleFunction, sdl.ModuleMutationFunction} {
 			root := m.p.ForName(ctx, sdl.ModuleTypeName(module, kind))
 			if root == nil {
 				continue
 			}
+			var entries []*FunctionEntry
 			for _, f := range root.Fields {
 				if !sdl.IsFunction(f) {
 					continue
@@ -244,37 +292,36 @@ func (m *providerLogicalModel) Functions(ctx context.Context, module string) ite
 				if err != nil {
 					continue
 				}
-				entry := &FunctionEntry{
+				entries = append(entries, &FunctionEntry{
 					Field:      f,
 					Kind:       kind,
 					Module:     module,
 					DataSource: fi.Catalog,
 					IsTable:    fi.ReturnsTable,
-				}
-				if !yield(entry) {
-					return
-				}
+				})
+			}
+			if !yieldSorted(entries) {
+				return
 			}
 		}
 		root := m.p.ForName(ctx, sdl.ModuleTypeName(module, sdl.ModuleSubscription))
 		if root == nil {
 			return
 		}
+		var entries []*FunctionEntry
 		for _, f := range root.Fields {
 			if !isSubscriptionField(f) || m.submoduleName(ctx, f) != "" {
 				continue
 			}
-			entry := &FunctionEntry{
+			entries = append(entries, &FunctionEntry{
 				Field:      f,
 				Kind:       sdl.ModuleSubscription,
 				Module:     module,
 				DataSource: base.FieldDefCatalog(f),
 				IsTable:    f.Type.NamedType == "",
-			}
-			if !yield(entry) {
-				return
-			}
+			})
 		}
+		yieldSorted(entries)
 	}
 }
 
@@ -307,6 +354,51 @@ func (m *providerLogicalModel) moduleDataSources(ctx context.Context, module str
 	return res
 }
 
+func (m *providerLogicalModel) Type(ctx context.Context, name string) *ast.Definition {
+	return m.p.ForName(ctx, name)
+}
+
+func (m *providerLogicalModel) SourceTypes(ctx context.Context) iter.Seq2[string, *ast.Definition] {
+	return func(yield func(string, *ast.Definition) bool) {
+		for name, def := range m.p.Types(ctx) {
+			if !isSourceDefinedType(def) {
+				continue
+			}
+			if !yield(name, def) {
+				return
+			}
+		}
+	}
+}
+
+func (m *providerLogicalModel) SystemTypes(ctx context.Context) iter.Seq2[string, *ast.Definition] {
+	return func(yield func(string, *ast.Definition) bool) {
+		for name, def := range m.p.Types(ctx) {
+			if !sdl.IsSystemType(def) {
+				continue
+			}
+			if !yield(name, def) {
+				return
+			}
+		}
+	}
+}
+
+// isSourceDefinedType reports whether a definition is a residual base type
+// contributed by a source — what the entity-storage types table will hold.
+// Excluded: system types (scalars, __*, roots, @system incl. the scalar
+// registry), data objects, module root types, and compiler-generated helpers
+// (filter/mutation inputs, aggregation types).
+func isSourceDefinedType(def *ast.Definition) bool {
+	if sdl.IsSystemType(def) || sdl.IsDataObject(def) || sdl.ModuleRootInfo(def) != nil {
+		return false
+	}
+	return def.Directives.ForName(base.FilterInputDirectiveName) == nil &&
+		def.Directives.ForName(base.FilterListInputDirectiveName) == nil &&
+		def.Directives.ForName(base.DataInputDirectiveName) == nil &&
+		def.Directives.ForName(base.ObjectAggregationDirectiveName) == nil
+}
+
 // Relations derives the logical edges of a data object from the compiled
 // schema:
 //   - the object's own @references directives → FORWARD FK edges (and this
@@ -327,6 +419,7 @@ func (m *providerLogicalModel) Relations(ctx context.Context, object string) ite
 		}
 		ownerSource := sdl.CatalogName(def)
 		ownRefs := map[string]struct{}{}
+		var rels []*RelationInfo
 
 		for _, d := range def.Directives.ForNames(base.ReferencesDirectiveName) {
 			ref := sdl.ReferencesInfo(d)
@@ -357,9 +450,7 @@ func (m *providerLogicalModel) Relations(ctx context.Context, object string) ite
 					}
 				}
 			}
-			if !yield(rel) {
-				return
-			}
+			rels = append(rels, rel)
 		}
 
 		for _, f := range def.Fields {
@@ -401,9 +492,7 @@ func (m *providerLogicalModel) Relations(ctx context.Context, object string) ite
 					rel.Kind = RelationM2M
 					rel.Through = ref.M2MName
 				}
-				if !yield(rel) {
-					return
-				}
+				rels = append(rels, rel)
 
 			case sdl.IsJoinSubqueryDefinition(f):
 				d := f.Directives.ForName(base.JoinDirectiveName)
@@ -423,9 +512,26 @@ func (m *providerLogicalModel) Relations(ctx context.Context, object string) ite
 					DestinationKeys: base.DirectiveArgStrings(d, base.ArgReferencesFields),
 					DataSource:      base.FieldDefCatalog(f),
 				}
-				if !yield(rel) {
-					return
-				}
+				rels = append(rels, rel)
+			}
+		}
+
+		// Deterministic listing order (see Modules).
+		slices.SortFunc(rels, func(a, b *RelationInfo) int {
+			if c := strings.Compare(a.Name, b.Name); c != 0 {
+				return c
+			}
+			if c := strings.Compare(string(a.Kind), string(b.Kind)); c != 0 {
+				return c
+			}
+			if c := strings.Compare(string(a.Direction), string(b.Direction)); c != 0 {
+				return c
+			}
+			return strings.Compare(a.FieldName, b.FieldName)
+		})
+		for _, rel := range rels {
+			if !yield(rel) {
+				return
 			}
 		}
 	}

--- a/pkg/catalog/logical.go
+++ b/pkg/catalog/logical.go
@@ -1,0 +1,432 @@
+package catalog
+
+import (
+	"context"
+	"iter"
+	"slices"
+	"strings"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
+	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// moduleKinds lists all module root kinds in a fixed iteration order.
+var moduleKinds = []sdl.ModuleObjectType{
+	sdl.ModuleQuery,
+	sdl.ModuleMutation,
+	sdl.ModuleFunction,
+	sdl.ModuleMutationFunction,
+	sdl.ModuleSubscription,
+}
+
+// ModuleInfo describes one node of the logical module tree.
+type ModuleInfo struct {
+	Name        string // full dotted name; "" for the root module
+	Description string
+	// RootTypes holds the resolved module root type per kind; a module exists
+	// when at least one kind resolves.
+	RootTypes   map[sdl.ModuleObjectType]*ast.Definition
+	DataSources []string // distinct data sources of direct members, sorted
+}
+
+// FunctionEntry describes one callable member of a module: a query function,
+// a mutation function, or a subscription field.
+type FunctionEntry struct {
+	Field      *ast.FieldDefinition
+	Kind       sdl.ModuleObjectType // ModuleFunction | ModuleMutationFunction | ModuleSubscription
+	Module     string
+	DataSource string
+	IsTable    bool
+}
+
+type RelationDirection string
+
+const (
+	RelationForward RelationDirection = "FORWARD"
+	RelationBack    RelationDirection = "BACK"
+)
+
+type RelationKind string
+
+const (
+	RelationFK   RelationKind = "FK"
+	RelationM2M  RelationKind = "M2M"
+	RelationJoin RelationKind = "JOIN"
+)
+
+// RelationInfo is one perspective on a logical edge between two data objects.
+// FK and M2M edges are visible from both ends (FORWARD from the declaring
+// side, BACK from the referenced side); JOIN edges are one-directional.
+type RelationInfo struct {
+	Name            string
+	Direction       RelationDirection
+	Kind            RelationKind
+	FieldName       string // the field ON the viewed object materializing the edge
+	Description     string // per-endpoint description (same perspective as FieldName)
+	DataObject      string // far data object type name (M2M: the far leg, not the junction)
+	Through         string // M2M junction type name; "" otherwise
+	SourceKeys      []string
+	DestinationKeys []string
+	DataSource      string // declaring data source
+}
+
+// LogicalModel is the narrow logical-model surface consumed by the _catalog
+// introspection resolvers. It returns the UNFILTERED model — permission
+// filtering is applied by consumers from the request context. The walk-based
+// adapter below implements it over any Provider; the future entity-storage
+// provider implements it natively.
+type LogicalModel interface {
+	// Module resolves a module by full dotted name ("" = root); nil when absent.
+	Module(ctx context.Context, name string) *ModuleInfo
+	// Modules iterates the DIRECT child modules of parent.
+	Modules(ctx context.Context, parent string) iter.Seq[*ModuleInfo]
+	// DataObject resolves a data object by GraphQL type name; nil for
+	// non-data-object types.
+	DataObject(ctx context.Context, name string) *sdl.Object
+	// DataObjects iterates the data objects that are members of a module.
+	DataObjects(ctx context.Context, module string) iter.Seq[*sdl.Object]
+	// Function resolves a callable member of a module by field name, probing
+	// the function, mutation-function and subscription roots in that order.
+	Function(ctx context.Context, module, name string) *FunctionEntry
+	// Functions iterates all callable members of a module (all three kinds).
+	Functions(ctx context.Context, module string) iter.Seq[*FunctionEntry]
+	// Relations iterates the logical edges of a data object, both directions.
+	Relations(ctx context.Context, object string) iter.Seq[*RelationInfo]
+}
+
+// LogicalModelFromProvider adapts a compiled-schema Provider to the
+// LogicalModel interface via top-down point lookups (module root types →
+// fields → base definitions) — no full-type enumeration on any path.
+func LogicalModelFromProvider(p Provider) LogicalModel {
+	return &providerLogicalModel{p: p}
+}
+
+type providerLogicalModel struct {
+	p Provider
+}
+
+var _ LogicalModel = (*providerLogicalModel)(nil)
+
+func (m *providerLogicalModel) rootTypes(ctx context.Context, name string) map[sdl.ModuleObjectType]*ast.Definition {
+	roots := map[sdl.ModuleObjectType]*ast.Definition{}
+	for _, kind := range moduleKinds {
+		if def := m.p.ForName(ctx, sdl.ModuleTypeName(name, kind)); def != nil {
+			roots[kind] = def
+		}
+	}
+	return roots
+}
+
+func (m *providerLogicalModel) Module(ctx context.Context, name string) *ModuleInfo {
+	roots := m.rootTypes(ctx, name)
+	if len(roots) == 0 {
+		return nil
+	}
+	info := &ModuleInfo{Name: name, RootTypes: roots}
+	if name == "" {
+		info.Description = m.p.Description(ctx)
+	}
+	if info.Description == "" {
+		for _, kind := range moduleKinds {
+			if def, ok := roots[kind]; ok && def.Description != "" {
+				info.Description = def.Description
+				break
+			}
+		}
+	}
+	info.DataSources = m.moduleDataSources(ctx, name)
+	return info
+}
+
+func (m *providerLogicalModel) Modules(ctx context.Context, parent string) iter.Seq[*ModuleInfo] {
+	return func(yield func(*ModuleInfo) bool) {
+		seen := map[string]struct{}{}
+		for _, kind := range moduleKinds {
+			root := m.p.ForName(ctx, sdl.ModuleTypeName(parent, kind))
+			if root == nil {
+				continue
+			}
+			for _, f := range root.Fields {
+				child := m.submoduleName(ctx, f)
+				if child == "" {
+					continue
+				}
+				if _, ok := seen[child]; ok {
+					continue
+				}
+				seen[child] = struct{}{}
+				info := m.Module(ctx, child)
+				if info == nil {
+					continue
+				}
+				if !yield(info) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// submoduleName returns the full dotted module name when the field navigates
+// to a submodule root type, "" otherwise.
+func (m *providerLogicalModel) submoduleName(ctx context.Context, f *ast.FieldDefinition) string {
+	if f.Type.NamedType == "" || strings.HasPrefix(f.Name, "__") {
+		return ""
+	}
+	td := m.p.ForName(ctx, f.Type.NamedType)
+	if td == nil {
+		return ""
+	}
+	mi := sdl.ModuleRootInfo(td)
+	if mi == nil {
+		return ""
+	}
+	return mi.Name
+}
+
+func (m *providerLogicalModel) DataObject(ctx context.Context, name string) *sdl.Object {
+	def := m.p.ForName(ctx, name)
+	if def == nil || !sdl.IsDataObject(def) {
+		return nil
+	}
+	return sdl.DataObjectInfo(def)
+}
+
+func (m *providerLogicalModel) DataObjects(ctx context.Context, module string) iter.Seq[*sdl.Object] {
+	return func(yield func(*sdl.Object) bool) {
+		root := m.p.ForName(ctx, sdl.ModuleTypeName(module, sdl.ModuleQuery))
+		if root == nil {
+			return
+		}
+		seen := map[string]struct{}{}
+		for _, f := range root.Fields {
+			if !sdl.IsSelectQueryDefinition(f) {
+				continue
+			}
+			tn := f.Type.Name()
+			if _, ok := seen[tn]; ok {
+				continue
+			}
+			seen[tn] = struct{}{}
+			info := m.DataObject(ctx, tn)
+			if info == nil {
+				continue
+			}
+			if !yield(info) {
+				return
+			}
+		}
+	}
+}
+
+func (m *providerLogicalModel) Function(ctx context.Context, module, name string) *FunctionEntry {
+	for entry := range m.Functions(ctx, module) {
+		if entry.Field.Name == name {
+			return entry
+		}
+	}
+	return nil
+}
+
+func (m *providerLogicalModel) Functions(ctx context.Context, module string) iter.Seq[*FunctionEntry] {
+	return func(yield func(*FunctionEntry) bool) {
+		for _, kind := range []sdl.ModuleObjectType{sdl.ModuleFunction, sdl.ModuleMutationFunction} {
+			root := m.p.ForName(ctx, sdl.ModuleTypeName(module, kind))
+			if root == nil {
+				continue
+			}
+			for _, f := range root.Fields {
+				if !sdl.IsFunction(f) {
+					continue
+				}
+				fi, err := sdl.FunctionInfo(f)
+				if err != nil {
+					continue
+				}
+				entry := &FunctionEntry{
+					Field:      f,
+					Kind:       kind,
+					Module:     module,
+					DataSource: fi.Catalog,
+					IsTable:    fi.ReturnsTable,
+				}
+				if !yield(entry) {
+					return
+				}
+			}
+		}
+		root := m.p.ForName(ctx, sdl.ModuleTypeName(module, sdl.ModuleSubscription))
+		if root == nil {
+			return
+		}
+		for _, f := range root.Fields {
+			if !isSubscriptionField(f) || m.submoduleName(ctx, f) != "" {
+				continue
+			}
+			entry := &FunctionEntry{
+				Field:      f,
+				Kind:       sdl.ModuleSubscription,
+				Module:     module,
+				DataSource: base.FieldDefCatalog(f),
+				IsTable:    f.Type.NamedType == "",
+			}
+			if !yield(entry) {
+				return
+			}
+		}
+	}
+}
+
+// isSubscriptionField filters out placeholder and system fields of a
+// subscription root type (same skip set the module assembler uses).
+func isSubscriptionField(f *ast.FieldDefinition) bool {
+	if strings.HasPrefix(f.Name, "__") {
+		return false
+	}
+	return f.Name != "_stub" && f.Name != "_placeholder" && f.Name != "query"
+}
+
+func (m *providerLogicalModel) moduleDataSources(ctx context.Context, module string) []string {
+	seen := map[string]struct{}{}
+	for o := range m.DataObjects(ctx, module) {
+		if o.Catalog != "" {
+			seen[o.Catalog] = struct{}{}
+		}
+	}
+	for f := range m.Functions(ctx, module) {
+		if f.DataSource != "" {
+			seen[f.DataSource] = struct{}{}
+		}
+	}
+	res := make([]string, 0, len(seen))
+	for s := range seen {
+		res = append(res, s)
+	}
+	slices.Sort(res)
+	return res
+}
+
+// Relations derives the logical edges of a data object from the compiled
+// schema:
+//   - the object's own @references directives → FORWARD FK edges (and this
+//     side's M2M leg: the compiler rewrites junction @field_references into
+//     @references(is_m2m, m2m_name) on BOTH endpoints);
+//   - generated @references_query fields that do NOT materialize an own
+//     declaration → BACK projections of the far object's @references;
+//   - @join fields targeting a data object → one-directional JOIN edges.
+//
+// Keys stay in the relation's canonical source→destination orientation
+// regardless of direction (one logical edge, two projections). Join SQL is
+// never surfaced.
+func (m *providerLogicalModel) Relations(ctx context.Context, object string) iter.Seq[*RelationInfo] {
+	return func(yield func(*RelationInfo) bool) {
+		def := m.p.ForName(ctx, object)
+		if def == nil || !sdl.IsDataObject(def) {
+			return
+		}
+		ownerSource := sdl.CatalogName(def)
+		ownRefs := map[string]struct{}{}
+
+		for _, d := range def.Directives.ForNames(base.ReferencesDirectiveName) {
+			ref := sdl.ReferencesInfo(d)
+			if ref == nil {
+				continue
+			}
+			ownRefs[ref.Name] = struct{}{}
+			rel := &RelationInfo{
+				Name:            ref.Name,
+				Direction:       RelationForward,
+				Kind:            RelationFK,
+				FieldName:       ref.Query,
+				Description:     ref.Description,
+				DataObject:      ref.ReferencesName,
+				SourceKeys:      ref.SourceFields(),
+				DestinationKeys: ref.ReferencesFields(),
+				DataSource:      ownerSource,
+			}
+			if ref.IsM2M {
+				rel.Kind = RelationM2M
+				rel.Through = ref.M2MName
+			}
+			// Extension-declared references attribute their navigation field.
+			if rel.FieldName != "" {
+				if f := def.Fields.ForName(rel.FieldName); f != nil {
+					if c := base.FieldDefCatalog(f); c != "" {
+						rel.DataSource = c
+					}
+				}
+			}
+			if !yield(rel) {
+				return
+			}
+		}
+
+		for _, f := range def.Fields {
+			switch {
+			case sdl.IsReferencesSubquery(f):
+				name := base.FieldDefDirectiveArgString(f, base.FieldReferencesQueryDirectiveName, base.ArgName)
+				if _, ok := ownRefs[name]; ok {
+					// Materializes an own declaration emitted above.
+					continue
+				}
+				// BACK projection: the declaring object is the field's element type.
+				farName := f.Type.Name()
+				far := m.p.ForName(ctx, farName)
+				if far == nil {
+					continue
+				}
+				var ref *sdl.References
+				for _, d := range far.Directives.ForNames(base.ReferencesDirectiveName) {
+					if ri := sdl.ReferencesInfo(d); ri != nil && ri.Name == name {
+						ref = ri
+						break
+					}
+				}
+				if ref == nil {
+					continue
+				}
+				rel := &RelationInfo{
+					Name:            ref.Name,
+					Direction:       RelationBack,
+					Kind:            RelationFK,
+					FieldName:       f.Name,
+					Description:     ref.ReferencesDescription,
+					DataObject:      farName,
+					SourceKeys:      ref.SourceFields(),
+					DestinationKeys: ref.ReferencesFields(),
+					DataSource:      base.FieldDefCatalog(f),
+				}
+				if ref.IsM2M {
+					rel.Kind = RelationM2M
+					rel.Through = ref.M2MName
+				}
+				if !yield(rel) {
+					return
+				}
+
+			case sdl.IsJoinSubqueryDefinition(f):
+				d := f.Directives.ForName(base.JoinDirectiveName)
+				target := base.DirectiveArgString(d, base.ArgReferencesName)
+				targetDef := m.p.ForName(ctx, target)
+				if targetDef == nil || !sdl.IsDataObject(targetDef) {
+					continue
+				}
+				rel := &RelationInfo{
+					Name:            f.Name,
+					Direction:       RelationForward,
+					Kind:            RelationJoin,
+					FieldName:       f.Name,
+					Description:     f.Description,
+					DataObject:      target,
+					SourceKeys:      base.DirectiveArgStrings(d, base.ArgSourceFields),
+					DestinationKeys: base.DirectiveArgStrings(d, base.ArgReferencesFields),
+					DataSource:      base.FieldDefCatalog(f),
+				}
+				if !yield(rel) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/pkg/catalog/logical_test.go
+++ b/pkg/catalog/logical_test.go
@@ -1,0 +1,309 @@
+package catalog_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog"
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler"
+	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
+	"github.com/hugr-lab/query-engine/pkg/catalog/sources"
+	"github.com/hugr-lab/query-engine/pkg/catalog/static"
+	"github.com/hugr-lab/query-engine/pkg/engines"
+)
+
+const logicalTestSchema = `
+type customers @module(name: "sales") @table(name: "customers") {
+  id: Int! @pk
+  name: String!
+  country: String
+}
+
+type orders @module(name: "sales")
+  @table(name: "orders")
+  @references(
+    name: "order_customer"
+    references_name: "customers"
+    source_fields: ["customer_id"]
+    references_fields: ["id"]
+    query: "customer"
+    description: "Order customer"
+    references_query: "orders"
+    references_description: "Customer orders"
+  ) {
+  id: Int! @pk
+  customer_id: Int!
+  amount: Float
+  status: String
+  source_info: [tags]
+    @join(
+      references_name: "tags"
+      source_fields: ["status"]
+      references_fields: ["name"]
+    )
+}
+
+type tags @module(name: "sales") @table(name: "tags") {
+  name: String! @pk
+}
+
+type order_tags @module(name: "sales")
+  @table(name: "order_tags", is_m2m: true) {
+  order_id: Int! @pk @field_references(references_name: "orders", field: "id", query: "tags", references_query: "orders")
+  tag_name: String! @pk @field_references(references_name: "tags", field: "name", query: "orders", references_query: "tags")
+}
+
+type sales_by_country @module(name: "sales.reports")
+  @view(
+    name: "sales_by_country"
+    sql: "SELECT c.country AS country, sum(o.amount) AS total FROM orders o JOIN customers c ON o.customer_id = c.id WHERE c.country = [$country] GROUP BY c.country"
+  )
+  @args(name: "sales_by_country_args") {
+  country: String @pk
+  total: Float
+}
+
+input sales_by_country_args {
+  country: String!
+}
+
+type root_things @table(name: "root_things") {
+  id: Int! @pk
+  name: String
+}
+
+extend type Function {
+  order_status(id: Int!): String @module(name: "sales")
+    @function(name: "order_status")
+}
+
+extend type MutationFunction {
+  reprice_orders(factor: Float!): OperationResult @module(name: "sales")
+    @function(name: "reprice_orders")
+}
+
+type order_event {
+  type: String
+  order_id: Int
+}
+
+extend type Subscription {
+  order_events(status: String): order_event @module(name: "sales")
+  tick(interval: String): String @module(name: "events")
+}
+`
+
+func newLogicalTestProvider(t *testing.T) catalog.Provider {
+	t.Helper()
+	provider, err := static.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss := catalog.NewService(provider)
+	e := &engines.DuckDB{}
+	cat, err := sources.NewStringSource("test", e, compiler.Options{
+		Name:         "test",
+		EngineType:   string(e.Type()),
+		Capabilities: e.Capabilities(),
+	}, logicalTestSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = ss.AddCatalog(context.Background(), "test", cat); err != nil {
+		t.Fatal(err)
+	}
+	return ss.Provider()
+}
+
+func TestLogicalModelFromProvider(t *testing.T) {
+	lm := catalog.LogicalModelFromProvider(newLogicalTestProvider(t))
+	ctx := t.Context()
+
+	t.Run("root module", func(t *testing.T) {
+		root := lm.Module(ctx, "")
+		if root == nil {
+			t.Fatal("root module not resolved")
+		}
+		if root.Name != "" {
+			t.Errorf("root module name = %q, want empty", root.Name)
+		}
+		if qt := root.RootTypes[sdl.ModuleQuery]; qt == nil || qt.Name != "Query" {
+			t.Errorf("root query type = %v, want Query", qt)
+		}
+	})
+
+	t.Run("module existence", func(t *testing.T) {
+		if lm.Module(ctx, "sales") == nil {
+			t.Error("module sales not resolved")
+		}
+		if lm.Module(ctx, "sales.reports") == nil {
+			t.Error("module sales.reports not resolved")
+		}
+		if lm.Module(ctx, "nope") != nil {
+			t.Error("unknown module resolved, want nil")
+		}
+	})
+
+	t.Run("subscription-only module", func(t *testing.T) {
+		ev := lm.Module(ctx, "events")
+		if ev == nil {
+			t.Fatal("subscription-only module events not resolved")
+		}
+		if ev.RootTypes[sdl.ModuleSubscription] == nil {
+			t.Error("events module has no subscription root type")
+		}
+		if len(ev.RootTypes) != 1 {
+			t.Errorf("events module has %d root kinds, want 1", len(ev.RootTypes))
+		}
+		if !slices.Equal(ev.DataSources, []string{"test"}) {
+			t.Errorf("events dataSources = %v, want [test]", ev.DataSources)
+		}
+	})
+
+	t.Run("direct children only", func(t *testing.T) {
+		var names []string
+		for m := range lm.Modules(ctx, "") {
+			names = append(names, m.Name)
+		}
+		slices.Sort(names)
+		for _, want := range []string{"events", "sales"} {
+			if !slices.Contains(names, want) {
+				t.Errorf("root children %v missing %q", names, want)
+			}
+		}
+		if slices.Contains(names, "sales.reports") {
+			t.Errorf("root children %v must not contain nested sales.reports", names)
+		}
+
+		names = names[:0]
+		for m := range lm.Modules(ctx, "sales") {
+			names = append(names, m.Name)
+		}
+		if !slices.Contains(names, "sales.reports") {
+			t.Errorf("sales children %v missing sales.reports", names)
+		}
+	})
+
+	t.Run("data objects", func(t *testing.T) {
+		var names []string
+		for o := range lm.DataObjects(ctx, "sales") {
+			names = append(names, o.TypeName())
+		}
+		slices.Sort(names)
+		want := []string{"customers", "order_tags", "orders", "tags"}
+		if !slices.Equal(names, want) {
+			t.Errorf("sales data objects = %v, want %v", names, want)
+		}
+
+		names = names[:0]
+		for o := range lm.DataObjects(ctx, "") {
+			names = append(names, o.TypeName())
+		}
+		if !slices.Contains(names, "root_things") {
+			t.Errorf("root data objects %v missing root_things", names)
+		}
+	})
+
+	t.Run("data object lookup", func(t *testing.T) {
+		if o := lm.DataObject(ctx, "customers"); o == nil || o.Catalog != "test" {
+			t.Errorf("customers lookup = %+v, want object with catalog test", o)
+		}
+		if lm.DataObject(ctx, "Query") != nil {
+			t.Error("Query resolved as data object, want nil")
+		}
+		if lm.DataObject(ctx, "unknown_object") != nil {
+			t.Error("unknown object resolved, want nil")
+		}
+	})
+
+	t.Run("functions", func(t *testing.T) {
+		byName := map[string]*catalog.FunctionEntry{}
+		for f := range lm.Functions(ctx, "sales") {
+			byName[f.Field.Name] = f
+		}
+		if f := byName["order_status"]; f == nil || f.Kind != sdl.ModuleFunction || f.DataSource != "test" {
+			t.Errorf("order_status = %+v, want function kind from test", f)
+		}
+		if f := byName["reprice_orders"]; f == nil || f.Kind != sdl.ModuleMutationFunction {
+			t.Errorf("reprice_orders = %+v, want mutation-function kind", f)
+		}
+		if f := byName["order_events"]; f == nil || f.Kind != sdl.ModuleSubscription {
+			t.Errorf("order_events = %+v, want subscription kind", f)
+		}
+
+		if f := lm.Function(ctx, "events", "tick"); f == nil || f.Kind != sdl.ModuleSubscription {
+			t.Errorf("events.tick = %+v, want subscription entry", f)
+		}
+		if lm.Function(ctx, "sales", "missing") != nil {
+			t.Error("unknown function resolved, want nil")
+		}
+	})
+
+	t.Run("module data sources", func(t *testing.T) {
+		m := lm.Module(ctx, "sales")
+		if m == nil {
+			t.Fatal("sales module not resolved")
+		}
+		if !slices.Equal(m.DataSources, []string{"test"}) {
+			t.Errorf("sales dataSources = %v, want [test]", m.DataSources)
+		}
+	})
+
+	t.Run("relations", func(t *testing.T) {
+		relsOf := func(object string) map[string]*catalog.RelationInfo {
+			t.Helper()
+			res := map[string]*catalog.RelationInfo{}
+			for r := range lm.Relations(ctx, object) {
+				res[string(r.Kind)+"/"+r.Name] = r
+			}
+			return res
+		}
+
+		// orders: FORWARD FK to customers, own M2M leg to tags, JOIN to tags.
+		orders := relsOf("orders")
+		fk := orders["FK/order_customer"]
+		if fk == nil || fk.Direction != catalog.RelationForward || fk.DataObject != "customers" ||
+			fk.FieldName != "customer" ||
+			!slices.Equal(fk.SourceKeys, []string{"customer_id"}) ||
+			!slices.Equal(fk.DestinationKeys, []string{"id"}) {
+			t.Errorf("orders FK = %+v, want FORWARD to customers via customer [customer_id]->[id]", fk)
+		}
+		m2m := orders["M2M/orders_order_id"]
+		if m2m == nil || m2m.DataObject != "tags" || m2m.Through != "order_tags" {
+			t.Errorf("orders M2M = %+v, want far=tags through=order_tags", m2m)
+		}
+		join := orders["JOIN/source_info"]
+		if join == nil || join.Direction != catalog.RelationForward || join.DataObject != "tags" ||
+			!slices.Equal(join.SourceKeys, []string{"status"}) ||
+			!slices.Equal(join.DestinationKeys, []string{"name"}) {
+			t.Errorf("orders JOIN = %+v, want FORWARD to tags [status]->[name]", join)
+		}
+
+		// customers: BACK FK from orders with canonical key orientation.
+		customers := relsOf("customers")
+		back := customers["FK/order_customer"]
+		if back == nil || back.Direction != catalog.RelationBack || back.DataObject != "orders" ||
+			back.FieldName != "orders" ||
+			!slices.Equal(back.SourceKeys, []string{"customer_id"}) ||
+			!slices.Equal(back.DestinationKeys, []string{"id"}) {
+			t.Errorf("customers BACK FK = %+v, want BACK from orders via orders field", back)
+		}
+
+		// tags: own M2M leg to orders; NO back-JOIN entry (join is one-directional).
+		tags := relsOf("tags")
+		if m2m := tags["M2M/tags_tag_name"]; m2m == nil || m2m.DataObject != "orders" || m2m.Through != "order_tags" {
+			t.Errorf("tags M2M = %+v, want far=orders through=order_tags", m2m)
+		}
+		for key, r := range tags {
+			if r.Kind == catalog.RelationJoin {
+				t.Errorf("tags has unexpected JOIN entry %s = %+v (join is one-directional)", key, r)
+			}
+		}
+
+		// non-data-object → empty
+		if len(relsOf("Query")) != 0 {
+			t.Error("Query yielded relations, want none")
+		}
+	})
+}

--- a/pkg/catalog/logical_test.go
+++ b/pkg/catalog/logical_test.go
@@ -250,6 +250,45 @@ func TestLogicalModelFromProvider(t *testing.T) {
 		}
 	})
 
+	t.Run("types", func(t *testing.T) {
+		if d := lm.Type(ctx, "customers"); d == nil || d.Name != "customers" {
+			t.Errorf("Type(customers) = %v, want definition", d)
+		}
+		if d := lm.Type(ctx, "_Module"); d == nil {
+			t.Error("Type(_Module) = nil, want system meta-type definition")
+		}
+		if lm.Type(ctx, "unknown_type") != nil {
+			t.Error("Type(unknown) resolved, want nil")
+		}
+
+		var source []string
+		for _, d := range lm.SourceTypes(ctx) {
+			source = append(source, d.Name)
+		}
+		slices.Sort(source)
+		// exactly the residual source-defined base types — what the future
+		// entity-storage types table will hold
+		want := []string{"order_event", "sales_by_country_args"}
+		if !slices.Equal(source, want) {
+			t.Errorf("SourceTypes() = %v, want %v", source, want)
+		}
+
+		var system []string
+		for _, d := range lm.SystemTypes(ctx) {
+			system = append(system, d.Name)
+		}
+		for _, w := range []string{"_Module", "OperationResult", "String", "Query"} {
+			if !slices.Contains(system, w) {
+				t.Errorf("SystemTypes() missing %q", w)
+			}
+		}
+		for _, absent := range []string{"order_event", "customers", "customers_filter"} {
+			if slices.Contains(system, absent) {
+				t.Errorf("SystemTypes() must not contain %q", absent)
+			}
+		}
+	})
+
 	t.Run("relations", func(t *testing.T) {
 		relsOf := func(object string) map[string]*catalog.RelationInfo {
 			t.Helper()

--- a/pkg/catalog/sdl/modules.go
+++ b/pkg/catalog/sdl/modules.go
@@ -16,6 +16,7 @@ const (
 	ModuleMutation         = base.ModuleMutation
 	ModuleFunction         = base.ModuleFunction
 	ModuleMutationFunction = base.ModuleMutationFunction
+	ModuleSubscription     = base.ModuleSubscription
 )
 
 var ModuleRootInfo = base.ModuleRootInfo
@@ -48,7 +49,12 @@ const (
 	moduleQuerySuffix            = "_query"
 	moduleMutationSuffix         = "_mutation"
 	moduleFunctionSuffix         = "_function"
-	moduleMutationFunctionSuffix = "_function_mutation"
+	// NOTE: must match the module assembler's inline naming
+	// (compiler/rules/assemble_modules.go): mutation-function module types are
+	// "_module_<m>_mut_function", subscription module types are
+	// "_module_<m>_subscription".
+	moduleMutationFunctionSuffix = "_mut_function"
+	moduleSubscriptionSuffix     = "_subscription"
 )
 
 func ModuleTypeName(module string, objectType base.ModuleObjectType) string {
@@ -62,6 +68,8 @@ func ModuleTypeName(module string, objectType base.ModuleObjectType) string {
 			return base.FunctionTypeName
 		case base.ModuleMutationFunction:
 			return base.FunctionMutationTypeName
+		case base.ModuleSubscription:
+			return base.SubscriptionBaseName
 		}
 	}
 	suffix := ""
@@ -74,6 +82,8 @@ func ModuleTypeName(module string, objectType base.ModuleObjectType) string {
 		suffix = moduleFunctionSuffix
 	case base.ModuleMutationFunction:
 		suffix = moduleMutationFunctionSuffix
+	case base.ModuleSubscription:
+		suffix = moduleSubscriptionSuffix
 	}
 	return "_module_" + strings.ReplaceAll(module, ".", "_") + suffix
 }

--- a/pkg/catalog/sdl/modules_test.go
+++ b/pkg/catalog/sdl/modules_test.go
@@ -1,0 +1,37 @@
+package sdl
+
+import (
+	"testing"
+)
+
+func TestModuleTypeName(t *testing.T) {
+	tests := []struct {
+		name       string
+		module     string
+		objectType ModuleObjectType
+		want       string
+	}{
+		{"root query", "", ModuleQuery, "Query"},
+		{"root mutation", "", ModuleMutation, "Mutation"},
+		{"root function", "", ModuleFunction, "Function"},
+		{"root mutation function", "", ModuleMutationFunction, "MutationFunction"},
+		{"root subscription", "", ModuleSubscription, "Subscription"},
+		{"module query", "core", ModuleQuery, "_module_core_query"},
+		{"module mutation", "core", ModuleMutation, "_module_core_mutation"},
+		{"module function", "core", ModuleFunction, "_module_core_function"},
+		{"module mutation function", "core", ModuleMutationFunction, "_module_core_mut_function"},
+		// The subscription names must match the module assembler, which builds
+		// them inline: "_module_" + strings.ReplaceAll(mod, ".", "_") + "_subscription"
+		// (compiler/rules/assemble_modules.go).
+		{"module subscription", "core", ModuleSubscription, "_module_core_subscription"},
+		{"nested module query", "a.b", ModuleQuery, "_module_a_b_query"},
+		{"nested module subscription", "a.b", ModuleSubscription, "_module_a_b_subscription"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ModuleTypeName(tt.module, tt.objectType); got != tt.want {
+				t.Errorf("ModuleTypeName(%q, %v) = %q, want %q", tt.module, tt.objectType, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/catalog/sdl/queries.go
+++ b/pkg/catalog/sdl/queries.go
@@ -24,10 +24,14 @@ const (
 )
 
 const (
-	MetadataSchemaQuery   = base.MetadataSchemaQuery
-	MetadataTypeQuery     = base.MetadataTypeQuery
-	MetadataTypeNameQuery = base.MetadataTypeNameQuery
-	JQTransformQueryName  = base.JQTransformQueryName
+	MetadataSchemaQuery     = base.MetadataSchemaQuery
+	MetadataTypeQuery       = base.MetadataTypeQuery
+	MetadataTypeNameQuery   = base.MetadataTypeNameQuery
+	MetadataCatalogQuery    = base.MetadataCatalogQuery
+	MetadataModuleQuery     = base.MetadataModuleQuery
+	MetadataDataObjectQuery = base.MetadataDataObjectQuery
+	MetadataFunctionQuery   = base.MetadataFunctionQuery
+	JQTransformQueryName    = base.JQTransformQueryName
 )
 
 func QueryRequestInfo(ss ast.SelectionSet) ([]QueryRequest, QueryType) {
@@ -49,7 +53,11 @@ func QueryRequestInfo(ss ast.SelectionSet) ([]QueryRequest, QueryType) {
 		}
 		if field.Name == MetadataSchemaQuery ||
 			field.Name == MetadataTypeQuery ||
-			field.Name == MetadataTypeNameQuery {
+			field.Name == MetadataTypeNameQuery ||
+			field.Name == MetadataCatalogQuery ||
+			field.Name == MetadataModuleQuery ||
+			field.Name == MetadataDataObjectQuery ||
+			field.Name == MetadataFunctionQuery {
 			resolvers = append(resolvers, QueryRequest{
 				Name:      field.Alias,
 				Field:     field,

--- a/pkg/catalog/sdl/queries.go
+++ b/pkg/catalog/sdl/queries.go
@@ -31,6 +31,7 @@ const (
 	MetadataModuleQuery     = base.MetadataModuleQuery
 	MetadataDataObjectQuery = base.MetadataDataObjectQuery
 	MetadataFunctionQuery   = base.MetadataFunctionQuery
+	MetadataTypesQuery      = base.MetadataTypesQuery
 	JQTransformQueryName    = base.JQTransformQueryName
 )
 
@@ -57,7 +58,8 @@ func QueryRequestInfo(ss ast.SelectionSet) ([]QueryRequest, QueryType) {
 			field.Name == MetadataCatalogQuery ||
 			field.Name == MetadataModuleQuery ||
 			field.Name == MetadataDataObjectQuery ||
-			field.Name == MetadataFunctionQuery {
+			field.Name == MetadataFunctionQuery ||
+			field.Name == MetadataTypesQuery {
 			resolvers = append(resolvers, QueryRequest{
 				Name:      field.Alias,
 				Field:     field,

--- a/pkg/catalog/sdl/queries_test.go
+++ b/pkg/catalog/sdl/queries_test.go
@@ -1,0 +1,47 @@
+package sdl
+
+import (
+	"testing"
+
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestQueryRequestInfo_MetaQueries(t *testing.T) {
+	metaNames := []string{
+		MetadataSchemaQuery,
+		MetadataTypeQuery,
+		MetadataTypeNameQuery,
+		MetadataCatalogQuery,
+		MetadataModuleQuery,
+		MetadataDataObjectQuery,
+		MetadataFunctionQuery,
+	}
+
+	ss := ast.SelectionSet{}
+	for _, name := range metaNames {
+		ss = append(ss, &ast.Field{Name: name, Alias: name})
+	}
+	// A non-meta field without an object definition is skipped by
+	// classification — it must not be reported as meta.
+	ss = append(ss, &ast.Field{Name: "some_data_query", Alias: "some_data_query"})
+
+	rr, qt := QueryRequestInfo(ss)
+
+	if qt&QueryTypeMeta == 0 {
+		t.Fatalf("QueryRequestInfo() type = %v, want QueryTypeMeta bit set", qt)
+	}
+	if len(rr) != len(metaNames) {
+		t.Fatalf("QueryRequestInfo() returned %d requests, want %d", len(rr), len(metaNames))
+	}
+	for i, r := range rr {
+		if r.QueryType != QueryTypeMeta {
+			t.Errorf("request %q classified as %v, want QueryTypeMeta", r.Name, r.QueryType)
+		}
+		if r.Name != metaNames[i] {
+			t.Errorf("request[%d] name = %q, want %q", i, r.Name, metaNames[i])
+		}
+		if r.Field == nil || r.Field.Name != metaNames[i] {
+			t.Errorf("request %q lost its field reference", r.Name)
+		}
+	}
+}

--- a/pkg/catalog/sdl/queries_test.go
+++ b/pkg/catalog/sdl/queries_test.go
@@ -15,6 +15,7 @@ func TestQueryRequestInfo_MetaQueries(t *testing.T) {
 		MetadataModuleQuery,
 		MetadataDataObjectQuery,
 		MetadataFunctionQuery,
+		MetadataTypesQuery,
 	}
 
 	ss := ast.SelectionSet{}

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -143,7 +143,9 @@ func (s *Source) cleanupGhosts(ctx context.Context) error {
 	}`, map[string]any{
 		"filter": map[string]any{
 			"last_heartbeat": map[string]any{"lt": cutoff},
-			"name":           map[string]any{"neq": s.config.NodeName},
+			"_not": map[string]any{
+				"name": map[string]any{"eq": s.config.NodeName},
+			},
 		},
 	})
 	if err != nil {

--- a/pkg/metadata/catalog.go
+++ b/pkg/metadata/catalog.go
@@ -77,6 +77,36 @@ func processFunctionQuery(ctx context.Context, provider catalog.Provider, field 
 	return functionResolver(ctx, lm, provider, entry, field.SelectionSet, maxDepth)
 }
 
+// processTypesQuery resolves _types — the GraphQL type definitions of the
+// logical model. scope: SOURCE (default) = residual base types defined by
+// data sources (the future entity-storage types table); SYSTEM = the
+// engine-defined types. Type-list semantics mirror __schema.types (no
+// permission filtering of the list itself; per-type fields are filtered).
+func processTypesQuery(ctx context.Context, provider catalog.Provider, field *ast.Field, maxDepth int, vars map[string]any) (any, error) {
+	scope := "SOURCE"
+	if field.Arguments.ForName("scope") != nil {
+		if args := field.ArgumentMap(vars); args != nil {
+			if s, ok := args["scope"].(string); ok && s != "" {
+				scope = s
+			}
+		}
+	}
+	lm := catalog.LogicalModelFromProvider(provider)
+	typesIter := lm.SourceTypes(ctx)
+	if scope == "SYSTEM" {
+		typesIter = lm.SystemTypes(ctx)
+	}
+	var res []map[string]any
+	for _, def := range typesIter {
+		data, err := typeResolver(ctx, provider, ast.NamedType(def.Name, &ast.Position{}), field.SelectionSet, maxDepth)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, data)
+	}
+	return res, nil
+}
+
 // metaStringArg extracts a required string argument of a meta query. An empty
 // string is a VALID value (the root module) — unlike __type(name:), absence or
 // a non-string value is the only failure.

--- a/pkg/metadata/catalog.go
+++ b/pkg/metadata/catalog.go
@@ -1,0 +1,546 @@
+package metadata
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog"
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
+	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
+	"github.com/hugr-lab/query-engine/pkg/perm"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// Logical-model introspection (_catalog / _module / _dataObject /
+// _function). Resolution consumes the narrow catalog.LogicalModel seam for
+// structure and reuses the standard __Type/__Field/__InputValue resolvers for
+// leaves. Permission semantics mirror __schema exactly: hidden elements are
+// absent, disabled elements stay visible, full-access contexts see everything.
+
+func processCatalogQuery(ctx context.Context, provider catalog.Provider, field *ast.Field, maxDepth int) (any, error) {
+	lm := catalog.LogicalModelFromProvider(provider)
+	info := lm.Module(ctx, "")
+	if info == nil {
+		return nil, nil
+	}
+	return moduleResolver(ctx, lm, provider, info, field.SelectionSet, maxDepth)
+}
+
+func processModuleQuery(ctx context.Context, provider catalog.Provider, field *ast.Field, maxDepth int, vars map[string]any) (any, error) {
+	name, ok := metaStringArg(field, vars, "name")
+	if !ok {
+		return nil, ErrInvalidTypeQuery
+	}
+	lm := catalog.LogicalModelFromProvider(provider)
+	info := lm.Module(ctx, name)
+	if info == nil {
+		return nil, nil
+	}
+	return moduleResolver(ctx, lm, provider, info, field.SelectionSet, maxDepth)
+}
+
+func processDataObjectQuery(ctx context.Context, provider catalog.Provider, field *ast.Field, maxDepth int, vars map[string]any) (any, error) {
+	name, ok := metaStringArg(field, vars, "name")
+	if !ok {
+		return nil, ErrInvalidTypeQuery
+	}
+	if name == "" {
+		return nil, nil
+	}
+	lm := catalog.LogicalModelFromProvider(provider)
+	obj := lm.DataObject(ctx, name)
+	if obj == nil || !dataObjectVisible(ctx, obj) {
+		return nil, nil
+	}
+	return dataObjectResolver(ctx, lm, provider, obj, field.SelectionSet, maxDepth)
+}
+
+func processFunctionQuery(ctx context.Context, provider catalog.Provider, field *ast.Field, maxDepth int, vars map[string]any) (any, error) {
+	module, ok := metaStringArg(field, vars, "module")
+	if !ok {
+		return nil, ErrInvalidTypeQuery
+	}
+	name, ok := metaStringArg(field, vars, "name")
+	if !ok {
+		return nil, ErrInvalidTypeQuery
+	}
+	if name == "" {
+		return nil, nil
+	}
+	lm := catalog.LogicalModelFromProvider(provider)
+	entry := lm.Function(ctx, module, name)
+	if entry == nil || !functionVisible(ctx, entry) {
+		return nil, nil
+	}
+	return functionResolver(ctx, lm, provider, entry, field.SelectionSet, maxDepth)
+}
+
+// metaStringArg extracts a required string argument of a meta query. An empty
+// string is a VALID value (the root module) — unlike __type(name:), absence or
+// a non-string value is the only failure.
+func metaStringArg(field *ast.Field, vars map[string]any, name string) (string, bool) {
+	if field.Arguments.ForName(name) == nil {
+		return "", false
+	}
+	args := field.ArgumentMap(vars)
+	if args == nil {
+		return "", false
+	}
+	v, ok := args[name]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func moduleResolver(ctx context.Context, lm catalog.LogicalModel, provider catalog.Provider, info *catalog.ModuleInfo, ss ast.SelectionSet, maxDepth int) (map[string]any, error) {
+	if maxDepth <= 0 {
+		return nil, nil
+	}
+	moduleRootType := func(kind sdl.ModuleObjectType) fieldResolverFunc {
+		return func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			rt := info.RootTypes[kind]
+			if rt == nil {
+				return nil, nil
+			}
+			data, err := typeResolver(ctx, provider, ast.NamedType(rt.Name, &ast.Position{}), field.SelectionSet, maxDepth)
+			if errors.Is(err, ErrTypeNotFound) {
+				return nil, nil
+			}
+			return data, err
+		}
+	}
+	return processSelectionSet(ctx, ss, map[string]fieldResolverFunc{
+		"__typename": typeNameResolver,
+		"name": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return info.Name, nil
+		},
+		"description": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return info.Description, nil
+		},
+		"longDescription": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return nil, nil
+		},
+		"dataSources": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			if info.DataSources == nil {
+				return []string{}, nil
+			}
+			return info.DataSources, nil
+		},
+		"modules": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			res := []map[string]any{}
+			for child := range lm.Modules(ctx, info.Name) {
+				if !submoduleVisible(ctx, info, child) {
+					continue
+				}
+				if !moduleHasVisibleContent(ctx, lm, provider, child) {
+					continue
+				}
+				data, err := moduleResolver(ctx, lm, provider, child, field.SelectionSet, maxDepth-1)
+				if err != nil {
+					return nil, err
+				}
+				if data != nil {
+					res = append(res, data)
+				}
+			}
+			return res, nil
+		},
+		"dataObjects": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			res := []map[string]any{}
+			for obj := range lm.DataObjects(ctx, info.Name) {
+				if !dataObjectVisible(ctx, obj) {
+					continue
+				}
+				data, err := dataObjectResolver(ctx, lm, provider, obj, field.SelectionSet, maxDepth-1)
+				if err != nil {
+					return nil, err
+				}
+				if data != nil {
+					res = append(res, data)
+				}
+			}
+			return res, nil
+		},
+		"functions": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			res := []map[string]any{}
+			for entry := range lm.Functions(ctx, info.Name) {
+				if !functionVisible(ctx, entry) {
+					continue
+				}
+				data, err := functionResolver(ctx, lm, provider, entry, field.SelectionSet, maxDepth-1)
+				if err != nil {
+					return nil, err
+				}
+				if data != nil {
+					res = append(res, data)
+				}
+			}
+			return res, nil
+		},
+		"queryType":            moduleRootType(sdl.ModuleQuery),
+		"mutationType":         moduleRootType(sdl.ModuleMutation),
+		"subscriptionType":     moduleRootType(sdl.ModuleSubscription),
+		"functionType":         moduleRootType(sdl.ModuleFunction),
+		"mutationFunctionType": moduleRootType(sdl.ModuleMutationFunction),
+	}, "_Module")
+}
+
+func dataObjectResolver(ctx context.Context, lm catalog.LogicalModel, provider catalog.Provider, obj *sdl.Object, ss ast.SelectionSet, maxDepth int) (map[string]any, error) {
+	if maxDepth <= 0 {
+		return nil, nil
+	}
+	def := obj.Definition()
+	return processSelectionSet(ctx, ss, map[string]fieldResolverFunc{
+		"__typename": typeNameResolver,
+		"name": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return def.Name, nil
+		},
+		"type": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return strings.ToUpper(obj.Type), nil
+		},
+		"properties": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return propertiesResolver(ctx, obj, field.SelectionSet)
+		},
+		"description": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return def.Description, nil
+		},
+		"longDescription": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return nil, nil
+		},
+		"moduleName": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return sdl.ObjectModule(def), nil
+		},
+		"module": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			info := lm.Module(ctx, sdl.ObjectModule(def))
+			if info == nil {
+				return nil, nil
+			}
+			return moduleResolver(ctx, lm, provider, info, field.SelectionSet, maxDepth-1)
+		},
+		"primaryKey": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			pk := sdl.ObjectPrimaryKeys(def)
+			if pk == nil {
+				return []string{}, nil
+			}
+			return pk, nil
+		},
+		"args": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			if obj.InputArgsName == "" {
+				return nil, nil
+			}
+			it := provider.ForName(ctx, obj.InputArgsName)
+			if it == nil {
+				return nil, nil
+			}
+			res := []map[string]any{}
+			for _, f := range it.Fields {
+				if isArgServerInjected(f.Directives) {
+					continue
+				}
+				data, err := inputValueResolver(ctx, provider, f, field.SelectionSet, maxDepth-1)
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, data)
+			}
+			return res, nil
+		},
+		"fields": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return objectFieldsResolver(ctx, provider, def, field, maxDepth)
+		},
+		"relations": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			res := []map[string]any{}
+			for rel := range lm.Relations(ctx, def.Name) {
+				if !relationVisible(ctx, lm, rel) {
+					continue
+				}
+				data, err := relationResolver(ctx, lm, provider, rel, field.SelectionSet, maxDepth-1)
+				if err != nil {
+					return nil, err
+				}
+				if data != nil {
+					res = append(res, data)
+				}
+			}
+			return res, nil
+		},
+		"dataSourceName": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return obj.Catalog, nil
+		},
+		"dataSources": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return dataObjectSources(obj), nil
+		},
+	}, "_DataObject")
+}
+
+func propertiesResolver(ctx context.Context, obj *sdl.Object, ss ast.SelectionSet) (map[string]any, error) {
+	boolField := func(v bool) fieldResolverFunc {
+		return func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return v, nil
+		}
+	}
+	return processSelectionSet(ctx, ss, map[string]fieldResolverFunc{
+		"__typename":   typeNameResolver,
+		"isCube":       boolField(obj.IsCube),
+		"isM2M":        boolField(obj.IsM2M),
+		"isHypertable": boolField(obj.IsHypertable),
+		"softDelete":   boolField(obj.SoftDelete),
+		"hasVectors":   boolField(obj.HasVectors),
+	}, "_DataObjectProperties")
+}
+
+func relationResolver(ctx context.Context, lm catalog.LogicalModel, provider catalog.Provider, rel *catalog.RelationInfo, ss ast.SelectionSet, maxDepth int) (map[string]any, error) {
+	if maxDepth <= 0 {
+		return nil, nil
+	}
+	farObject := func(name string) fieldResolverFunc {
+		return func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			if name == "" {
+				return nil, nil
+			}
+			obj := lm.DataObject(ctx, name)
+			if obj == nil {
+				return nil, nil
+			}
+			return dataObjectResolver(ctx, lm, provider, obj, field.SelectionSet, maxDepth-1)
+		}
+	}
+	stringOrNil := func(v string) fieldResolverFunc {
+		return func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			if v == "" {
+				return nil, nil
+			}
+			return v, nil
+		}
+	}
+	keys := func(v []string) fieldResolverFunc {
+		return func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			if v == nil {
+				return []string{}, nil
+			}
+			return v, nil
+		}
+	}
+	return processSelectionSet(ctx, ss, map[string]fieldResolverFunc{
+		"__typename": typeNameResolver,
+		"name": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return rel.Name, nil
+		},
+		"direction": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return string(rel.Direction), nil
+		},
+		"kind": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return string(rel.Kind), nil
+		},
+		"fieldName":       stringOrNil(rel.FieldName),
+		"description":     stringOrNil(rel.Description),
+		"dataObject":      farObject(rel.DataObject),
+		"through":         farObject(rel.Through),
+		"sourceKeys":      keys(rel.SourceKeys),
+		"destinationKeys": keys(rel.DestinationKeys),
+		"dataSource":      stringOrNil(rel.DataSource),
+	}, "_Relation")
+}
+
+func functionResolver(ctx context.Context, lm catalog.LogicalModel, provider catalog.Provider, entry *catalog.FunctionEntry, ss ast.SelectionSet, maxDepth int) (map[string]any, error) {
+	if maxDepth <= 0 {
+		return nil, nil
+	}
+	return processSelectionSet(ctx, ss, map[string]fieldResolverFunc{
+		"__typename": typeNameResolver,
+		"name": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return entry.Field.Name, nil
+		},
+		"type": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return functionTypeText(entry.Kind), nil
+		},
+		"description": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return entry.Field.Description, nil
+		},
+		"longDescription": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return nil, nil
+		},
+		"moduleName": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return entry.Module, nil
+		},
+		"module": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			info := lm.Module(ctx, entry.Module)
+			if info == nil {
+				return nil, nil
+			}
+			return moduleResolver(ctx, lm, provider, info, field.SelectionSet, maxDepth-1)
+		},
+		"args": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			res := []map[string]any{}
+			for _, a := range entry.Field.Arguments {
+				if isArgServerInjected(a.Directives) {
+					continue
+				}
+				data, err := argumentResolver(ctx, provider, a, field.SelectionSet, maxDepth-1)
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, data)
+			}
+			return res, nil
+		},
+		"returns": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			data, err := typeResolver(ctx, provider, entry.Field.Type, field.SelectionSet, maxDepth-1)
+			if errors.Is(err, ErrTypeNotFound) {
+				return nil, nil
+			}
+			return data, err
+		},
+		"isTable": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			return entry.IsTable, nil
+		},
+		"dataSourceName": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
+			if entry.DataSource == "" {
+				return nil, nil
+			}
+			return entry.DataSource, nil
+		},
+	}, "_Function")
+}
+
+func functionTypeText(kind sdl.ModuleObjectType) string {
+	switch kind {
+	case sdl.ModuleFunction:
+		return "FUNCTION"
+	case sdl.ModuleMutationFunction:
+		return "MUTATION"
+	case sdl.ModuleSubscription:
+		return "SUBSCRIPTION"
+	}
+	return ""
+}
+
+// dataObjectSources returns the owning data source plus every source that
+// contributed extension fields (@join/@function_call added cross-source).
+func dataObjectSources(obj *sdl.Object) []string {
+	owner := obj.Catalog
+	seen := map[string]struct{}{}
+	if owner != "" {
+		seen[owner] = struct{}{}
+	}
+	for _, f := range obj.Definition().Fields {
+		if c := base.FieldDefCatalog(f); c != "" {
+			seen[c] = struct{}{}
+		}
+	}
+	res := make([]string, 0, len(seen))
+	for s := range seen {
+		res = append(res, s)
+	}
+	slices.Sort(res)
+	return res
+}
+
+// --- permission filters (same semantics as __schema introspection) ---
+
+// dataObjectVisible reports whether a data object is visible to the request:
+// not hidden by a table-level (data-object) rule and with at least one visible
+// select query field on its module's query root type. Disabled objects stay
+// visible by design.
+func dataObjectVisible(ctx context.Context, obj *sdl.Object) bool {
+	p := perm.PermissionsFromCtx(ctx)
+	if p == nil {
+		return true
+	}
+	if p.DataObjectHidden(obj.TypeName()) {
+		return false
+	}
+	rootName := sdl.ModuleTypeName(sdl.ObjectModule(obj.Definition()), sdl.ModuleQuery)
+	selects := 0
+	for _, q := range obj.Queries() {
+		if q.Type != sdl.QueryTypeSelect {
+			continue
+		}
+		selects++
+		if _, ok := p.Visible(rootName, q.Name); ok {
+			return true
+		}
+	}
+	// No select queries declared — nothing to gate on; keep visible.
+	return selects == 0
+}
+
+// functionVisible reports whether a callable member is visible to the request
+// (role field visibility on its module root type).
+func functionVisible(ctx context.Context, entry *catalog.FunctionEntry) bool {
+	p := perm.PermissionsFromCtx(ctx)
+	if p == nil {
+		return true
+	}
+	rootName := sdl.ModuleTypeName(entry.Module, entry.Kind)
+	_, ok := p.Visible(rootName, entry.Field.Name)
+	return ok
+}
+
+// submoduleVisible reports whether a child module's navigation field is
+// visible on at least one of the parent's root types that carry it.
+func submoduleVisible(ctx context.Context, parent *catalog.ModuleInfo, child *catalog.ModuleInfo) bool {
+	p := perm.PermissionsFromCtx(ctx)
+	if p == nil {
+		return true
+	}
+	seg := child.Name
+	if i := strings.LastIndex(seg, "."); i >= 0 {
+		seg = seg[i+1:]
+	}
+	for _, rootDef := range parent.RootTypes {
+		if rootDef.Fields.ForName(seg) == nil {
+			continue
+		}
+		if _, ok := p.Visible(rootDef.Name, seg); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// relationVisible drops relation entries whose far object or M2M junction is
+// hidden — a hidden endpoint removes the whole edge (fail-closed: an
+// unresolvable endpoint hides too).
+func relationVisible(ctx context.Context, lm catalog.LogicalModel, rel *catalog.RelationInfo) bool {
+	far := lm.DataObject(ctx, rel.DataObject)
+	if far == nil || !dataObjectVisible(ctx, far) {
+		return false
+	}
+	if rel.Through != "" {
+		junction := lm.DataObject(ctx, rel.Through)
+		if junction == nil || !dataObjectVisible(ctx, junction) {
+			return false
+		}
+	}
+	return true
+}
+
+// moduleHasVisibleContent reports whether a module still has any visible data
+// object, function, or non-empty submodule after permission filtering — empty
+// modules are omitted from listings (direct _module lookups still resolve).
+func moduleHasVisibleContent(ctx context.Context, lm catalog.LogicalModel, provider catalog.Provider, info *catalog.ModuleInfo) bool {
+	for obj := range lm.DataObjects(ctx, info.Name) {
+		if dataObjectVisible(ctx, obj) {
+			return true
+		}
+	}
+	for entry := range lm.Functions(ctx, info.Name) {
+		if functionVisible(ctx, entry) {
+			return true
+		}
+	}
+	for child := range lm.Modules(ctx, info.Name) {
+		if !submoduleVisible(ctx, info, child) {
+			continue
+		}
+		if moduleHasVisibleContent(ctx, lm, provider, child) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/metadata/catalog_test.go
+++ b/pkg/metadata/catalog_test.go
@@ -1,0 +1,682 @@
+package metadata
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog"
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler"
+	"github.com/hugr-lab/query-engine/pkg/catalog/sources"
+	"github.com/hugr-lab/query-engine/pkg/catalog/static"
+	"github.com/hugr-lab/query-engine/pkg/engines"
+	"github.com/hugr-lab/query-engine/pkg/perm"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func newCatalogTestService(t *testing.T) *catalog.Service {
+	t.Helper()
+	provider, err := static.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss := catalog.NewService(provider)
+	e := &engines.DuckDB{}
+	cat, err := sources.NewStringSource("test", e, compiler.Options{
+		Name:         "test",
+		EngineType:   string(e.Type()),
+		Capabilities: e.Capabilities(),
+	}, testSchemaData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = ss.AddCatalog(context.Background(), "test", cat); err != nil {
+		t.Fatal(err)
+	}
+	return ss
+}
+
+// runMetaQuery parses a query through the full pipeline (walker validation
+// included — exercising the synthesized _catalog root field definitions) and
+// resolves every classified meta request.
+func runMetaQuery(t *testing.T, ss *catalog.Service, query string) map[string]any {
+	t.Helper()
+	return runMetaQueryDepth(t, ss, query, 20)
+}
+
+func runMetaQueryDepth(t *testing.T, ss *catalog.Service, query string, maxDepth int) map[string]any {
+	t.Helper()
+	op, err := ss.ParseQuery(context.Background(), query, nil, "")
+	if err != nil {
+		t.Fatalf("ParseQuery: %v", err)
+	}
+	res := map[string]any{}
+	for _, r := range op.Queries {
+		data, err := ProcessQuery(t.Context(), ss.Provider(), r, maxDepth, op.Variables)
+		if err != nil {
+			t.Fatalf("ProcessQuery(%s): %v", r.Name, err)
+		}
+		res[r.Name] = data
+	}
+	return res
+}
+
+func asMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	if v == nil {
+		t.Fatal("expected object, got nil")
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map, got %T", v)
+	}
+	return m
+}
+
+func namesOf(t *testing.T, v any) []string {
+	t.Helper()
+	list, ok := v.([]map[string]any)
+	if !ok {
+		t.Fatalf("expected list of objects, got %T", v)
+	}
+	var names []string
+	for _, item := range list {
+		if n, ok := item["name"].(string); ok {
+			names = append(names, n)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+func TestCatalogQuery_Tree(t *testing.T) {
+	ss := newCatalogTestService(t)
+
+	res := runMetaQuery(t, ss, `{
+		_catalog {
+			name
+			modules { name functions { name type } }
+			dataObjects { name }
+			functions { name }
+			queryType { name }
+			mutationType { name }
+			subscriptionType { name }
+			functionType { name }
+			mutationFunctionType { name }
+		}
+	}`)
+	root := asMap(t, res["_catalog"])
+
+	if root["name"] != "" {
+		t.Errorf("root module name = %v, want empty string", root["name"])
+	}
+
+	modNames := namesOf(t, root["modules"])
+	for _, want := range []string{"core", "events", "sales"} {
+		if !slices.Contains(modNames, want) {
+			t.Errorf("root modules %v missing %q", modNames, want)
+		}
+	}
+	if slices.Contains(modNames, "sales.reports") {
+		t.Errorf("root modules %v must not contain nested sales.reports", modNames)
+	}
+
+	// no root-level data objects or functions in the fixture
+	if n := namesOf(t, root["dataObjects"]); len(n) != 0 {
+		t.Errorf("root dataObjects = %v, want empty", n)
+	}
+	if n := namesOf(t, root["functions"]); len(n) != 0 {
+		t.Errorf("root functions = %v, want empty", n)
+	}
+
+	// five root-type back-refs
+	for field, want := range map[string]string{
+		"queryType":            "Query",
+		"mutationType":         "Mutation",
+		"subscriptionType":     "Subscription",
+		"functionType":         "Function",
+		"mutationFunctionType": "MutationFunction",
+	} {
+		got := asMap(t, root[field])
+		if got["name"] != want {
+			t.Errorf("%s = %v, want %s", field, got["name"], want)
+		}
+	}
+
+	// subscription-only module carries its subscription function
+	for _, m := range root["modules"].([]map[string]any) {
+		if m["name"] != "events" {
+			continue
+		}
+		fns := m["functions"].([]map[string]any)
+		if len(fns) != 1 || fns[0]["name"] != "tick" || fns[0]["type"] != "SUBSCRIPTION" {
+			t.Errorf("events functions = %v, want [tick SUBSCRIPTION]", fns)
+		}
+	}
+}
+
+func TestCatalogQuery_ModuleLookup(t *testing.T) {
+	ss := newCatalogTestService(t)
+
+	res := runMetaQuery(t, ss, `{
+		_module(name: "sales") {
+			name
+			dataObjects { name }
+			functions { name type }
+			modules { name }
+			subscriptionType { name }
+			dataSources
+		}
+		root: _module(name: "") { name }
+		missing: _module(name: "nope") { name }
+	}`)
+
+	sales := asMap(t, res["_module"])
+	if sales["name"] != "sales" {
+		t.Errorf("module name = %v, want sales", sales["name"])
+	}
+	objNames := namesOf(t, sales["dataObjects"])
+	if !slices.Contains(objNames, "customers") || !slices.Contains(objNames, "orders") {
+		t.Errorf("sales dataObjects = %v, want customers+orders", objNames)
+	}
+	// dedupe: each object exactly once
+	for _, n := range []string{"customers", "orders"} {
+		count := 0
+		for _, o := range objNames {
+			if o == n {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("object %s appears %d times, want 1", n, count)
+		}
+	}
+
+	fnByName := map[string]string{}
+	for _, f := range sales["functions"].([]map[string]any) {
+		fnByName[f["name"].(string)] = f["type"].(string)
+	}
+	if fnByName["order_events"] != "SUBSCRIPTION" {
+		t.Errorf("order_events type = %q, want SUBSCRIPTION", fnByName["order_events"])
+	}
+
+	if children := namesOf(t, sales["modules"]); !slices.Equal(children, []string{"sales.reports"}) {
+		t.Errorf("sales children = %v, want [sales.reports]", children)
+	}
+	if st := asMap(t, sales["subscriptionType"]); st["name"] != "_module_sales_subscription" {
+		t.Errorf("sales subscriptionType = %v, want _module_sales_subscription", st["name"])
+	}
+	if ds, ok := sales["dataSources"].([]string); !ok || !slices.Equal(ds, []string{"test"}) {
+		t.Errorf("sales dataSources = %v, want [test]", sales["dataSources"])
+	}
+
+	if root := asMap(t, res["root"]); root["name"] != "" {
+		t.Errorf(`_module(name: "") = %v, want root module`, root["name"])
+	}
+	if res["missing"] != nil {
+		t.Errorf("unknown module = %v, want nil", res["missing"])
+	}
+}
+
+func TestCatalogQuery_DataObjectLookup(t *testing.T) {
+	ss := newCatalogTestService(t)
+
+	res := runMetaQuery(t, ss, `{
+		_dataObject(name: "customers") {
+			name
+			type
+			moduleName
+			primaryKey
+			dataSourceName
+			dataSources
+			properties { isCube isM2M isHypertable softDelete hasVectors }
+			module { name }
+		}
+		view: _dataObject(name: "sales_by_country") {
+			name type moduleName
+			args { name }
+		}
+		junction: _dataObject(name: "catalogs") { properties { isM2M } }
+		moduleType: _dataObject(name: "_module_core_query") { name }
+		missing: _dataObject(name: "no_such_object") { name }
+		fields: _dataObject(name: "orders") { fields { name } }
+	}`)
+
+	customers := asMap(t, res["_dataObject"])
+	if customers["type"] != "TABLE" {
+		t.Errorf("customers type = %v, want TABLE", customers["type"])
+	}
+	if customers["moduleName"] != "sales" {
+		t.Errorf("customers moduleName = %v, want sales", customers["moduleName"])
+	}
+	if pk, ok := customers["primaryKey"].([]string); !ok || !slices.Equal(pk, []string{"id"}) {
+		t.Errorf("customers primaryKey = %v, want [id]", customers["primaryKey"])
+	}
+	if customers["dataSourceName"] != "test" {
+		t.Errorf("customers dataSourceName = %v, want test", customers["dataSourceName"])
+	}
+	if ds, ok := customers["dataSources"].([]string); !ok || !slices.Equal(ds, []string{"test"}) {
+		t.Errorf("customers dataSources = %v, want [test]", customers["dataSources"])
+	}
+	props := asMap(t, customers["properties"])
+	for name, want := range map[string]bool{"isCube": false, "isM2M": false, "isHypertable": false, "softDelete": false, "hasVectors": false} {
+		if props[name] != want {
+			t.Errorf("customers properties.%s = %v, want %v", name, props[name], want)
+		}
+	}
+	if mod := asMap(t, customers["module"]); mod["name"] != "sales" {
+		t.Errorf("customers module = %v, want sales", mod["name"])
+	}
+
+	view := asMap(t, res["view"])
+	if view["type"] != "VIEW" {
+		t.Errorf("view type = %v, want VIEW", view["type"])
+	}
+	if view["moduleName"] != "sales.reports" {
+		t.Errorf("view moduleName = %v, want sales.reports", view["moduleName"])
+	}
+	if args := namesOf(t, view["args"]); !slices.Equal(args, []string{"country"}) {
+		t.Errorf("view args = %v, want [country]", args)
+	}
+
+	junction := asMap(t, res["junction"])
+	if p := asMap(t, junction["properties"]); p["isM2M"] != true {
+		t.Errorf("catalogs isM2M = %v, want true", p["isM2M"])
+	}
+
+	if res["moduleType"] != nil {
+		t.Errorf("module root type resolved as data object: %v, want nil", res["moduleType"])
+	}
+	if res["missing"] != nil {
+		t.Errorf("unknown data object = %v, want nil", res["missing"])
+	}
+
+	fieldNames := namesOf(t, asMap(t, res["fields"])["fields"])
+	for _, want := range []string{"id", "customer_id", "customer", "source_info"} {
+		if !slices.Contains(fieldNames, want) {
+			t.Errorf("orders fields %v missing %q", fieldNames, want)
+		}
+	}
+}
+
+func TestCatalogQuery_FunctionLookup(t *testing.T) {
+	ss := newCatalogTestService(t)
+
+	res := runMetaQuery(t, ss, `{
+		fn: _function(module: "core", name: "data_source_status") {
+			name type isTable moduleName dataSourceName
+			args { name }
+			returns { name kind }
+		}
+		mut: _function(module: "core", name: "load_data_source") { name type }
+		sub: _function(module: "sales", name: "order_events") { name type returns { name } }
+		missingFn: _function(module: "core", name: "nope") { name }
+		rootNav: _function(module: "", name: "core") { name }
+	}`)
+
+	fn := asMap(t, res["fn"])
+	if fn["type"] != "FUNCTION" {
+		t.Errorf("data_source_status type = %v, want FUNCTION", fn["type"])
+	}
+	if fn["isTable"] != false {
+		t.Errorf("data_source_status isTable = %v, want false", fn["isTable"])
+	}
+	if fn["moduleName"] != "core" {
+		t.Errorf("data_source_status moduleName = %v, want core", fn["moduleName"])
+	}
+	if args := namesOf(t, fn["args"]); !slices.Equal(args, []string{"name"}) {
+		t.Errorf("data_source_status args = %v, want [name]", args)
+	}
+	if ret := asMap(t, fn["returns"]); ret["name"] != "String" {
+		t.Errorf("data_source_status returns = %v, want String", ret["name"])
+	}
+
+	if mut := asMap(t, res["mut"]); mut["type"] != "MUTATION" {
+		t.Errorf("load_data_source type = %v, want MUTATION", mut["type"])
+	}
+	sub := asMap(t, res["sub"])
+	if sub["type"] != "SUBSCRIPTION" {
+		t.Errorf("order_events type = %v, want SUBSCRIPTION", sub["type"])
+	}
+	if ret := asMap(t, sub["returns"]); ret["name"] != "order_event" {
+		t.Errorf("order_events returns = %v, want order_event", ret["name"])
+	}
+
+	if res["missingFn"] != nil {
+		t.Errorf("unknown function = %v, want nil", res["missingFn"])
+	}
+	// "core" on the root Function type is a submodule navigation field, not a function
+	if res["rootNav"] != nil {
+		t.Errorf("submodule nav field resolved as function: %v, want nil", res["rootNav"])
+	}
+}
+
+func TestCatalogQuery_Relations(t *testing.T) {
+	ss := newCatalogTestService(t)
+
+	res := runMetaQuery(t, ss, `{
+		orders: _dataObject(name: "orders") {
+			relations {
+				name direction kind fieldName description
+				dataObject { name }
+				through { name }
+				sourceKeys destinationKeys
+				dataSource
+			}
+		}
+		customers: _dataObject(name: "customers") {
+			relations { name direction kind fieldName dataObject { name } }
+		}
+		junctionSide: _dataObject(name: "catalog_sources") {
+			relations { name kind direction dataObject { name } through { name } }
+		}
+	}`)
+
+	type relKey struct{ kind, name string }
+	collect := func(v any) map[relKey]map[string]any {
+		t.Helper()
+		out := map[relKey]map[string]any{}
+		for _, r := range asMap(t, v)["relations"].([]map[string]any) {
+			out[relKey{r["kind"].(string), r["name"].(string)}] = r
+		}
+		return out
+	}
+
+	orders := collect(res["orders"])
+	fk := orders[relKey{"FK", "order_customer"}]
+	if fk == nil {
+		t.Fatalf("orders missing FK order_customer: %v", orders)
+	}
+	if fk["direction"] != "FORWARD" || fk["fieldName"] != "customer" {
+		t.Errorf("orders FK = %v, want FORWARD via customer", fk)
+	}
+	if far := asMap(t, fk["dataObject"]); far["name"] != "customers" {
+		t.Errorf("orders FK far = %v, want customers", far["name"])
+	}
+	if fk["through"] != nil {
+		t.Errorf("FK through = %v, want nil", fk["through"])
+	}
+	if sk, ok := fk["sourceKeys"].([]string); !ok || !slices.Equal(sk, []string{"customer_id"}) {
+		t.Errorf("FK sourceKeys = %v, want [customer_id]", fk["sourceKeys"])
+	}
+	if fk["description"] != "Order customer" {
+		t.Errorf("FK description = %v, want Order customer", fk["description"])
+	}
+	if fk["dataSource"] != "test" {
+		t.Errorf("FK dataSource = %v, want test", fk["dataSource"])
+	}
+
+	join := orders[relKey{"JOIN", "source_info"}]
+	if join == nil {
+		t.Fatalf("orders missing JOIN source_info: %v", orders)
+	}
+	if join["direction"] != "FORWARD" {
+		t.Errorf("JOIN direction = %v, want FORWARD", join["direction"])
+	}
+	if far := asMap(t, join["dataObject"]); far["name"] != "catalog_sources" {
+		t.Errorf("JOIN far = %v, want catalog_sources", far["name"])
+	}
+	// relation SQL must not leak anywhere in the payload
+	for _, r := range orders {
+		if _, ok := r["sql"]; ok {
+			t.Errorf("relation exposes sql: %v", r)
+		}
+	}
+
+	customers := collect(res["customers"])
+	back := customers[relKey{"FK", "order_customer"}]
+	if back == nil {
+		t.Fatalf("customers missing BACK FK: %v", customers)
+	}
+	if back["direction"] != "BACK" || back["fieldName"] != "orders" {
+		t.Errorf("customers BACK FK = %v, want BACK via orders", back)
+	}
+	if far := asMap(t, back["dataObject"]); far["name"] != "orders" {
+		t.Errorf("customers BACK far = %v, want orders", far["name"])
+	}
+	// JOIN is one-directional: no BACK JOIN entry on the join target
+	for k := range customers {
+		if k.kind == "JOIN" {
+			t.Errorf("customers has JOIN entry %v (join is one-directional)", k)
+		}
+	}
+
+	// M2M through the catalogs junction: catalog_sources sees data_sources
+	// through catalogs.
+	junctionSide := collect(res["junctionSide"])
+	var m2m map[string]any
+	for k, r := range junctionSide {
+		if k.kind == "M2M" {
+			m2m = r
+		}
+	}
+	if m2m == nil {
+		t.Fatalf("catalog_sources missing M2M relation: %v", junctionSide)
+	}
+	if th := asMap(t, m2m["through"]); th["name"] != "catalogs" {
+		t.Errorf("M2M through = %v, want catalogs", th["name"])
+	}
+}
+
+// runMetaQueryPerm parses without permissions (meta queries are classified
+// ahead of permission validation) and resolves WITH the permission context —
+// introspection filtering happens at resolution time, as in production.
+func runMetaQueryPerm(t *testing.T, ss *catalog.Service, perms *perm.RolePermissions, query string) map[string]any {
+	t.Helper()
+	op, err := ss.ParseQuery(context.Background(), query, nil, "")
+	if err != nil {
+		t.Fatalf("ParseQuery: %v", err)
+	}
+	ctx := perm.CtxWithPerm(t.Context(), perms)
+	res := map[string]any{}
+	for _, r := range op.Queries {
+		data, err := ProcessQuery(ctx, ss.Provider(), r, 20, op.Variables)
+		if err != nil {
+			t.Fatalf("ProcessQuery(%s): %v", r.Name, err)
+		}
+		res[r.Name] = data
+	}
+	return res
+}
+
+func TestCatalogQuery_Permissions(t *testing.T) {
+	ss := newCatalogTestService(t)
+
+	t.Run("hidden data object absent everywhere", func(t *testing.T) {
+		perms := &perm.RolePermissions{
+			Name: "restricted",
+			Permissions: []perm.Permission{
+				{Object: "data-object:query", Field: "orders", Hidden: true},
+			},
+		}
+		res := runMetaQueryPerm(t, ss, perms, `{
+			_module(name: "sales") { dataObjects { name } }
+			obj: _dataObject(name: "orders") { name }
+			rels: _dataObject(name: "customers") { relations { name kind } }
+		}`)
+
+		objs := namesOf(t, asMap(t, res["_module"])["dataObjects"])
+		if slices.Contains(objs, "orders") {
+			t.Errorf("sales dataObjects %v must not contain hidden orders", objs)
+		}
+		if !slices.Contains(objs, "customers") {
+			t.Errorf("sales dataObjects %v missing customers", objs)
+		}
+		if res["obj"] != nil {
+			t.Errorf("_dataObject on hidden object = %v, want nil", res["obj"])
+		}
+		// customers' BACK FK to hidden orders must disappear
+		rels := asMap(t, res["rels"])["relations"].([]map[string]any)
+		for _, r := range rels {
+			if r["name"] == "order_customer" {
+				t.Errorf("relation to hidden object leaked: %v", r)
+			}
+		}
+	})
+
+	t.Run("hidden junction hides whole M2M relation", func(t *testing.T) {
+		perms := &perm.RolePermissions{
+			Name: "restricted",
+			Permissions: []perm.Permission{
+				{Object: "data-object:query", Field: "catalogs", Hidden: true},
+			},
+		}
+		res := runMetaQueryPerm(t, ss, perms, `{
+			_dataObject(name: "catalog_sources") { relations { name kind } }
+		}`)
+		rels := asMap(t, res["_dataObject"])["relations"].([]map[string]any)
+		for _, r := range rels {
+			if r["kind"] == "M2M" {
+				t.Errorf("M2M relation with hidden junction leaked: %v", r)
+			}
+		}
+	})
+
+	t.Run("disabled stays visible", func(t *testing.T) {
+		perms := &perm.RolePermissions{
+			Name: "restricted",
+			Permissions: []perm.Permission{
+				{Object: "data-object:query", Field: "customers", Disabled: true},
+			},
+		}
+		res := runMetaQueryPerm(t, ss, perms, `{
+			_module(name: "sales") { dataObjects { name } }
+			obj: _dataObject(name: "customers") { name }
+		}`)
+		objs := namesOf(t, asMap(t, res["_module"])["dataObjects"])
+		if !slices.Contains(objs, "customers") {
+			t.Errorf("disabled customers must stay visible, got %v", objs)
+		}
+		if res["obj"] == nil {
+			t.Error("_dataObject on disabled object = nil, want visible")
+		}
+	})
+
+	t.Run("empty module omitted from listing but direct lookup resolves", func(t *testing.T) {
+		perms := &perm.RolePermissions{
+			Name: "restricted",
+			Permissions: []perm.Permission{
+				{Object: "_module_sales_reports_query", Field: "sales_by_country", Hidden: true},
+			},
+		}
+		res := runMetaQueryPerm(t, ss, perms, `{
+			_module(name: "sales") { modules { name } }
+			direct: _module(name: "sales.reports") { name }
+		}`)
+		children := namesOf(t, asMap(t, res["_module"])["modules"])
+		if slices.Contains(children, "sales.reports") {
+			t.Errorf("empty module sales.reports must be omitted, got %v", children)
+		}
+		if direct := asMap(t, res["direct"]); direct["name"] != "sales.reports" {
+			t.Errorf("direct lookup of empty module = %v, want sales.reports", direct)
+		}
+	})
+
+	t.Run("fields filter parity with __type", func(t *testing.T) {
+		perms := &perm.RolePermissions{
+			Name: "restricted",
+			Permissions: []perm.Permission{
+				{Object: "customers", Field: "country", Hidden: true},
+			},
+		}
+		res := runMetaQueryPerm(t, ss, perms, `{
+			_dataObject(name: "customers") { fields { name } }
+			__type(name: "customers") { fields { name } }
+		}`)
+		objFields := namesOf(t, asMap(t, res["_dataObject"])["fields"])
+		typeFields := namesOf(t, asMap(t, res["__type"])["fields"])
+		if slices.Contains(objFields, "country") {
+			t.Errorf("_DataObject.fields %v must not contain hidden country", objFields)
+		}
+		if !slices.Equal(objFields, typeFields) {
+			t.Errorf("fields filter mismatch: _dataObject %v vs __type %v", objFields, typeFields)
+		}
+	})
+
+	t.Run("full access sees everything", func(t *testing.T) {
+		res := runMetaQuery(t, ss, `{
+			_module(name: "sales") { dataObjects { name } }
+		}`)
+		objs := namesOf(t, asMap(t, res["_module"])["dataObjects"])
+		for _, want := range []string{"customers", "orders"} {
+			if !slices.Contains(objs, want) {
+				t.Errorf("full access dataObjects %v missing %q", objs, want)
+			}
+		}
+	})
+}
+
+func TestCatalogQuery_SelfIntrospection(t *testing.T) {
+	ss := newCatalogTestService(t)
+
+	res := runMetaQuery(t, ss, `{
+		mod: __type(name: "_Module") { name kind fields { name } }
+		obj: __type(name: "_DataObject") { name kind fields { name } }
+		props: __type(name: "_DataObjectProperties") { name kind }
+		rel: __type(name: "_Relation") { name kind }
+		fn: __type(name: "_Function") { name kind }
+		dot: __type(name: "_DataObjectType") { name kind enumValues { name } }
+		ft: __type(name: "_FunctionType") { name kind enumValues { name } }
+		rd: __type(name: "_RelationDirection") { name kind enumValues { name } }
+		rk: __type(name: "_RelationKind") { name kind enumValues { name } }
+	}`)
+
+	for alias, want := range map[string]string{
+		"mod": "_Module", "obj": "_DataObject", "props": "_DataObjectProperties",
+		"rel": "_Relation", "fn": "_Function",
+	} {
+		got := asMap(t, res[alias])
+		if got["name"] != want || got["kind"] != ast.Object {
+			t.Errorf("__type(%s) = %v/%v, want %s OBJECT", alias, got["name"], got["kind"], want)
+		}
+	}
+
+	modFields := namesOf(t, asMap(t, res["mod"])["fields"])
+	for _, want := range []string{"name", "dataSources", "modules", "dataObjects", "functions",
+		"queryType", "mutationType", "subscriptionType", "functionType", "mutationFunctionType"} {
+		if !slices.Contains(modFields, want) {
+			t.Errorf("_Module fields %v missing %q", modFields, want)
+		}
+	}
+
+	for alias, want := range map[string][]string{
+		"dot": {"TABLE", "VIEW"},
+		"ft":  {"FUNCTION", "MUTATION", "SUBSCRIPTION"},
+		"rd":  {"BACK", "FORWARD"},
+		"rk":  {"FK", "JOIN", "M2M"},
+	} {
+		got := asMap(t, res[alias])
+		if got["kind"] != ast.Enum {
+			t.Errorf("__type(%s) kind = %v, want ENUM", alias, got["kind"])
+		}
+		vals := namesOf(t, got["enumValues"])
+		if !slices.Equal(vals, want) {
+			t.Errorf("__type(%s) enumValues = %v, want %v", alias, vals, want)
+		}
+	}
+
+	// The four root meta queries are ordinary (single-underscore) system
+	// fields of Query — they MUST appear in standard introspection so
+	// GraphiQL/codegen can autocomplete and validate them (SC-006).
+	q := runMetaQuery(t, ss, `{ __type(name: "Query") { fields { name } } }`)
+	queryFields := namesOf(t, asMap(t, q["__type"])["fields"])
+	for _, want := range []string{"_catalog", "_module", "_dataObject", "_function"} {
+		if !slices.Contains(queryFields, want) {
+			t.Errorf("Query introspection fields missing %q", want)
+		}
+	}
+}
+
+func TestCatalogQuery_DepthBudget(t *testing.T) {
+	ss := newCatalogTestService(t)
+
+	// With a tiny depth budget nested module blocks truncate to empty/null
+	// instead of erroring.
+	res := runMetaQueryDepth(t, ss, `{
+		_catalog { name modules { name modules { name } } }
+	}`, 2)
+	root := asMap(t, res["_catalog"])
+	if root["name"] != "" {
+		t.Errorf("root name = %v, want empty", root["name"])
+	}
+}

--- a/pkg/metadata/catalog_test.go
+++ b/pkg/metadata/catalog_test.go
@@ -667,6 +667,33 @@ func TestCatalogQuery_SelfIntrospection(t *testing.T) {
 	}
 }
 
+func TestCatalogQuery_Types(t *testing.T) {
+	ss := newCatalogTestService(t)
+
+	res := runMetaQuery(t, ss, `{
+		_types { name kind }
+		sys: _types(scope: SYSTEM) { name }
+	}`)
+
+	// default scope = SOURCE: exactly the residual source-defined base types
+	names := namesOf(t, res["_types"])
+	if !slices.Equal(names, []string{"order_event", "sales_by_country_args"}) {
+		t.Errorf("_types (SOURCE) = %v, want [order_event sales_by_country_args]", names)
+	}
+
+	sys := namesOf(t, res["sys"])
+	for _, want := range []string{"_Module", "_DataObject", "OperationResult", "Query", "String"} {
+		if !slices.Contains(sys, want) {
+			t.Errorf("_types(SYSTEM) missing %q", want)
+		}
+	}
+	for _, absent := range []string{"order_event", "customers", "customers_filter", "_customers_aggregation"} {
+		if slices.Contains(sys, absent) {
+			t.Errorf("_types(SYSTEM) must not contain %q", absent)
+		}
+	}
+}
+
 func TestCatalogQuery_DepthBudget(t *testing.T) {
 	ss := newCatalogTestService(t)
 

--- a/pkg/metadata/query.go
+++ b/pkg/metadata/query.go
@@ -38,6 +38,30 @@ func ProcessQuery(ctx context.Context, provider catalog.Provider, query sdl.Quer
 			slog.Error("metadata __type query failed", "error", err)
 		}
 		return res, err
+	case sdl.MetadataCatalogQuery:
+		res, err := processCatalogQuery(ctx, provider, query.Field, maxDepth)
+		if err != nil {
+			slog.Error("metadata _catalog query failed", "error", err)
+		}
+		return res, err
+	case sdl.MetadataModuleQuery:
+		res, err := processModuleQuery(ctx, provider, query.Field, maxDepth, vars)
+		if err != nil {
+			slog.Error("metadata _module query failed", "error", err)
+		}
+		return res, err
+	case sdl.MetadataDataObjectQuery:
+		res, err := processDataObjectQuery(ctx, provider, query.Field, maxDepth, vars)
+		if err != nil {
+			slog.Error("metadata _dataObject query failed", "error", err)
+		}
+		return res, err
+	case sdl.MetadataFunctionQuery:
+		res, err := processFunctionQuery(ctx, provider, query.Field, maxDepth, vars)
+		if err != nil {
+			slog.Error("metadata _function query failed", "error", err)
+		}
+		return res, err
 	}
 
 	return nil, nil

--- a/pkg/metadata/query.go
+++ b/pkg/metadata/query.go
@@ -62,6 +62,12 @@ func ProcessQuery(ctx context.Context, provider catalog.Provider, query sdl.Quer
 			slog.Error("metadata _function query failed", "error", err)
 		}
 		return res, err
+	case sdl.MetadataTypesQuery:
+		res, err := processTypesQuery(ctx, provider, query.Field, maxDepth, vars)
+		if err != nil {
+			slog.Error("metadata _types query failed", "error", err)
+		}
+		return res, err
 	}
 
 	return nil, nil

--- a/pkg/metadata/schema.go
+++ b/pkg/metadata/schema.go
@@ -137,60 +137,7 @@ func typeResolver(ctx context.Context, provider catalog.Provider, typeDef *ast.T
 			if def.Kind != ast.Object && def.Kind != ast.Interface {
 				return nil, nil
 			}
-			includeDeprecated := false
-			if a := field.Arguments.ForName("includeDeprecated"); a != nil {
-				includeDeprecated = a.Value.Raw == "true"
-			}
-			res := []map[string]any{}
-			for _, f := range def.Fields {
-				if strings.HasPrefix(f.Name, "__") {
-					continue
-				}
-				// Show _stub only when it's the sole field; hide it when real fields exist
-				if isPlaceholderField(f.Name) && len(def.Fields) > 1 {
-					continue
-				}
-				di := sdl.FieldDeprecatedInfo(f)
-				if !includeDeprecated && di.IsDeprecated {
-					continue
-				}
-				if p := perm.PermissionsFromCtx(ctx); p != nil {
-					if _, ok := p.Visible(def.Name, f.Name); !ok {
-						continue
-					}
-					// hide fields returning a hidden data object (table-level rule).
-					// The cheap in-memory scan gates the (possibly DB-hitting) type
-					// lookup; a rule only fires for an actual data object, so the
-					// IsDataObject check rejects a scalar/struct return type a
-					// wildcard rule would otherwise match. If the type cannot be
-					// resolved (transient error / suspended catalog), fail closed
-					// and hide rather than leak the field.
-					if tn := f.Type.Name(); !sdl.IsScalarType(tn) && p.DataObjectHidden(tn) {
-						if rd := provider.ForName(ctx, tn); rd == nil || sdl.IsDataObject(rd) {
-							continue
-						}
-					}
-				}
-				data, err := fieldResolver(ctx, provider, f, field.SelectionSet, maxDepth-1)
-				if err != nil {
-					return nil, err
-				}
-				res = append(res, data)
-			}
-			// GraphQL spec requires OBJECT/INTERFACE types to have at least one field.
-			// Add a placeholder when all fields were filtered out or the type is empty.
-			if len(res) == 0 {
-				placeholder := &ast.FieldDefinition{
-					Name: "_placeholder",
-					Type: ast.NamedType("Boolean", &ast.Position{}),
-				}
-				data, err := fieldResolver(ctx, provider, placeholder, field.SelectionSet, maxDepth-1)
-				if err != nil {
-					return nil, err
-				}
-				res = append(res, data)
-			}
-			return res, nil
+			return objectFieldsResolver(ctx, provider, def, field, maxDepth)
 		},
 		"interfaces": func(ctx context.Context, field *ast.Field, onType string) (any, error) {
 			if typeDef.NamedType == "" || typeDef.NonNull {
@@ -549,6 +496,77 @@ func inputValueResolver(ctx context.Context, provider catalog.Provider, def *ast
 			return "", nil
 		},
 	}, "__InputValue")
+}
+
+// objectFieldsResolver resolves the permission-filtered field list of an
+// object/interface definition — shared by __Type.fields and
+// _DataObject.fields so both introspection surfaces apply identical rules.
+func objectFieldsResolver(ctx context.Context, provider catalog.Provider, def *ast.Definition, field *ast.Field, maxDepth int) (any, error) {
+	includeDeprecated := false
+	if a := field.Arguments.ForName("includeDeprecated"); a != nil {
+		includeDeprecated = a.Value.Raw == "true"
+	}
+	res := []map[string]any{}
+	for _, f := range def.Fields {
+		if strings.HasPrefix(f.Name, "__") {
+			continue
+		}
+		// Show _stub only when it's the sole field; hide it when real fields exist
+		if isPlaceholderField(f.Name) && len(def.Fields) > 1 {
+			continue
+		}
+		di := sdl.FieldDeprecatedInfo(f)
+		if !includeDeprecated && di.IsDeprecated {
+			continue
+		}
+		if !introspectionFieldVisible(ctx, provider, def, f) {
+			continue
+		}
+		data, err := fieldResolver(ctx, provider, f, field.SelectionSet, maxDepth-1)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, data)
+	}
+	// GraphQL spec requires OBJECT/INTERFACE types to have at least one field.
+	// Add a placeholder when all fields were filtered out or the type is empty.
+	if len(res) == 0 {
+		placeholder := &ast.FieldDefinition{
+			Name: "_placeholder",
+			Type: ast.NamedType("Boolean", &ast.Position{}),
+		}
+		data, err := fieldResolver(ctx, provider, placeholder, field.SelectionSet, maxDepth-1)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, data)
+	}
+	return res, nil
+}
+
+// introspectionFieldVisible applies the permission filter used by introspection
+// field listings: role field visibility plus the hidden-data-object rule.
+//
+// The hidden-data-object part hides fields returning a hidden data object
+// (table-level rule). The cheap in-memory scan gates the (possibly DB-hitting)
+// type lookup; a rule only fires for an actual data object, so the
+// IsDataObject check rejects a scalar/struct return type a wildcard rule would
+// otherwise match. If the type cannot be resolved (transient error / suspended
+// catalog), fail closed and hide rather than leak the field.
+func introspectionFieldVisible(ctx context.Context, provider catalog.Provider, def *ast.Definition, f *ast.FieldDefinition) bool {
+	p := perm.PermissionsFromCtx(ctx)
+	if p == nil {
+		return true
+	}
+	if _, ok := p.Visible(def.Name, f.Name); !ok {
+		return false
+	}
+	if tn := f.Type.Name(); !sdl.IsScalarType(tn) && p.DataObjectHidden(tn) {
+		if rd := provider.ForName(ctx, tn); rd == nil || sdl.IsDataObject(rd) {
+			return false
+		}
+	}
+	return true
 }
 
 // isPlaceholderField returns true for stub/placeholder field names used as

--- a/pkg/metadata/schema_test.graphql
+++ b/pkg/metadata/schema_test.graphql
@@ -71,3 +71,62 @@ extend type Function {
   ): String @module(name: "core")
     @function(name: "data_source_status")
 }
+
+# --- logical-model introspection fixtures (_catalog family) ---
+
+type customers @module(name: "sales") @table(name: "customers") {
+  id: Int! @pk
+  name: String!
+  country: String
+}
+
+type orders @module(name: "sales")
+  @table(name: "orders")
+  @references(
+    name: "order_customer"
+    references_name: "customers"
+    source_fields: ["customer_id"]
+    references_fields: ["id"]
+    query: "customer"
+    description: "Order customer"
+    references_query: "orders"
+    references_description: "Customer orders"
+  ) {
+  id: Int! @pk
+  customer_id: Int!
+  amount: Float
+  status: String
+  source_info: [catalog_sources]
+    @join(
+      references_name: "catalog_sources"
+      source_fields: ["status"]
+      references_fields: ["name"]
+    )
+}
+
+# Parameterized view in a nested module.
+type sales_by_country @module(name: "sales.reports")
+  @view(
+    name: "sales_by_country"
+    sql: "SELECT c.country AS country, sum(o.amount) AS total FROM orders o JOIN customers c ON o.customer_id = c.id WHERE c.country = [$country] GROUP BY c.country"
+  )
+  @args(name: "sales_by_country_args") {
+  country: String @pk
+  total: Float
+}
+
+input sales_by_country_args {
+  country: String!
+}
+
+type order_event {
+  type: String
+  order_id: Int
+}
+
+extend type Subscription {
+  # subscription in a module that also has data objects
+  order_events(status: String): order_event @module(name: "sales")
+  # subscription-only module: "events" exists solely through this field
+  tick(interval: String): String @module(name: "events")
+}


### PR DESCRIPTION
## Summary

Adds a **logical-model introspection** family beside `__schema`/`__type` — exposing hugr's module tree, data objects (with properties, keys, args, relations) and functions as first-class meta queries, so clients no longer reverse-engineer the model from generated type names:

| Query | Returns | Purpose |
|---|---|---|
| `_catalog` | `_Module` | The root module tree (`name: ""`) |
| `_module(name)` | `_Module` | Direct lookup; `""` = root |
| `_dataObject(name)` | `_DataObject` | By GraphQL type name |
| `_function(module, name)` | `_Function` | Function / mutation / subscription; `""` = root |

Resolved on the metadata path (like `__schema`), never planned as data queries. Unknown names → `null`, never an error.

## Design

- **Naming**: single underscore, following the existing `jq`/`_join`/`_spatial` system-namespace convention on `Query`. GraphQL hard-reserves `__`: gqlparser rejects such field names in SDL, and graphql-js tooling (GraphiQL `buildClientSchema`, codegen) rejects them even in introspection results — single `_` keeps the family first-class for autocomplete and code generation.
- **Declarations**: `system_types.graphql` — four `@system` fields on the base `type Query` + 5 `@system` types (`_Module`, `_DataObject`, `_DataObjectProperties`, `_Relation`, `_Function`) and 4 enums. Visible in standard introspection; leaves reuse the standard `__Type`/`__Field`/`__InputValue` resolvers.
- **`catalog.LogicalModel` seam** (`pkg/catalog/logical.go`): narrow interface + walk-based adapter over existing providers. Resolution is point-lookup only (module root types via `sdl.ModuleTypeName` → fields → base defs; no `Types()` iteration) — works identically on static and DB-backed providers and gives a stable seam for a future entity-storage implementation.
- **Relations**: FK edges visible from both ends (canonical key orientation), M2M with the junction in `through`, one-directional `JOIN` edges; relation SQL is never exposed.
- **Permissions** mirror `__schema` exactly: hidden objects disappear from every path (listings, lookups, relation endpoints — fail-closed incl. hidden M2M junctions), disabled objects stay visible, modules with no visible content are omitted from listings (direct lookups still resolve); `_DataObject.fields` shares the extracted permission-filtered fields loop with `__Type.fields`.

Also fixes two latent gaps in `sdl.ModuleTypeName`: the missing `ModuleSubscription` case and the mutation-function suffix (`_function_mutation` → `_mut_function`, matching the module assembler — the old suffix had no consumers).

The second commit carries an unrelated small cluster fix: ghost-node cleanup filter excludes the own node via `_not{eq}`.

## Example

```graphql
{
  _dataObject(name: "pg_store_products") {
    type properties { isM2M } primaryKey dataSourceName dataSources
    relations {
      name direction kind fieldName
      dataObject { name } through { name }
      sourceKeys destinationKeys
    }
  }
}
```

## Test plan

- Unit: `pkg/metadata` (tree / lookups / relations / permissions / self-introspection / depth budget through the full `ParseQuery` pipeline), `pkg/catalog` (walk adapter incl. relations derivation), `pkg/catalog/sdl` (naming parity with the assembler, meta classification) — all green, full `./pkg/...` uncached green.
- Compiler goldens: updated, **purely additive** (+14580/−0 across 60 fixtures — 4 Query fields + new system types).
- Main E2E: **235 passed / 0 failed**, zero changes to pre-existing expected files; new cases `metadata/catalog_tree` (cross-source `dataSources` attribution proven live), `metadata/catalog_relations` (self-ref FK, M2M, cross-source JOIN), `permissions/catalog_visibility` (hidden/disabled semantics).
- hugr-app E2E: **39 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)