### PR TITLE
Catalog store: read-side cache + dependency tracking (design 034, Ш5)

### DIFF
--- a/pkg/catalog/compiler/rules/gen_extension_fields.go
+++ b/pkg/catalog/compiler/rules/gen_extension_fields.go
@@ -157,11 +157,22 @@ func processExtensionTFCJField(ctx base.CompilationContext, parentName string, f
 	targetAggName := "_" + targetName + "_aggregation"
 	bucketAggName := "_" + targetName + "_aggregation_bucket"
 	subAggName := AggTypeNameAtDepth(targetName, 1)
-	targetCatDir := targetCatalogDirective(targetDef)
 
-	// Add @catalog from the target type so the planner knows which engine
-	// this join's data comes from (critical for cross-source joins).
-	if targetCatDir != nil {
+	// @catalog names the source where the referenced FUNCTION is defined —
+	// the TFCJ data comes from the function call; the return type only shapes
+	// the join side. Fall back to the return type's catalog when the function
+	// does not resolve.
+	targetCatDir := targetCatalogDirective(targetDef)
+	if tfcjDir := f.Directives.ForName(base.FunctionCallTableJoinDirectiveName); tfcjDir != nil {
+		if refName := base.DirectiveArgString(tfcjDir, base.ArgReferencesName); refName != "" {
+			if fn := buildFuncRegistry(ctx)[refName]; fn != nil {
+				if d := fn.Directives.ForName(base.CatalogDirectiveName); d != nil {
+					targetCatDir = d
+				}
+			}
+		}
+	}
+	if targetCatDir != nil && f.Directives.ForName(base.CatalogDirectiveName) == nil {
 		f.Directives = append(f.Directives, targetCatDir)
 	}
 

--- a/pkg/catalog/compiler/rules/validate_function_call.go
+++ b/pkg/catalog/compiler/rules/validate_function_call.go
@@ -169,6 +169,18 @@ func validateFuncCallField(ctx base.CompilationContext, def *ast.Definition, fie
 			"%s.%s: unknown function %q", def.Name, field.Name, refName)
 	}
 
+	// 1b. A regular source describes ONLY its own data — cross-source schema
+	// artifacts (@function_call / @table_function_call_join referencing
+	// another source's function) belong to EXTENSION sources exclusively.
+	if !ctx.CompileOptions().IsExtension {
+		funcCat := base.DirectiveArgString(funcField.Directives.ForName(base.CatalogDirectiveName), base.ArgName)
+		if funcCat != "" && funcCat != ctx.CompileOptions().Name {
+			return gqlerror.ErrorPosf(field.Position,
+				"%s.%s: references function %q of data source %q — cross-source references are only allowed in extension sources",
+				def.Name, field.Name, refName, funcCat)
+		}
+	}
+
 	// 2. Validate return type
 	if !isTableFuncJoin {
 		if !equalTypes(funcField.Type, field.Type) {

--- a/pkg/catalog/compiler/rules/validate_join.go
+++ b/pkg/catalog/compiler/rules/validate_join.go
@@ -73,6 +73,18 @@ func validateJoinField(ctx base.CompilationContext, def *ast.Definition, field *
 			def.Name, field.Name, refName)
 	}
 
+	// 2b. A regular source describes ONLY its own data — cross-source schema
+	// artifacts (@join to another source's object) belong to EXTENSION
+	// sources exclusively.
+	if !ctx.CompileOptions().IsExtension {
+		refCat := base.DirectiveArgString(refDef.Directives.ForName(base.CatalogDirectiveName), base.ArgName)
+		if refCat != "" && refCat != ctx.CompileOptions().Name {
+			return gqlerror.ErrorPosf(field.Position,
+				"@join on %s.%s: references object %q of data source %q — cross-source references are only allowed in extension sources",
+				def.Name, field.Name, refName, refCat)
+		}
+	}
+
 	// 3. Propagate @catalog from referenced object to field if missing
 	if field.Directives.ForName(base.CatalogDirectiveName) == nil {
 		if refCatalog := refDef.Directives.ForName(base.CatalogDirectiveName); refCatalog != nil {

--- a/pkg/catalog/store/cache.go
+++ b/pkg/catalog/store/cache.go
@@ -100,25 +100,35 @@ func (c *defCache) get(name string) *ast.Definition {
 // caller's invalidation-clock check (Store.gen captured when the resolution
 // started): it is verified before indexing AND re-verified after the LRU add,
 // so an invalidation racing the install either sees the indexed name or the
-// post-add check removes the stale entry.
+// post-add check removes the stale entry. The memberships are re-asserted
+// AFTER the add too — the LRU's background expiry can evict the PREVIOUS
+// entry under this name between our index write and the add, and its onEvict
+// would strip the fresh memberships.
 func (c *defCache) put(name string, sources []string, def *ast.Definition, stillValid func() bool) {
 	if c == nil {
 		return
+	}
+	index := func() {
+		for _, src := range sources {
+			if c.sourceIndex[src] == nil {
+				c.sourceIndex[src] = map[string]struct{}{}
+			}
+			c.sourceIndex[src][name] = struct{}{}
+		}
 	}
 	c.mu.Lock()
 	if !stillValid() {
 		c.mu.Unlock()
 		return
 	}
-	for _, src := range sources {
-		if c.sourceIndex[src] == nil {
-			c.sourceIndex[src] = map[string]struct{}{}
-		}
-		c.sourceIndex[src][name] = struct{}{}
-	}
+	index()
 	c.mu.Unlock()
 
 	c.types.Add(name, &defEntry{def: def, sources: sources})
+
+	c.mu.Lock()
+	index()
+	c.mu.Unlock()
 	if !stillValid() {
 		c.types.Remove(name)
 	}

--- a/pkg/catalog/store/cache.go
+++ b/pkg/catalog/store/cache.go
@@ -1,0 +1,168 @@
+package store
+
+import (
+	"sync"
+	"time"
+
+	expirable "github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// CacheConfig controls the read-side definition cache (the store's port of
+// the compiled provider's schemaCache).
+type CacheConfig struct {
+	// MaxEntries is the LRU capacity; 0 selects the default.
+	MaxEntries int
+	// TTL bounds staleness the invalidation closure cannot see; 0 selects
+	// the default.
+	TTL time.Duration
+	// Disabled turns the cache off entirely (every ForName resolves from
+	// CoreDB).
+	Disabled bool
+}
+
+// DefaultCacheConfig mirrors the compiled provider's defaults.
+func DefaultCacheConfig() CacheConfig {
+	return CacheConfig{MaxEntries: 10000, TTL: 10 * time.Minute}
+}
+
+// allSources is the pseudo-source of definitions built from the WHOLE
+// active-source set (module roots, shared types): every invalidation evicts
+// its bucket.
+const allSources = "*"
+
+// defEntry is one cached compiled definition plus the data sources it was
+// built from — the index membership used for scoped invalidation.
+type defEntry struct {
+	def     *ast.Definition
+	sources []string
+}
+
+// defCache is an expirable LRU over compiled definitions keyed by type name,
+// with a source→names index scoping invalidation to the sources a definition
+// actually read rows from. A nil *defCache is valid and inert (cache
+// disabled). Cached *ast.Definition values are shared with callers — the
+// same read-only contract the compiled provider's cache has.
+type defCache struct {
+	types *expirable.LRU[string, *defEntry]
+
+	mu          sync.Mutex
+	sourceIndex map[string]map[string]struct{}
+}
+
+// newDefCache builds the cache; zero-valued fields take the defaults, and
+// Disabled returns nil (all methods are nil-receiver safe).
+func newDefCache(cfg CacheConfig) *defCache {
+	if cfg.Disabled {
+		return nil
+	}
+	def := DefaultCacheConfig()
+	if cfg.MaxEntries <= 0 {
+		cfg.MaxEntries = def.MaxEntries
+	}
+	if cfg.TTL <= 0 {
+		cfg.TTL = def.TTL
+	}
+	c := &defCache{sourceIndex: map[string]map[string]struct{}{}}
+	c.types = expirable.NewLRU(cfg.MaxEntries, c.onEvict, cfg.TTL)
+	return c
+}
+
+// onEvict drops the evicted entry's index memberships (also fired by Remove).
+func (c *defCache) onEvict(name string, e *defEntry) {
+	if e == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, src := range e.sources {
+		if names, ok := c.sourceIndex[src]; ok {
+			delete(names, name)
+			if len(names) == 0 {
+				delete(c.sourceIndex, src)
+			}
+		}
+	}
+}
+
+func (c *defCache) get(name string) *ast.Definition {
+	if c == nil {
+		return nil
+	}
+	e, ok := c.types.Get(name)
+	if !ok {
+		return nil
+	}
+	return e.def
+}
+
+// put installs a definition under its source memberships. stillValid is the
+// caller's invalidation-clock check (Store.gen captured when the resolution
+// started): it is verified before indexing AND re-verified after the LRU add,
+// so an invalidation racing the install either sees the indexed name or the
+// post-add check removes the stale entry.
+func (c *defCache) put(name string, sources []string, def *ast.Definition, stillValid func() bool) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if !stillValid() {
+		c.mu.Unlock()
+		return
+	}
+	for _, src := range sources {
+		if c.sourceIndex[src] == nil {
+			c.sourceIndex[src] = map[string]struct{}{}
+		}
+		c.sourceIndex[src][name] = struct{}{}
+	}
+	c.mu.Unlock()
+
+	c.types.Add(name, &defEntry{def: def, sources: sources})
+	if !stillValid() {
+		c.types.Remove(name)
+	}
+}
+
+// invalidate evicts everything a write to the source could have changed: its
+// index bucket, the allSources bucket, and any remaining key alsoEvict
+// matches (the write-side family closure for cross-source absence
+// dependencies — see Store.invalidateSource).
+func (c *defCache) invalidate(source string, alsoEvict func(name string) bool) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	names := make([]string, 0, len(c.sourceIndex[source])+len(c.sourceIndex[allSources]))
+	for _, bucket := range []map[string]struct{}{c.sourceIndex[source], c.sourceIndex[allSources]} {
+		for name := range bucket {
+			names = append(names, name)
+		}
+	}
+	delete(c.sourceIndex, source)
+	delete(c.sourceIndex, allSources)
+	c.mu.Unlock()
+
+	for _, name := range names {
+		c.types.Remove(name)
+	}
+	if alsoEvict == nil {
+		return
+	}
+	for _, name := range c.types.Keys() {
+		if alsoEvict(name) {
+			c.types.Remove(name)
+		}
+	}
+}
+
+// invalidateAll purges the cache.
+func (c *defCache) invalidateAll() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.sourceIndex = map[string]map[string]struct{}{}
+	c.mu.Unlock()
+	c.types.Purge()
+}

--- a/pkg/catalog/store/cache_test.go
+++ b/pkg/catalog/store/cache_test.go
@@ -1,0 +1,178 @@
+//go:build duckdb_arrow
+
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The Ш5 read-cache checks: served-from-cache pointer stability, per-source
+// invalidation on rewrite / delete / flag flips, the cross-source family
+// closure (absence dependencies), error-poisoned resolutions staying out of
+// the cache, and the NameExists classification.
+
+// cacheTestSchemaV2 is collectTestSchema with the orders.note column added
+// and a NEW object — the reshape an invalidated cache must serve.
+const cacheTestSchemaV2 = collectTestSchema + `
+extend type orders {
+  note: String
+}
+
+type invoices @module(name: "sales") @table(name: "invoices") {
+  id: Int! @pk
+}
+`
+
+func TestCacheHitAndRewriteInvalidation(t *testing.T) {
+	store, ctx := writtenStore(t)
+
+	def1 := store.ForName(ctx, "orders")
+	require.NotNil(t, def1)
+	assert.Nil(t, def1.Fields.ForName("note"))
+	def1b := store.ForName(ctx, "orders")
+	assert.True(t, def1 == def1b, "second read is served from the cache")
+
+	filter1 := store.ForName(ctx, "orders_filter")
+	require.NotNil(t, filter1)
+	assert.Nil(t, filter1.Fields.ForName("note"))
+
+	// The new object is unknown yet.
+	assert.Nil(t, store.ForName(ctx, "invoices"))
+
+	// Rewrite the source with a changed version — the cache drops.
+	d := collect(ctx, partialSource(t, "test", cacheTestSchemaV2), "test")
+	rewritten, err := store.writeSource(ctx, d, SourceState{Name: "test", Version: "v2", Engine: "duckdb", Loaded: true})
+	require.NoError(t, err)
+	require.True(t, rewritten)
+
+	def2 := store.ForName(ctx, "orders")
+	require.NotNil(t, def2)
+	assert.False(t, def1 == def2, "rewrite evicts the cached definition")
+	assert.NotNil(t, def2.Fields.ForName("note"), "new column served")
+
+	filter2 := store.ForName(ctx, "orders_filter")
+	require.NotNil(t, filter2)
+	assert.NotNil(t, filter2.Fields.ForName("note"), "derived type rebuilt")
+
+	require.NotNil(t, store.ForName(ctx, "invoices"), "new object served after the rewrite")
+}
+
+func TestCacheVersionGateKeepsEntries(t *testing.T) {
+	store, ctx := writtenStore(t)
+
+	def1 := store.ForName(ctx, "orders")
+	require.NotNil(t, def1)
+
+	// Same version — writeSource is a no-op and must NOT invalidate.
+	d := collect(ctx, partialSource(t, "test", collectTestSchema), "test")
+	rewritten, err := store.writeSource(ctx, d, SourceState{Name: "test", Version: "v1", Engine: "duckdb", Loaded: true})
+	require.NoError(t, err)
+	require.False(t, rewritten)
+
+	def2 := store.ForName(ctx, "orders")
+	assert.True(t, def1 == def2, "unchanged version keeps the cache")
+}
+
+func TestCacheFlagFlipsInvalidate(t *testing.T) {
+	store, ctx := writtenStore(t)
+
+	require.NotNil(t, store.ForName(ctx, "orders"))
+	require.True(t, store.NameExists(ctx, "orders"))
+
+	require.NoError(t, store.setFlags(ctx, "test", true, true, false))
+	assert.Nil(t, store.ForName(ctx, "orders"), "disabled source hides its types")
+	assert.False(t, store.NameExists(ctx, "orders"), "disabled source is not servable")
+
+	require.NoError(t, store.setFlags(ctx, "test", true, false, false))
+	def := store.ForName(ctx, "orders")
+	require.NotNil(t, def, "re-enabled source serves again")
+	assert.True(t, def == store.ForName(ctx, "orders"), "and caches again")
+}
+
+// TestCacheCrossSourceClosure is the absence-dependency regression: object A
+// is cached BEFORE source B exists; B's write stores a relation pointing at
+// A, which A's cached definition never read a row of — the write-side family
+// closure must evict A anyway.
+func TestCacheCrossSourceClosure(t *testing.T) {
+	const schemaA = `
+type a_obj @module(name: "app") @table(name: "a_obj") {
+  id: Int! @pk
+}
+`
+	const schemaB = `
+type b_obj @module(name: "app") @table(name: "b_obj")
+  @references(name: "b_to_a", references_name: "a_obj",
+    source_fields: ["a_id"], references_fields: ["id"],
+    query: "a", references_query: "b_items") {
+  id: Int! @pk
+  a_id: Int!
+}
+`
+	store, ctx := storeFor(t, schemaA)
+	srcA := partialSource(t, "test", schemaA)
+
+	before := store.ForName(ctx, "a_obj")
+	require.NotNil(t, before)
+	require.Nil(t, before.Fields.ForName("b_items"), "no back navigation yet")
+
+	srcB := partialSource(t, "b", schemaB, definitionsOnly{srcA})
+	d := collect(ctx, srcB, "b")
+	rewritten, err := store.writeSource(ctx, d, SourceState{Name: "b", Version: "v1", Engine: "duckdb", Loaded: true})
+	require.NoError(t, err)
+	require.True(t, rewritten)
+
+	after := store.ForName(ctx, "a_obj")
+	require.NotNil(t, after)
+	assert.False(t, before == after, "family closure evicted the foreign endpoint")
+	assert.NotNil(t, after.Fields.ForName("b_items"), "back navigation from B's relation")
+
+	// And the derived family of A follows.
+	lf := store.ForName(ctx, "a_obj_list_filter")
+	assert.NotNil(t, lf, "list filter exists once A is a back-projection target")
+}
+
+func TestCacheErrorNotCached(t *testing.T) {
+	store, ctx := writtenStore(t)
+
+	// A canceled context fails every read: the error propagates to ForName,
+	// which logs, serves nil and caches nothing.
+	cctx, cancel := context.WithCancel(ctx)
+	cancel()
+	assert.Nil(t, store.ForName(cctx, "orders"))
+	assert.Nil(t, store.cache.get("orders"), "failed resolution never cached")
+
+	def := store.ForName(ctx, "orders")
+	require.NotNil(t, def, "healthy context resolves")
+	assert.True(t, def == store.ForName(ctx, "orders"), "and caches")
+}
+
+func TestNameExistsClassification(t *testing.T) {
+	store, ctx := writtenStore(t)
+
+	for _, name := range []string{
+		"orders",                       // data object
+		"sales_by_country_args",        // residual source type
+		"Query",                        // top-level root
+		"_module_sales_query",          // module root
+		"orders_filter",                // derived over object
+		"_orders_aggregation",          // derived aggregation
+		"sales_by_country_args_filter", // derived over a structural residual type
+		"String",                       // static scalar
+		"_join",                        // shared-type stub
+	} {
+		assert.Truef(t, store.NameExists(ctx, name), "NameExists(%s)", name)
+	}
+
+	for _, name := range []string{
+		"definitely_not_a_type",
+		"nope_filter",
+		"_module_missing_query",
+		"_nope_aggregation",
+	} {
+		assert.Falsef(t, store.NameExists(ctx, name), "NameExists(%s)", name)
+	}
+}

--- a/pkg/catalog/store/cache_test.go
+++ b/pkg/catalog/store/cache_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"testing"
 
+	coredb "github.com/hugr-lab/query-engine/pkg/data-sources/sources/runtime/core-db"
+	"github.com/hugr-lab/query-engine/pkg/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -118,6 +120,10 @@ type b_obj @module(name: "app") @table(name: "b_obj")
 	before := store.ForName(ctx, "a_obj")
 	require.NotNil(t, before)
 	require.Nil(t, before.Fields.ForName("b_items"), "no back navigation yet")
+	// Cache the derived family BEFORE the write — its eviction is the point.
+	filterBefore := store.ForName(ctx, "a_obj_filter")
+	require.NotNil(t, filterBefore)
+	require.Nil(t, filterBefore.Fields.ForName("b_items"))
 
 	srcB := partialSource(t, "b", schemaB, definitionsOnly{srcA})
 	d := collect(ctx, srcB, "b")
@@ -130,9 +136,215 @@ type b_obj @module(name: "app") @table(name: "b_obj")
 	assert.False(t, before == after, "family closure evicted the foreign endpoint")
 	assert.NotNil(t, after.Fields.ForName("b_items"), "back navigation from B's relation")
 
-	// And the derived family of A follows.
+	// The derived family of A was evicted and rebuilt too.
+	filterAfter := store.ForName(ctx, "a_obj_filter")
+	require.NotNil(t, filterAfter)
+	assert.False(t, filterBefore == filterAfter, "derived family evicted")
+	assert.NotNil(t, filterAfter.Fields.ForName("b_items"), "filter nav member from B's relation")
 	lf := store.ForName(ctx, "a_obj_list_filter")
 	assert.NotNil(t, lf, "list filter exists once A is a back-projection target")
+
+	// deleteSource closes the reverse direction: B's relation disappears.
+	require.NoError(t, store.deleteSource(ctx, "b"))
+	dropped := store.ForName(ctx, "a_obj")
+	require.NotNil(t, dropped)
+	assert.Nil(t, dropped.Fields.ForName("b_items"), "back navigation dropped with B")
+}
+
+// TestCacheJoinTargetClosure pins the cross-source @join semantics the
+// multi-source golden established: a base source's @join to a FOREIGN object
+// serves a BARE declared field (no subquery args, no aggregation twins) —
+// and stays bare through the target source's whole lifecycle; the target
+// lookup still records provenance, so the definition re-resolves cleanly on
+// every flip instead of serving stale machinery.
+func TestCacheJoinTargetClosure(t *testing.T) {
+	const schemaB = `
+type b_stats @module(name: "app") @table(name: "b_stats") {
+  order_id: Int! @pk
+}
+`
+	const schemaA = `
+type a_orders @module(name: "app") @table(name: "a_orders") {
+  id: Int! @pk
+  stats: [b_stats] @join(references_name: "b_stats", source_fields: ["id"], references_fields: ["order_id"])
+}
+`
+	// A compiles against B's definitions, but only A is WRITTEN — the target
+	// source does not exist in the store yet.
+	srcB := partialSource(t, "b", schemaB)
+	ctx := context.Background()
+	pool, err := db.NewPool("")
+	require.NoError(t, err)
+	t.Cleanup(func() { pool.Close() })
+	require.NoError(t, coredb.New(coredb.Config{VectorSize: 8}).Attach(ctx, pool))
+	store, err := New(ctx, pool, Config{VecSize: 8}, nil)
+	require.NoError(t, err)
+	srcA := partialSource(t, "test", schemaA, definitionsOnly{srcB})
+	dA := collect(ctx, srcA, "test")
+	_, err = store.writeSource(ctx, dA, SourceState{Name: "test", Version: "v1", Engine: "duckdb", Loaded: true})
+	require.NoError(t, err)
+
+	assertBare := func(when string) {
+		def := store.ForName(ctx, "a_orders")
+		require.NotNilf(t, def, "a_orders served (%s)", when)
+		fd := def.Fields.ForName("stats")
+		require.NotNilf(t, fd, "declared join field present (%s)", when)
+		assert.Emptyf(t, fd.Arguments, "cross-source join field stays bare (%s)", when)
+		assert.Nilf(t, def.Fields.ForName("stats_aggregation"), "no twins for a cross-source target (%s)", when)
+	}
+
+	assertBare("target absent")
+
+	// Register the target source — the field stays bare (compiled parity).
+	dB := collect(ctx, srcB, "b")
+	_, err = store.writeSource(ctx, dB, SourceState{Name: "b", Version: "v1", Engine: "duckdb", Loaded: true})
+	require.NoError(t, err)
+	assertBare("target active")
+
+	require.NoError(t, store.setFlags(ctx, "b", true, true, false))
+	assertBare("target disabled")
+}
+
+// TestMultiSourceFlagPlay drives the 5-source golden fixture set through
+// source enable/disable cycles: the extension flip drops every contributed
+// artifact, the shop flip hides the @dependency view while the extension
+// stays active, and the ro / func flips hide the wired fields entirely —
+// a virtual field is attributed to the source its DATA comes from
+// (write-time resolution), so the standard activity gate applies. Every
+// assertion goes through the definition cache — a stale entry after a flip
+// fails the test.
+func TestMultiSourceFlagPlay(t *testing.T) {
+	store, ctx := storeForSources(t, genMultiFixtures)
+
+	assertBaseline := func(when string) {
+		items := store.ForName(ctx, "shop_items")
+		require.NotNilf(t, items, "shop_items (%s)", when)
+		for _, name := range []string{"note", "label", "similar", "similar_aggregation"} {
+			assert.NotNilf(t, items.Fields.ForName(name), "shop_items.%s (%s)", name, when)
+		}
+		audit := store.ForName(ctx, "audit_events")
+		require.NotNilf(t, audit, "audit_events (%s)", when)
+		assert.NotNilf(t, audit.Fields.ForName("logs"), "audit_events.logs (%s)", when)
+		assert.NotNilf(t, audit.Fields.ForName("logs_aggregation"), "audit_events.logs_aggregation (%s)", when)
+		require.NotNilf(t, store.ForName(ctx, "shop_overview"), "shop_overview (%s)", when)
+		require.NotNilf(t, store.ForName(ctx, "logs"), "logs (%s)", when)
+	}
+	assertBaseline("initial")
+
+	// --- extension off: every contributed artifact disappears ---
+	require.NoError(t, store.setFlags(ctx, "ext", true, true, false))
+	items := store.ForName(ctx, "shop_items")
+	require.NotNil(t, items, "base object survives the extension flip")
+	for _, name := range []string{"note", "label", "similar", "similar_aggregation"} {
+		assert.Nilf(t, items.Fields.ForName(name), "shop_items.%s dropped with the extension", name)
+	}
+	audit := store.ForName(ctx, "audit_events")
+	require.NotNil(t, audit)
+	assert.Nil(t, audit.Fields.ForName("logs"), "extension join dropped")
+	assert.Nil(t, store.ForName(ctx, "shop_overview"), "extension view dropped")
+	assert.False(t, store.NameExists(ctx, "shop_overview"))
+	require.NoError(t, store.setFlags(ctx, "ext", true, false, false))
+	assertBaseline("extension back")
+
+	// --- shop off: the @dependency view hides while the extension is active ---
+	require.NoError(t, store.setFlags(ctx, "shop", true, true, false))
+	assert.Nil(t, store.ForName(ctx, "shop_items"))
+	assert.Nil(t, store.ForName(ctx, "shop_overview"), "declared @dependency gates the view")
+	assert.Nil(t, store.ForName(ctx, "shop_overview_filter"), "derived types follow")
+	assert.False(t, store.NameExists(ctx, "shop_overview"))
+	require.NoError(t, store.setFlags(ctx, "shop", true, false, false))
+	assertBaseline("shop back")
+
+	// --- ro off: the extension join field is ATTRIBUTED to ro (its data
+	// source) and disappears with it, machinery included ---
+	require.NoError(t, store.setFlags(ctx, "ro", true, true, false))
+	assert.Nil(t, store.ForName(ctx, "logs"))
+	audit = store.ForName(ctx, "audit_events")
+	require.NotNil(t, audit)
+	assert.Nil(t, audit.Fields.ForName("logs"), "join field hidden with its data source")
+	assert.Nil(t, audit.Fields.ForName("logs_aggregation"))
+	require.NoError(t, store.setFlags(ctx, "ro", true, false, false))
+	assertBaseline("ro back")
+
+	// --- func off: the TFCJ field is ATTRIBUTED to the function's source and
+	// disappears with it; the same-source @function_call stays ---
+	require.NoError(t, store.setFlags(ctx, "func", true, true, false))
+	items = store.ForName(ctx, "shop_items")
+	require.NotNil(t, items)
+	assert.Nil(t, items.Fields.ForName("similar"), "TFCJ field hidden with the function's source")
+	assert.Nil(t, items.Fields.ForName("similar_aggregation"))
+	assert.NotNil(t, items.Fields.ForName("label"), "shop's function_call unaffected")
+	require.NoError(t, store.setFlags(ctx, "func", true, false, false))
+	assertBaseline("func back")
+}
+
+// TestObjectDependencyGate pins the @dependency contract on views: the object
+// (and everything derived from it) is hidden while ANY declared dependency
+// source is inactive or unregistered, and dependency flag flips invalidate
+// the cache through the recorded provenance.
+func TestObjectDependencyGate(t *testing.T) {
+	const schema = `
+type v_stats @module(name: "app")
+  @view(name: "v_stats", sql: "SELECT 1 AS id")
+  @dependency(name: "depsrc") {
+  id: Int! @pk
+}
+`
+	store, ctx := storeFor(t, schema)
+
+	// The dependency is unregistered → the view is not served.
+	assert.Nil(t, store.ForName(ctx, "v_stats"))
+	assert.False(t, store.NameExists(ctx, "v_stats"))
+	assert.Nil(t, store.ForName(ctx, "v_stats_filter"), "derived types follow the gate")
+
+	// Register the dependency (meta only) → the view appears.
+	_, err := store.writeSource(ctx, newDesired(), SourceState{Name: "depsrc", Version: "v1", Engine: "duckdb", Loaded: true})
+	require.NoError(t, err)
+	def := store.ForName(ctx, "v_stats")
+	require.NotNil(t, def, "view served once the dependency is active")
+	require.NotNil(t, def.Directives.ForName("dependency"), "@dependency re-emitted")
+	assert.True(t, store.NameExists(ctx, "v_stats"))
+	require.NotNil(t, store.ForName(ctx, "v_stats_filter"))
+
+	// Disabling the dependency hides it again — the cached definition was
+	// indexed under the dependency source and must be evicted.
+	require.NoError(t, store.setFlags(ctx, "depsrc", true, true, false))
+	assert.Nil(t, store.ForName(ctx, "v_stats"), "view hidden with its dependency")
+	assert.Nil(t, store.ForName(ctx, "v_stats_filter"))
+	assert.False(t, store.NameExists(ctx, "v_stats"))
+
+	require.NoError(t, store.setFlags(ctx, "depsrc", true, false, false))
+	require.NotNil(t, store.ForName(ctx, "v_stats"), "and back")
+}
+
+// TestFieldDependencyGate mirrors the compiled provider's read-time gate on
+// dependency_catalog: a field whose @dependency source is inactive is hidden
+// from the object and its derived types.
+func TestFieldDependencyGate(t *testing.T) {
+	store, ctx := writtenStore(t)
+
+	// Attribute one stored column to a dependency source directly (the
+	// compiled path stamps @dependency on virtual/extension fields).
+	conn, err := store.pool.Conn(ctx)
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, `UPDATE core.catalog.fields SET dependency_data_source = 'ghost'
+		WHERE type_name = 'orders' AND name = 'amount'`)
+	conn.Close()
+	require.NoError(t, err)
+
+	def := store.ForName(ctx, "orders")
+	require.NotNil(t, def)
+	assert.Nil(t, def.Fields.ForName("amount"), "field hidden while its dependency is unregistered")
+
+	// Registering the dependency reveals it — the closure covers fields BY
+	// dependency attribution, so the cached object is evicted.
+	_, err = store.writeSource(ctx, newDesired(), SourceState{Name: "ghost", Version: "v1", Engine: "duckdb", Loaded: true})
+	require.NoError(t, err)
+	def = store.ForName(ctx, "orders")
+	require.NotNil(t, def)
+	fd := def.Fields.ForName("amount")
+	require.NotNil(t, fd, "field served once the dependency is active")
+	assert.NotNil(t, fd.Directives.ForName("dependency"), "@dependency re-emitted on the field")
 }
 
 func TestCacheErrorNotCached(t *testing.T) {

--- a/pkg/catalog/store/gen.go
+++ b/pkg/catalog/store/gen.go
@@ -25,15 +25,62 @@ import (
 // long-term home of this file is the compiler package (schema logic with the
 // rules, storage in store), and that split keeps the move mechanical.
 
-// genContext is the narrow read surface the generation registries work
-// against: lookups over the Store's read models for one resolution request.
-// No memoization yet — every lookup hits CoreDB; the per-request cache
-// arrives with the read-cache step (schemaCache port).
+// genContext is the READ SESSION of one resolution request: the narrow
+// surface the generation registries work against, with the request's reader
+// memoization and the touched-source set the definition cache indexes the
+// result under. Readers return errors Go-style — absent rows are nil results
+// WITHOUT an error — and the whole generation chain propagates them up to the
+// Provider surface (ForName / the logical model), which logs and serves empty
+// because those interfaces have no error channel. A session runs on a single
+// goroutine — the maps are unsynchronized by design.
 type genContext struct {
 	s *Store
+
+	// touched is the set of data sources whose ROWS the session read —
+	// exactly the sources whose rewrite can change the produced definition
+	// (row-level provenance; absence dependencies are closed on the write
+	// side, see affectedByStored).
+	touched map[string]struct{}
+
+	// Per-request memoization (one ForName reads activeSources and the base
+	// object rows many times across the generation rules). Only successful
+	// reads are memoized; absent rows memoize as nil entries.
+	sources     map[string]activeSource
+	haveSources bool
+	objects     map[string]*dataObject // nil value = known absent
+	fieldRows   map[string][]*field
+	relSrc      map[string][]*relation
+	relDst      map[string][]*relationEdge
+	nameRows    map[string][]string         // queryNames, by SQL text
+	moduleInfos map[string][]*moduleInfoRow // queryModuleInfos, by SQL text
+	functions   map[string][]*function      // readFunctions, by module
+	function    map[string]*function        // readFunction, by module\x1fname (nil = absent)
+	typeRows    map[string]*typeRow         // readType, by name (nil = absent)
 }
 
-func (s *Store) genCtx() *genContext { return &genContext{s: s} }
+// typeRow memoizes a catalog.types row as its STORED text: readType parses a
+// fresh AST per call because callers mutate the returned definition
+// (attachCatalog, applyScalarFieldArguments).
+type typeRow struct {
+	definition string
+	dataSource string
+}
+
+func (s *Store) genCtx() *genContext {
+	return &genContext{s: s, touched: map[string]struct{}{}}
+}
+
+// touch records the data sources of rows a reader returned.
+func (g *genContext) touch(sources ...string) {
+	for _, src := range sources {
+		if src != "" {
+			g.touched[src] = struct{}{}
+		}
+	}
+}
+
+// sourceList returns the touched sources in deterministic order.
+func (g *genContext) sourceList() []string { return sortedKeys(g.touched) }
 
 // queryShape (§3.1) declares one per-object query/mutation kind: select,
 // select_one (by pk / by unique), aggregate, bucket_agg, insert, update,
@@ -81,7 +128,7 @@ var queryShapes = []queryShape{
 // New field on existing types = one rule.
 type fieldRule struct {
 	name  string
-	apply func(ctx context.Context, g *genContext, t *objectTraits, def *ast.Definition)
+	apply func(ctx context.Context, g *genContext, t *objectTraits, def *ast.Definition) error
 }
 
 var fieldRules = []fieldRule{
@@ -104,7 +151,7 @@ type derivedRule struct {
 	// so registration order puts the more specific suffix first and build
 	// returning nil (base is not a data object) falls through to later rules.
 	match func(name string) (baseName string, ok bool)
-	build func(ctx context.Context, g *genContext, baseName, name string) *ast.Definition
+	build func(ctx context.Context, g *genContext, baseName, name string) (*ast.Definition, error)
 }
 
 // derivedRules in match order — ONE place: a more specific suffix registers
@@ -118,19 +165,22 @@ var derivedRules = []derivedRule{
 }
 
 // resolveDerivedType (5) generates a derived type from its base data object.
-func resolveDerivedType(ctx context.Context, s *Store, name string) *ast.Definition {
-	g := s.genCtx()
+func resolveDerivedType(ctx context.Context, g *genContext, name string) (*ast.Definition, error) {
 	for i := range derivedRules {
 		r := &derivedRules[i]
 		baseName, ok := r.match(name)
 		if !ok {
 			continue
 		}
-		if def := r.build(ctx, g, baseName, name); def != nil {
-			return def
+		def, err := r.build(ctx, g, baseName, name)
+		if err != nil {
+			return nil, err
+		}
+		if def != nil {
+			return def, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // sharedTypeRule (§3.5) synthesizes one per-schema shared system type from
@@ -139,7 +189,7 @@ func resolveDerivedType(ctx context.Context, s *Store, name string) *ast.Definit
 // static stub when the planner needs the name to always exist).
 type sharedTypeRule struct {
 	name  string
-	build func(ctx context.Context, g *genContext) *ast.Definition
+	build func(ctx context.Context, g *genContext) (*ast.Definition, error)
 }
 
 var sharedTypeRules = []sharedTypeRule{
@@ -153,14 +203,14 @@ var sharedTypeRules = []sharedTypeRule{
 // resolveSharedType (6) serves shared system types. It runs BEFORE the static
 // layer: the prelude holds only stubs for these names, the real member fields
 // come from the active objects.
-func resolveSharedType(ctx context.Context, s *Store, name string) *ast.Definition {
+func resolveSharedType(ctx context.Context, g *genContext, name string) (*ast.Definition, error) {
 	for i := range sharedTypeRules {
 		if sharedTypeRules[i].name != name {
 			continue
 		}
-		return sharedTypeRules[i].build(ctx, s.genCtx())
+		return sharedTypeRules[i].build(ctx, g)
 	}
-	return nil
+	return nil, nil
 }
 
 // rootRule (§3.6) contributes members to a synthesized module root: data
@@ -169,7 +219,7 @@ func resolveSharedType(ctx context.Context, s *Store, name string) *ast.Definiti
 // run in registration order over an empty root definition.
 type rootRule struct {
 	name  string
-	apply func(ctx context.Context, g *genContext, sc *rootScope, def *ast.Definition)
+	apply func(ctx context.Context, g *genContext, sc *rootScope, def *ast.Definition) error
 }
 
 // moduleRootRef is one syntactic parse of a module-root type name. Module is

--- a/pkg/catalog/store/gen_agg.go
+++ b/pkg/catalog/store/gen_agg.go
@@ -144,12 +144,16 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 		typ := parseFieldType(f.FieldType)
 		typeName := typ.Name()
 		isList := typ.NamedType == ""
-		if f.Name == "_stub" || f.DependencyDataSource != "" {
-			continue // extension fields join no derived types
+		if f.Name == "_stub" {
+			continue
+		}
+		if f.DependencyDataSource != "" && !isVirtualStoreField(f) {
+			continue // plain extension fields join no derived types
 		}
 		if s := types.Lookup(typeName); s != nil {
 			// Scalar twin — the compiler takes every non-list Aggregatable
-			// scalar here, virtual (@function_call) fields included.
+			// scalar here, virtual (@function_call) fields included;
+			// extension-contributed ones keep their @dependency marker.
 			if isList {
 				continue
 			}
@@ -161,11 +165,16 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 			if extra := cubeHypertableArgs(row, f); extra != nil {
 				args = append(args, extra)
 			}
+			dirs := ast.DirectiveList{}
+			if f.DependencyDataSource != "" {
+				dirs = append(dirs, dependencyDirective(f.DependencyDataSource))
+			}
+			dirs = append(dirs, fieldAggregationMarker(f.Name))
 			def.Fields = append(def.Fields, &ast.FieldDefinition{
 				Name:       f.Name,
 				Type:       ast.NamedType(a.AggregationTypeName(), reconPos),
 				Arguments:  args,
-				Directives: ast.DirectiveList{fieldAggregationMarker(f.Name)},
+				Directives: dirs,
 				Position:   reconPos,
 			})
 			continue
@@ -192,6 +201,7 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 
 	// Virtual object-list twins (addVirtualFieldAggregations): @join pairs
 	// use the agg-ref profiles, TFCJ pairs reuse the DECLARED call arguments.
+	// A cross-source @join target generates nothing (bare declared field).
 	for _, f := range fields {
 		j := f.Properties
 		if j == nil || (j.Join == nil && j.TableFunctionCallJoin == nil) {
@@ -202,7 +212,13 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 		if typ.NamedType != "" {
 			continue
 		}
-		if exists, err := g.dataObjectExists(ctx, target); err != nil {
+		if j.Join != nil {
+			if _, ok, err := g.joinMachineryTarget(ctx, f); err != nil {
+				return nil, err
+			} else if !ok {
+				continue
+			}
+		} else if exists, err := g.dataObjectExists(ctx, target); err != nil {
 			return nil, err
 		} else if !exists {
 			continue
@@ -214,19 +230,26 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 			directArgs = emitArgumentDefs(f.Args)
 			subArgs = emitArgumentDefs(f.Args)
 		}
+		memberDirs := func() ast.DirectiveList {
+			var out ast.DirectiveList
+			if f.DependencyDataSource != "" {
+				out = append(out, dependencyDirective(f.DependencyDataSource))
+			}
+			return append(out, fieldAggregationMarker(f.Name))
+		}
 		def.Fields = append(def.Fields,
 			&ast.FieldDefinition{
 				Name:       f.Name,
 				Type:       ast.NamedType("_"+target+"_aggregation", reconPos),
 				Arguments:  directArgs,
-				Directives: ast.DirectiveList{fieldAggregationMarker(f.Name)},
+				Directives: memberDirs(),
 				Position:   reconPos,
 			},
 			&ast.FieldDefinition{
 				Name:       f.Name + "_aggregation",
 				Type:       ast.NamedType(rules.AggTypeNameAtDepth(target, 1), reconPos),
 				Arguments:  subArgs,
-				Directives: ast.DirectiveList{fieldAggregationMarker(f.Name)},
+				Directives: memberDirs(),
 				Position:   reconPos,
 			},
 		)
@@ -253,15 +276,23 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 	// Every non-M2M data object's aggregation carries the shared cross-source
 	// `_join` member — and `_spatial` when the object has a Geometry field
 	// (JoinSpatialRule); their args are skipped by the sub-agg mapping, so
-	// they stay base-level-only members.
+	// they stay base-level-only members. On an extension-owned object they
+	// carry @dependency like every generated member.
 	if row.Properties == nil || !row.Properties.IsM2M {
+		sharedDirs := func(name string) ast.DirectiveList {
+			var out ast.DirectiveList
+			if srcs[row.DataSource].IsExtension {
+				out = append(out, dependencyDirective(row.DataSource))
+			}
+			return append(out, fieldAggregationMarker(name))
+		}
 		def.Fields = append(def.Fields, &ast.FieldDefinition{
 			Name: "_join",
 			Type: ast.NamedType("_join_aggregation", reconPos),
 			Arguments: ast.ArgumentDefinitionList{
 				{Name: "fields", Type: ast.NonNullListType(ast.NonNullNamedType("String", reconPos), reconPos), Position: reconPos},
 			},
-			Directives: ast.DirectiveList{fieldAggregationMarker("_join")},
+			Directives: sharedDirs("_join"),
 			Position:   reconPos,
 		})
 		if fieldsHaveGeometry(fields) {
@@ -269,7 +300,7 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 				Name:       "_spatial",
 				Type:       ast.NamedType("_spatial_aggregation", reconPos),
 				Arguments:  spatialFieldArgs(),
-				Directives: ast.DirectiveList{fieldAggregationMarker("_spatial")},
+				Directives: sharedDirs("_spatial"),
 				Position:   reconPos,
 			})
 		}
@@ -466,6 +497,25 @@ func buildObjectSubAggregation(ctx context.Context, g *genContext, row *dataObje
 	if err != nil {
 		return nil, err
 	}
+	// Virtual @join/TFCJ twin members never reach the sub-aggregations — the
+	// compiler drops BOTH the direct member and the `_aggregation` twin at
+	// sub level (args-ful ones fall out of the generic mapping anyway; the
+	// set closes the argless extension-contributed case).
+	fields, err := g.readFields(ctx, row.Name)
+	if err != nil {
+		return nil, err
+	}
+	virtualTwins := map[string]bool{}
+	for _, f := range fields {
+		if f.Properties == nil || (f.Properties.Join == nil && f.Properties.TableFunctionCallJoin == nil) {
+			continue
+		}
+		if parseFieldType(f.FieldType).NamedType != "" {
+			continue
+		}
+		virtualTwins[f.Name] = true
+		virtualTwins[f.Name+"_aggregation"] = true
+	}
 	for _, f := range baseAgg.Fields {
 		if f.Name == "_rows_count" {
 			continue
@@ -473,6 +523,13 @@ func buildObjectSubAggregation(ctx context.Context, g *genContext, row *dataObje
 		if f.Name == "_distance_to_query" {
 			// EmbeddingsRule extends the base aggregation only — the member
 			// never reaches the sub-aggregations.
+			continue
+		}
+		if f.Directives.ForName(base.DependencyDirectiveName) != nil {
+			// Extension-contributed members stay base-level-only.
+			continue
+		}
+		if virtualTwins[f.Name] {
 			continue
 		}
 		if subType := types.SubAggregationTypeName(f.Type.Name()); subType != "" {
@@ -492,7 +549,7 @@ func buildObjectSubAggregation(ctx context.Context, g *genContext, row *dataObje
 				Position:   reconPos,
 			})
 		}
-		// Members with args (relation / virtual twins) re-instantiate below.
+		// Members with args (relation twins) re-instantiate below.
 	}
 	// Extra members flip through the scalar mapping above (their base twins
 	// are Aggregatable-typed), so no separate pass is needed here.

--- a/pkg/catalog/store/gen_agg.go
+++ b/pkg/catalog/store/gen_agg.go
@@ -45,7 +45,7 @@ func matchAggregationName(name string) (string, bool) {
 	return baseName, ok && baseName != ""
 }
 
-func buildAggregation(ctx context.Context, g *genContext, baseName, name string) *ast.Definition {
+func buildAggregation(ctx context.Context, g *genContext, baseName, name string) (*ast.Definition, error) {
 	// Re-parse the variant off the full name.
 	aggName := "_" + baseName + "_aggregation"
 	isBucket := name == aggName+"_bucket"
@@ -53,16 +53,20 @@ func buildAggregation(ctx context.Context, g *genContext, baseName, name string)
 	if !isBucket {
 		for n := aggName; n != name; n += "_sub_aggregation" {
 			if !strings.HasPrefix(name, n) {
-				return nil
+				return nil, nil
 			}
 			depth++
 			if depth > maxSubAggDepth {
-				return nil
+				return nil, nil
 			}
 		}
 	}
 
-	if row, ok := g.s.readDataObject(ctx, baseName); ok {
+	row, err := g.readDataObject(ctx, baseName)
+	if err != nil {
+		return nil, err
+	}
+	if row != nil {
 		switch {
 		case isBucket:
 			return buildObjectAggBucket(ctx, g, row, name)
@@ -72,19 +76,23 @@ func buildAggregation(ctx context.Context, g *genContext, baseName, name string)
 			return buildObjectSubAggregation(ctx, g, row, name, depth)
 		}
 	}
-	if td, ds := g.structType(ctx, baseName); td != nil {
+	td, ds, err := g.structType(ctx, baseName)
+	if err != nil {
+		return nil, err
+	}
+	if td != nil {
 		switch {
 		case isBucket:
-			return nil // structural types take no bucket aggregation
+			return nil, nil // structural types take no bucket aggregation
 		case depth == 0:
 			return buildStructAggregation(ctx, g, td, ds, name)
 		case depth == 1:
 			return buildStructSubAggregation(ctx, g, td, ds, name)
 		default:
-			return nil // struct sub-aggs stop at depth 1
+			return nil, nil // struct sub-aggs stop at depth 1
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 const maxSubAggDepth = 2
@@ -110,8 +118,11 @@ func scalarFieldArguments(s types.ScalarType) ast.ArgumentDefinitionList {
 // buildObjectAggregation assembles the FINAL `_X_aggregation` for a data
 // object: _rows_count + scalar twins + structural members + virtual @join
 // list twins + relation members + ExtraFieldProvider twins.
-func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject, name string) *ast.Definition {
-	srcs := g.s.activeSources(ctx)
+func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject, name string) (*ast.Definition, error) {
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return nil, err
+	}
 	def := &ast.Definition{
 		Kind:     ast.Object,
 		Name:     name,
@@ -125,7 +136,10 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 		},
 	}
 
-	fields := g.s.readFields(ctx, row.Name)
+	fields, err := g.readFields(ctx, row.Name)
+	if err != nil {
+		return nil, err
+	}
 	for _, f := range fields {
 		typ := parseFieldType(f.FieldType)
 		typeName := typ.Name()
@@ -156,10 +170,17 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 			})
 			continue
 		}
-		if isList || isVirtualStoreField(f) || g.s.dataObjectExists(ctx, typeName) {
+		if isList || isVirtualStoreField(f) {
 			continue
 		}
-		if td, _ := g.structType(ctx, typeName); td != nil {
+		if exists, err := g.dataObjectExists(ctx, typeName); err != nil {
+			return nil, err
+		} else if exists {
+			continue
+		}
+		if td, _, err := g.structType(ctx, typeName); err != nil {
+			return nil, err
+		} else if td != nil {
 			def.Fields = append(def.Fields, &ast.FieldDefinition{
 				Name:       f.Name,
 				Type:       ast.NamedType("_"+typeName+"_aggregation", reconPos),
@@ -178,7 +199,12 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 		}
 		typ := parseFieldType(f.FieldType)
 		target := typ.Name()
-		if typ.NamedType != "" || !g.s.dataObjectExists(ctx, target) {
+		if typ.NamedType != "" {
+			continue
+		}
+		if exists, err := g.dataObjectExists(ctx, target); err != nil {
+			return nil, err
+		} else if !exists {
 			continue
 		}
 		targetFilter := target + filterSuffix
@@ -206,7 +232,9 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 		)
 	}
 
-	appendRelationAggFields(ctx, g, row, def, 0)
+	if err := appendRelationAggFields(ctx, g, row, def, 0); err != nil {
+		return nil, err
+	}
 	appendExtraAggFields(fields, def)
 
 	// @embeddings objects aggregate the query distance too (EmbeddingsRule).
@@ -246,7 +274,7 @@ func buildObjectAggregation(ctx context.Context, g *genContext, row *dataObject,
 			})
 		}
 	}
-	return def
+	return def, nil
 }
 
 func fieldsHaveGeometry(fields []*field) bool {
@@ -271,8 +299,12 @@ func spatialFieldArgs() ast.ArgumentDefinitionList {
 // appendRelationAggFields mirrors addRefToAggAtDepth for one depth: forward
 // FK single members (depth 0 only), list members (BACK/M2M) with their
 // `_aggregation` sub-member one level deeper.
-func appendRelationAggFields(ctx context.Context, g *genContext, row *dataObject, def *ast.Definition, depth int) {
-	for r := range g.s.Relations(ctx, row.Name) {
+func appendRelationAggFields(ctx context.Context, g *genContext, row *dataObject, def *ast.Definition, depth int) error {
+	rels, err := g.relations(ctx, row.Name)
+	if err != nil {
+		return err
+	}
+	for _, r := range rels {
 		if r.Kind == catalog.RelationJoin {
 			continue // @join members come from the field bags
 		}
@@ -318,6 +350,7 @@ func appendRelationAggFields(ctx context.Context, g *genContext, row *dataObject
 			},
 		)
 	}
+	return nil
 }
 
 // appendExtraAggFields adds ExtraFieldProvider twins with the extra field's
@@ -360,8 +393,11 @@ func appendExtraAggFields(fields []*field, def *ast.Definition) {
 }
 
 // buildObjectAggBucket is the literal bucket shape: key + aggregations.
-func buildObjectAggBucket(ctx context.Context, g *genContext, row *dataObject, name string) *ast.Definition {
-	srcs := g.s.activeSources(ctx)
+func buildObjectAggBucket(ctx context.Context, g *genContext, row *dataObject, name string) (*ast.Definition, error) {
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return &ast.Definition{
 		Kind:        ast.Object,
 		Name:        name,
@@ -389,7 +425,7 @@ func buildObjectAggBucket(ctx context.Context, g *genContext, row *dataObject, n
 				Position: reconPos,
 			},
 		},
-	}
+	}, nil
 }
 
 // buildObjectSubAggregation maps the base aggregation into its depth-1 or
@@ -397,8 +433,11 @@ func buildObjectAggBucket(ctx context.Context, g *genContext, row *dataObject, n
 // SubAggregation types (directives + args copied), structural members to
 // their _sub_aggregation, relation list members re-instantiate one level
 // deeper; depth 2 keeps only _rows_count.
-func buildObjectSubAggregation(ctx context.Context, g *genContext, row *dataObject, name string, depth int) *ast.Definition {
-	srcs := g.s.activeSources(ctx)
+func buildObjectSubAggregation(ctx context.Context, g *genContext, row *dataObject, name string, depth int) (*ast.Definition, error) {
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return nil, err
+	}
 	level := depth + 1
 	def := &ast.Definition{
 		Kind:     ast.Object,
@@ -420,10 +459,13 @@ func buildObjectSubAggregation(ctx context.Context, g *genContext, row *dataObje
 		Position:   reconPos,
 	})
 	if depth >= maxSubAggDepth {
-		return def
+		return def, nil
 	}
 
-	baseAgg := buildObjectAggregation(ctx, g, row, "_"+row.Name+"_aggregation")
+	baseAgg, err := buildObjectAggregation(ctx, g, row, "_"+row.Name+"_aggregation")
+	if err != nil {
+		return nil, err
+	}
 	for _, f := range baseAgg.Fields {
 		if f.Name == "_rows_count" {
 			continue
@@ -454,20 +496,26 @@ func buildObjectSubAggregation(ctx context.Context, g *genContext, row *dataObje
 	}
 	// Extra members flip through the scalar mapping above (their base twins
 	// are Aggregatable-typed), so no separate pass is needed here.
-	appendRelationAggFields(ctx, g, row, def, depth)
-	return def
+	if err := appendRelationAggFields(ctx, g, row, def, depth); err != nil {
+		return nil, err
+	}
+	return def, nil
 }
 
 // buildStructAggregation mirrors generateAggregationType on a structural
 // type: _rows_count + scalar twins (with scalar args) + nested struct members.
-func buildStructAggregation(ctx context.Context, g *genContext, td *ast.Definition, dataSource, name string) *ast.Definition {
+func buildStructAggregation(ctx context.Context, g *genContext, td *ast.Definition, dataSource, name string) (*ast.Definition, error) {
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return nil, err
+	}
 	def := &ast.Definition{
 		Kind:     ast.Object,
 		Name:     name,
 		Position: reconPos,
 		Directives: ast.DirectiveList{
 			aggregationMarker(td.Name, false, 1),
-			catalogDirective(dataSource, g.s.activeSources(ctx)[dataSource].Engine),
+			catalogDirective(dataSource, srcs[dataSource].Engine),
 		},
 		Fields: ast.FieldList{
 			{Name: "_rows_count", Type: ast.NamedType("BigInt", reconPos), Position: reconPos},
@@ -496,10 +544,17 @@ func buildStructAggregation(ctx context.Context, g *genContext, td *ast.Definiti
 			})
 			continue
 		}
-		if isList || g.s.dataObjectExists(ctx, typeName) {
+		if isList {
 			continue
 		}
-		if nested, _ := g.structType(ctx, typeName); nested != nil {
+		if exists, err := g.dataObjectExists(ctx, typeName); err != nil {
+			return nil, err
+		} else if exists {
+			continue
+		}
+		if nested, _, err := g.structType(ctx, typeName); err != nil {
+			return nil, err
+		} else if nested != nil {
 			def.Fields = append(def.Fields, &ast.FieldDefinition{
 				Name:       f.Name,
 				Type:       ast.NamedType("_"+typeName+"_aggregation", reconPos),
@@ -508,22 +563,29 @@ func buildStructAggregation(ctx context.Context, g *genContext, td *ast.Definiti
 			})
 		}
 	}
-	return def
+	return def, nil
 }
 
 // buildStructSubAggregation mirrors generateStructSubAggType: scalar members
 // flip to SubAggregation variants (directives copied, args dropped), nested
 // struct members are omitted.
-func buildStructSubAggregation(ctx context.Context, g *genContext, td *ast.Definition, dataSource, name string) *ast.Definition {
+func buildStructSubAggregation(ctx context.Context, g *genContext, td *ast.Definition, dataSource, name string) (*ast.Definition, error) {
 	aggName := "_" + td.Name + "_aggregation"
-	baseAgg := buildStructAggregation(ctx, g, td, dataSource, aggName)
+	baseAgg, err := buildStructAggregation(ctx, g, td, dataSource, aggName)
+	if err != nil {
+		return nil, err
+	}
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return nil, err
+	}
 	def := &ast.Definition{
 		Kind:     ast.Object,
 		Name:     name,
 		Position: reconPos,
 		Directives: ast.DirectiveList{
 			aggregationMarker(aggName, false, 2),
-			catalogDirective(dataSource, g.s.activeSources(ctx)[dataSource].Engine),
+			catalogDirective(dataSource, srcs[dataSource].Engine),
 		},
 		Fields: ast.FieldList{
 			{
@@ -549,7 +611,7 @@ func buildStructSubAggregation(ctx context.Context, g *genContext, td *ast.Defin
 			Position:   reconPos,
 		})
 	}
-	return def
+	return def, nil
 }
 
 func fieldAggregationMarker(name string) *ast.Directive {

--- a/pkg/catalog/store/gen_fields.go
+++ b/pkg/catalog/store/gen_fields.go
@@ -53,25 +53,38 @@ var joinFieldsRule = fieldRule{
 			if typ.NamedType != "" {
 				continue
 			}
-			if exists, err := g.dataObjectExists(ctx, target); err != nil {
-				return err
-			} else if !exists {
-				continue
-			}
 			twinArgs := func() ast.ArgumentDefinitionList {
 				return rules.SubQueryArgs(target+filterSuffix, reconPos)
 			}
 			if f.Properties.Join != nil {
+				_, ok, err := g.joinMachineryTarget(ctx, f)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					continue // cross-source (or absent) target → bare field
+				}
 				if fd := def.Fields.ForName(f.Name); fd != nil && len(fd.Arguments) == 0 {
 					fd.Arguments = rules.SubQueryArgs(target+filterSuffix, reconPos)
 				}
 			} else {
+				if exists, err := g.dataObjectExists(ctx, target); err != nil {
+					return err
+				} else if !exists {
+					continue
+				}
 				// TFCJ twins reuse the declared call arguments as-is.
 				declared := f.Args
 				twinArgs = func() ast.ArgumentDefinitionList { return emitArgumentDefs(declared) }
 			}
+			// Extension-contributed virtual fields: the twins carry the same
+			// write-time-resolved @catalog as the field, plus @dependency.
+			var extra []*ast.Directive
+			if f.DependencyDataSource != "" {
+				extra = append(extra, dependencyDirective(f.DependencyDataSource))
+			}
 			def.Fields = append(def.Fields,
-				relationAggTwinFields(f.Name, target, twinArgs, t.srcs, f.DataSource)...)
+				relationAggTwinFields(f.Name, target, twinArgs, t.srcs, f.DataSource, extra...)...)
 		}
 		return nil
 	},
@@ -173,14 +186,18 @@ func navQueryDirective(referencesName, relName string, isM2M bool, m2mName strin
 // relationAggTwinFields is addReferenceAggregationFields: the
 // {name}_aggregation / {name}_bucket_aggregation members every list relation
 // (@join / TFCJ / back FK / M2M) puts on the base object. args is a factory —
-// each twin gets its own argument list instance.
-func relationAggTwinFields(fieldName, target string, args func() ast.ArgumentDefinitionList, srcs map[string]activeSource, dataSource string) []*ast.FieldDefinition {
-	catalog := func() *ast.Directive { return catalogDirective(dataSource, srcs[dataSource].Engine) }
-	aggQuery := func(isBucket bool) *ast.Directive {
-		return directive(base.FieldAggregationQueryDirectiveName,
-			boolArg(base.ArgIsBucket, isBucket),
-			strArg(base.ArgName, fieldName),
-		)
+// each twin gets its own argument list instance; extra directives (the
+// @dependency of extension-contributed fields) are appended to both twins.
+func relationAggTwinFields(fieldName, target string, args func() ast.ArgumentDefinitionList, srcs map[string]activeSource, dataSource string, extra ...*ast.Directive) []*ast.FieldDefinition {
+	twinDirectives := func(isBucket bool) ast.DirectiveList {
+		out := ast.DirectiveList{
+			directive(base.FieldAggregationQueryDirectiveName,
+				boolArg(base.ArgIsBucket, isBucket),
+				strArg(base.ArgName, fieldName),
+			),
+			catalogDirective(dataSource, srcs[dataSource].Engine),
+		}
+		return append(out, extra...)
 	}
 	return []*ast.FieldDefinition{
 		{
@@ -188,7 +205,7 @@ func relationAggTwinFields(fieldName, target string, args func() ast.ArgumentDef
 			Description: "The aggregation for " + fieldName,
 			Type:        ast.NamedType("_"+target+"_aggregation", reconPos),
 			Arguments:   args(),
-			Directives:  ast.DirectiveList{aggQuery(false), catalog()},
+			Directives:  twinDirectives(false),
 			Position:    reconPos,
 		},
 		{
@@ -196,7 +213,7 @@ func relationAggTwinFields(fieldName, target string, args func() ast.ArgumentDef
 			Description: "The bucket aggregation for " + fieldName,
 			Type:        ast.ListType(ast.NamedType("_"+target+"_aggregation_bucket", reconPos), reconPos),
 			Arguments:   args(),
-			Directives:  ast.DirectiveList{aggQuery(true), catalog()},
+			Directives:  twinDirectives(true),
 			Position:    reconPos,
 		},
 	}
@@ -329,20 +346,28 @@ var sharedFieldsRule = fieldRule{
 		if t.isM2M() {
 			return nil
 		}
+		// Generated members of an extension-owned object carry @dependency
+		// so dependency tracking drops them with the extension.
+		var dirs ast.DirectiveList
+		if t.src.IsExtension {
+			dirs = ast.DirectiveList{dependencyDirective(t.row.DataSource)}
+		}
 		def.Fields = append(def.Fields, &ast.FieldDefinition{
 			Name: "_join",
 			Type: ast.NamedType("_join", reconPos),
 			Arguments: ast.ArgumentDefinitionList{
 				{Name: "fields", Type: ast.NonNullListType(ast.NonNullNamedType("String", reconPos), reconPos), Position: reconPos},
 			},
-			Position: reconPos,
+			Directives: dirs,
+			Position:   reconPos,
 		})
 		if fieldsHaveGeometry(t.fields) {
 			def.Fields = append(def.Fields, &ast.FieldDefinition{
-				Name:      "_spatial",
-				Type:      ast.NamedType("_spatial", reconPos),
-				Arguments: spatialFieldArgs(),
-				Position:  reconPos,
+				Name:       "_spatial",
+				Type:       ast.NamedType("_spatial", reconPos),
+				Arguments:  spatialFieldArgs(),
+				Directives: dirs,
+				Position:   reconPos,
 			})
 		}
 		return nil

--- a/pkg/catalog/store/gen_fields.go
+++ b/pkg/catalog/store/gen_fields.go
@@ -20,7 +20,7 @@ import (
 // (bucket for Timestamp, transforms for Geometry, …).
 var scalarArgsFieldRule = fieldRule{
 	name: "scalar_args",
-	apply: func(_ context.Context, _ *genContext, _ *objectTraits, def *ast.Definition) {
+	apply: func(_ context.Context, _ *genContext, _ *objectTraits, def *ast.Definition) error {
 		for _, fd := range def.Fields {
 			if fd.Type.NamedType == "" {
 				continue
@@ -33,6 +33,7 @@ var scalarArgsFieldRule = fieldRule{
 				fd.Arguments = args
 			}
 		}
+		return nil
 	},
 }
 
@@ -42,14 +43,19 @@ var scalarArgsFieldRule = fieldRule{
 // the {name}_aggregation / {name}_bucket_aggregation twins on the object.
 var joinFieldsRule = fieldRule{
 	name: "join_fields",
-	apply: func(ctx context.Context, g *genContext, t *objectTraits, def *ast.Definition) {
+	apply: func(ctx context.Context, g *genContext, t *objectTraits, def *ast.Definition) error {
 		for _, f := range t.fields {
 			if f.Properties == nil || (f.Properties.Join == nil && f.Properties.TableFunctionCallJoin == nil) {
 				continue
 			}
 			typ := parseFieldType(f.FieldType)
 			target := typ.Name()
-			if typ.NamedType != "" || !g.s.dataObjectExists(ctx, target) {
+			if typ.NamedType != "" {
+				continue
+			}
+			if exists, err := g.dataObjectExists(ctx, target); err != nil {
+				return err
+			} else if !exists {
 				continue
 			}
 			twinArgs := func() ast.ArgumentDefinitionList {
@@ -67,6 +73,7 @@ var joinFieldsRule = fieldRule{
 			def.Fields = append(def.Fields,
 				relationAggTwinFields(f.Name, target, twinArgs, t.srcs, f.DataSource)...)
 		}
+		return nil
 	},
 }
 
@@ -76,9 +83,13 @@ var joinFieldsRule = fieldRule{
 // forward navigation of its own.
 var navFieldsRule = fieldRule{
 	name: "nav_fields",
-	apply: func(ctx context.Context, g *genContext, t *objectTraits, def *ast.Definition) {
+	apply: func(ctx context.Context, g *genContext, t *objectTraits, def *ast.Definition) error {
 		if !t.isM2M() {
-			for _, leg := range g.s.relationsBySource(ctx, t.row.Name) {
+			legs, err := g.relationsBySource(ctx, t.row.Name)
+			if err != nil {
+				return err
+			}
+			for _, leg := range legs {
 				def.Fields = append(def.Fields, &ast.FieldDefinition{
 					Name: leg.SourceField,
 					Type: ast.NamedType(leg.Destination, reconPos),
@@ -93,10 +104,18 @@ var navFieldsRule = fieldRule{
 				})
 			}
 		}
-		for _, leg := range g.s.relationsByDestination(ctx, t.row.Name) {
+		legs, err := g.relationsByDestination(ctx, t.row.Name)
+		if err != nil {
+			return err
+		}
+		for _, leg := range legs {
 			backName := orDefault(leg.DestinationField, leg.Source)
 			if leg.m2mJunction {
-				for _, co := range g.s.relationsBySource(ctx, leg.Source) {
+				cos, err := g.relationsBySource(ctx, leg.Source)
+				if err != nil {
+					return err
+				}
+				for _, co := range cos {
 					if co.Name == leg.Name {
 						continue
 					}
@@ -118,6 +137,7 @@ var navFieldsRule = fieldRule{
 				relationAggTwinFields(backName, leg.Source,
 					subQueryArgsFactory(leg.Source), t.srcs, leg.DataSource)...)
 		}
+		return nil
 	},
 }
 
@@ -187,7 +207,7 @@ func relationAggTwinFields(fieldName, target string, args func() ast.ArgumentDef
 // complete field definition.
 var extraFieldsRule = fieldRule{
 	name: "extra_fields",
-	apply: func(_ context.Context, _ *genContext, t *objectTraits, def *ast.Definition) {
+	apply: func(_ context.Context, _ *genContext, t *objectTraits, def *ast.Definition) error {
 		for _, f := range t.fields {
 			if f.Name == "_stub" {
 				continue
@@ -204,6 +224,7 @@ var extraFieldsRule = fieldRule{
 				def.Fields = append(def.Fields, extraField)
 			}
 		}
+		return nil
 	},
 }
 
@@ -246,9 +267,9 @@ func cubeHypertableArgs(row *dataObject, f *field) *ast.ArgumentDefinition {
 // the object fields themselves.
 var cubeHypertableFieldRule = fieldRule{
 	name: "cube_hypertable_args",
-	apply: func(_ context.Context, _ *genContext, t *objectTraits, def *ast.Definition) {
+	apply: func(_ context.Context, _ *genContext, t *objectTraits, def *ast.Definition) error {
 		if t.row.Properties == nil || (!t.row.Properties.IsCube && !t.row.Properties.IsHypertable) {
-			return
+			return nil
 		}
 		for _, f := range t.fields {
 			arg := cubeHypertableArgs(t.row, f)
@@ -259,6 +280,7 @@ var cubeHypertableFieldRule = fieldRule{
 				fd.Arguments = append(fd.Arguments, arg)
 			}
 		}
+		return nil
 	},
 }
 
@@ -267,10 +289,10 @@ var cubeHypertableFieldRule = fieldRule{
 // QueryEmbeddingDistance extra-field binding.
 var embeddingsFieldRule = fieldRule{
 	name: "embeddings_fields",
-	apply: func(_ context.Context, _ *genContext, t *objectTraits, def *ast.Definition) {
+	apply: func(_ context.Context, _ *genContext, t *objectTraits, def *ast.Definition) error {
 		_, emb := t.vectorTraits()
 		if emb == nil {
-			return
+			return nil
 		}
 		def.Fields = append(def.Fields, &ast.FieldDefinition{
 			Name:        "_distance_to_query",
@@ -294,6 +316,7 @@ var embeddingsFieldRule = fieldRule{
 			},
 			Position: reconPos,
 		})
+		return nil
 	},
 }
 
@@ -302,9 +325,9 @@ var embeddingsFieldRule = fieldRule{
 // (JoinSpatialRule).
 var sharedFieldsRule = fieldRule{
 	name: "shared_fields",
-	apply: func(_ context.Context, _ *genContext, t *objectTraits, def *ast.Definition) {
+	apply: func(_ context.Context, _ *genContext, t *objectTraits, def *ast.Definition) error {
 		if t.isM2M() {
-			return
+			return nil
 		}
 		def.Fields = append(def.Fields, &ast.FieldDefinition{
 			Name: "_join",
@@ -322,5 +345,6 @@ var sharedFieldsRule = fieldRule{
 				Position:  reconPos,
 			})
 		}
+		return nil
 	},
 }

--- a/pkg/catalog/store/gen_filter.go
+++ b/pkg/catalog/store/gen_filter.go
@@ -42,19 +42,29 @@ var listFilterRule = derivedRule{
 // buildFilter serves X_filter for a data object (full shape: scalars with
 // directive copies, structural nesting, nav fields from relations, logical
 // ops) or for a structural type (scalar members + logical ops only).
-func buildFilter(ctx context.Context, g *genContext, baseName, name string) *ast.Definition {
-	if row, ok := g.s.readDataObject(ctx, baseName); ok {
+func buildFilter(ctx context.Context, g *genContext, baseName, name string) (*ast.Definition, error) {
+	row, err := g.readDataObject(ctx, baseName)
+	if err != nil {
+		return nil, err
+	}
+	if row != nil {
 		return buildObjectFilter(ctx, g, row, name)
 	}
-	if td, ds := g.structType(ctx, baseName); td != nil {
+	td, ds, err := g.structType(ctx, baseName)
+	if err != nil {
+		return nil, err
+	}
+	if td != nil {
 		return buildStructFilter(ctx, g, td, ds, name)
 	}
-	return nil
+	return nil, nil
 }
 
-func buildObjectFilter(ctx context.Context, g *genContext, row *dataObject, name string) *ast.Definition {
-	s := g.s
-	engines := s.activeEngines(ctx)
+func buildObjectFilter(ctx context.Context, g *genContext, row *dataObject, name string) (*ast.Definition, error) {
+	engines, err := g.activeEngines(ctx)
+	if err != nil {
+		return nil, err
+	}
 	def := &ast.Definition{
 		Kind:        ast.InputObject,
 		Name:        name,
@@ -66,8 +76,16 @@ func buildObjectFilter(ctx context.Context, g *genContext, row *dataObject, name
 		},
 	}
 
-	for _, f := range s.readFields(ctx, row.Name) {
-		if fd := filterFieldFor(ctx, g, f); fd != nil {
+	fields, err := g.readFields(ctx, row.Name)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range fields {
+		fd, err := filterFieldFor(ctx, g, f)
+		if err != nil {
+			return nil, err
+		}
+		if fd != nil {
 			def.Fields = append(def.Fields, fd)
 		}
 	}
@@ -77,7 +95,11 @@ func buildObjectFilter(ctx context.Context, g *genContext, row *dataObject, name
 	// M2M → list filter; parameterized-view targets are excluded; an is_m2m
 	// junction contributes no forward nav (its @references processing stops at
 	// the endpoint synthesis).
-	for r := range s.Relations(ctx, row.Name) {
+	rels, err := g.relations(ctx, row.Name)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rels {
 		if r.Kind == catalog.RelationJoin {
 			continue
 		}
@@ -85,8 +107,11 @@ func buildObjectFilter(ctx context.Context, g *genContext, row *dataObject, name
 			r.Kind == catalog.RelationFK && r.Direction == catalog.RelationForward {
 			continue
 		}
-		target, ok := s.readDataObject(ctx, r.DataObject)
-		if !ok {
+		target, err := g.readDataObject(ctx, r.DataObject)
+		if err != nil {
+			return nil, err
+		}
+		if target == nil {
 			continue
 		}
 		if target.Properties != nil && target.Properties.ArgsTypeName != "" {
@@ -109,7 +134,11 @@ func buildObjectFilter(ctx context.Context, g *genContext, row *dataObject, name
 
 	// Field-declared legs are mirrored onto the matching scalar filter field
 	// as @field_references (gen_references.go: addFieldReferencesToFilter).
-	for _, rel := range s.relationsBySource(ctx, row.Name) {
+	legs, err := g.relationsBySource(ctx, row.Name)
+	if err != nil {
+		return nil, err
+	}
+	for _, rel := range legs {
 		if !rel.FieldDeclared || len(rel.SourceKeys) != 1 {
 			continue
 		}
@@ -119,20 +148,20 @@ func buildObjectFilter(ctx context.Context, g *genContext, row *dataObject, name
 	}
 
 	appendFilterLogicalOps(def, name)
-	return def
+	return def, nil
 }
 
 // filterFieldFor maps one stored field into its filter member (nil = not
 // filterable): scalars via the Filterable registry, structural members via
 // the nested filter names; _stub and virtual fields are skipped.
-func filterFieldFor(ctx context.Context, g *genContext, f *field) *ast.FieldDefinition {
+func filterFieldFor(ctx context.Context, g *genContext, f *field) (*ast.FieldDefinition, error) {
 	if f.Name == "_stub" || isVirtualStoreField(f) {
-		return nil
+		return nil, nil
 	}
 	if f.DependencyDataSource != "" {
 		// The compiler's extension path extends ONLY the object definition —
 		// extension fields join none of the derived types; mirrored here.
-		return nil
+		return nil, nil
 	}
 	typ := parseFieldType(f.FieldType)
 	typeName := typ.Name()
@@ -141,7 +170,7 @@ func filterFieldFor(ctx context.Context, g *genContext, f *field) *ast.FieldDefi
 	if s := types.Lookup(typeName); s != nil {
 		fi, ok := s.(types.Filterable)
 		if !ok {
-			return nil
+			return nil, nil
 		}
 		filterType := fi.FilterTypeName()
 		if isList {
@@ -165,17 +194,17 @@ func filterFieldFor(ctx context.Context, g *genContext, f *field) *ast.FieldDefi
 		if f.Properties != nil && f.Properties.FilterRequired {
 			fd.Type.NonNull = true
 		}
-		return fd
+		return fd, nil
 	}
 
 	// Structural member: nested filter by name (the struct's own filter is a
 	// derived name too). Data objects and non-Object residual types (enums,
 	// inputs) contribute no filter member.
-	if g.s.dataObjectExists(ctx, typeName) {
-		return nil
+	if exists, err := g.dataObjectExists(ctx, typeName); err != nil || exists {
+		return nil, err
 	}
-	if td, _ := g.structType(ctx, typeName); td == nil {
-		return nil
+	if td, _, err := g.structType(ctx, typeName); err != nil || td == nil {
+		return nil, err
 	}
 	filterType := typeName + filterSuffix
 	if isList {
@@ -185,19 +214,23 @@ func filterFieldFor(ctx context.Context, g *genContext, f *field) *ast.FieldDefi
 		Name:     f.Name,
 		Type:     ast.NamedType(filterType, reconPos),
 		Position: reconPos,
-	}
+	}, nil
 }
 
 // buildStructFilter mirrors generateNestedFilterInput: scalar members only,
 // no directive copies, logical ops.
-func buildStructFilter(ctx context.Context, g *genContext, td *ast.Definition, dataSource, name string) *ast.Definition {
+func buildStructFilter(ctx context.Context, g *genContext, td *ast.Definition, dataSource, name string) (*ast.Definition, error) {
+	engines, err := g.activeEngines(ctx)
+	if err != nil {
+		return nil, err
+	}
 	def := &ast.Definition{
 		Kind:     ast.InputObject,
 		Name:     name,
 		Position: reconPos,
 		Directives: ast.DirectiveList{
 			directive(base.FilterInputDirectiveName, strArg(base.ArgName, td.Name)),
-			catalogDirective(dataSource, g.s.activeEngines(ctx)[dataSource]),
+			catalogDirective(dataSource, engines[dataSource]),
 		},
 	}
 	for _, f := range td.Fields {
@@ -225,21 +258,31 @@ func buildStructFilter(ctx context.Context, g *genContext, td *ast.Definition, d
 		})
 	}
 	appendFilterLogicalOps(def, name)
-	return def
+	return def, nil
 }
 
 // buildListFilter serves X_list_filter (any_of / all_of / none_of over
 // X_filter) for any base that has a filter: a data object or a structural
 // type. The compiler creates these lazily on first use; serving them for
 // every filterable base is a superset — nothing references the extra names.
-func buildListFilter(ctx context.Context, g *genContext, baseName, name string) *ast.Definition {
+func buildListFilter(ctx context.Context, g *genContext, baseName, name string) (*ast.Definition, error) {
 	var dataSource string
-	if row, ok := g.s.readDataObject(ctx, baseName); ok {
+	row, err := g.readDataObject(ctx, baseName)
+	if err != nil {
+		return nil, err
+	}
+	if row != nil {
 		dataSource = row.DataSource
-	} else if td, ds := g.structType(ctx, baseName); td != nil {
+	} else if td, ds, err := g.structType(ctx, baseName); err != nil {
+		return nil, err
+	} else if td != nil {
 		dataSource = ds
 	} else {
-		return nil
+		return nil, nil
+	}
+	engines, err := g.activeEngines(ctx)
+	if err != nil {
+		return nil, err
 	}
 	filterName := baseName + filterSuffix
 	return &ast.Definition{
@@ -248,14 +291,14 @@ func buildListFilter(ctx context.Context, g *genContext, baseName, name string) 
 		Position: reconPos,
 		Directives: ast.DirectiveList{
 			directive(base.FilterListInputDirectiveName, strArg(base.ArgName, baseName)),
-			catalogDirective(dataSource, g.s.activeEngines(ctx)[dataSource]),
+			catalogDirective(dataSource, engines[dataSource]),
 		},
 		Fields: ast.FieldList{
 			{Name: "any_of", Type: ast.NamedType(filterName, reconPos), Position: reconPos},
 			{Name: "all_of", Type: ast.NamedType(filterName, reconPos), Position: reconPos},
 			{Name: "none_of", Type: ast.NamedType(filterName, reconPos), Position: reconPos},
 		},
-	}
+	}, nil
 }
 
 func appendFilterLogicalOps(def *ast.Definition, name string) {
@@ -269,16 +312,15 @@ func appendFilterLogicalOps(def *ast.Definition, name string) {
 // structType resolves a STRUCTURAL residual type: a stored Object definition
 // that is not a table/view (those are data objects). Returns the definition
 // (without @catalog) and its owning data source.
-func (g *genContext) structType(ctx context.Context, name string) (*ast.Definition, string) {
-	td, ds, err := g.s.readType(ctx, name)
+func (g *genContext) structType(ctx context.Context, name string) (*ast.Definition, string, error) {
+	td, ds, err := g.readType(ctx, name)
 	if err != nil {
-		readErr("type", err)
-		return nil, ""
+		return nil, "", err
 	}
 	if td == nil || td.Kind != ast.Object {
-		return nil, ""
+		return nil, "", nil
 	}
-	return td, ds
+	return td, ds, nil
 }
 
 // isVirtualStoreField reports a declared @join / @function_call /

--- a/pkg/catalog/store/gen_golden_test.go
+++ b/pkg/catalog/store/gen_golden_test.go
@@ -444,7 +444,8 @@ func storeForSources(t *testing.T, fixtures []fixtureSource) (*Store, context.Co
 		d := collect(ctx, src, fs.name)
 		_, err = store.writeSource(ctx, d, SourceState{
 			Name: fs.name, Version: "v1", Engine: string(e.Type()),
-			Prefix: fs.prefix, AsModule: fs.asModule, ReadOnly: fs.readOnly, Loaded: true,
+			Prefix: fs.prefix, AsModule: fs.asModule, ReadOnly: fs.readOnly,
+			IsExtension: fs.isExtension, Loaded: true,
 		})
 		require.NoError(t, err)
 	}
@@ -477,7 +478,11 @@ func goldenRefSources(t *testing.T, fixtures []fixtureSource) *static.Provider {
 }
 
 // genMultiFixtures covers the deferred source-option axes: a prefixed
-// AsModule source, a read-only source, and a cross-source extension.
+// AsModule source, a read-only source, plain sources and a cross-source
+// extension. The CONTRACT pinned here: a regular source describes ONLY its
+// own data — every cross-source schema artifact (@join / @function_call /
+// @table_function_call_join wiring, cross-source views) lives in the
+// EXTENSION source.
 var genMultiFixtures = []fixtureSource{
 	{
 		name: "shop", prefix: "shop", asModule: true,
@@ -499,7 +504,6 @@ type items @table(name: "items") {
 
 extend type Function {
   item_label(id: Int!): String @function(name: "item_label")
-  slugify(s: String!): String @module(name: "tools") @function(name: "slugify")
 }
 `,
 	},
@@ -513,9 +517,47 @@ type logs @module(name: "ro_mod") @table(name: "logs") {
 `,
 	},
 	{
+		name: "audit",
+		schema: `
+type audit_events @module(name: "audit") @table(name: "audit_events") {
+  id: Int! @pk
+  log_id: Int
+}
+`,
+	},
+	{
+		// A function-only source; similar_items RETURNS another source's
+		// objects — the TFCJ wiring onto shop_items happens in the extension.
+		name: "func",
+		schema: `
+extend type Function {
+  similar_items(item_id: Int!, limit: Int = 5): [shop_items] @function(name: "similar_items")
+  slugify(s: String!): String @module(name: "tools") @function(name: "slugify")
+}
+`,
+	},
+	{
+		// The extension owns EVERY cross-source artifact: the @function_call
+		// wiring to shop's function, the @table_function_call_join wiring to
+		// the func source's function, the cross-source @join from audit's
+		// object to ro's logs, and a view with an explicit @dependency.
 		name: "ext", isExtension: true,
-		schema: `extend type shop_items {
+		schema: `
+extend type shop_items {
   note: String
+  label: String @function_call(references_name: "item_label", module: "shop", args: {id: "id"})
+  similar: [shop_items] @table_function_call_join(references_name: "similar_items", args: {item_id: "id"})
+}
+
+extend type audit_events {
+  logs: [logs] @join(references_name: "logs", source_fields: ["log_id"], references_fields: ["id"])
+}
+
+type shop_overview
+  @view(name: "shop_overview", sql: "SELECT category_id, count(*) AS items_count FROM shop.main.items GROUP BY category_id")
+  @dependency(name: "shop") {
+  category_id: Int @pk
+  items_count: BigInt
 }
 `,
 	},
@@ -545,6 +587,15 @@ func TestGenGoldenMultiSource(t *testing.T) {
 		"logs",
 		"logs_filter",
 		"_logs_aggregation",
+		// Cross-source @join: the declared field's @catalog is PROPAGATED from
+		// the referenced object ("ro"), computed via references_name on read.
+		"audit_events",
+		"_audit_events_aggregation",
+		// Extension view with an explicit @dependency (round-trips through the
+		// properties bag) and its derived types.
+		"shop_overview",
+		"shop_overview_filter",
+		"_shop_overview_aggregation",
 		// Roots: AsModule module named after the source, original-name
 		// members; ro_mod contributes no mutation root. Functions route into
 		// the source module (inline @module nests: shop.tools).
@@ -554,8 +605,9 @@ func TestGenGoldenMultiSource(t *testing.T) {
 		"_module_shop_query",
 		"_module_shop_mutation",
 		"_module_shop_function",
-		"_module_shop_tools_function",
+		"_module_tools_function",
 		"_module_ro_mod_query",
+		"_module_audit_query",
 		// Shared types span all three sources.
 		"_join",
 		"_join_aggregation",

--- a/pkg/catalog/store/gen_live_test.go
+++ b/pkg/catalog/store/gen_live_test.go
@@ -111,6 +111,12 @@ func TestGenGoldenLiveCorpus(t *testing.T) {
 			assert.NotNil(t, got, "store must serve %s", name)
 			continue
 		}
+		// Cache parity: a repeat read serves the SAME definition (cached
+		// classes by pointer identity, static classes are stable anyway).
+		if got2 := store.ForName(ctx, name); got2 != got {
+			diffs++
+			assert.Fail(t, "cache parity", "second read of %s is a different definition", name)
+		}
 		// Old-path quirks tolerated on the REFERENCE side (logged, never
 		// silent): @wfs* directives (intentionally dropped from the store —
 		// the surface moves to a separate service), duplicated @catalog tags

--- a/pkg/catalog/store/gen_mut.go
+++ b/pkg/catalog/store/gen_mut.go
@@ -32,42 +32,63 @@ var mutDataRule = derivedRule{
 	build: buildMutData,
 }
 
-func buildMutInputData(ctx context.Context, g *genContext, baseName, name string) *ast.Definition {
-	if row, ok := g.s.readDataObject(ctx, baseName); ok {
-		def := buildObjectMutInput(ctx, g, row, name, mutInputDataSuffix)
-		if def == nil {
-			return nil
-		}
-		appendInsertRelationFields(ctx, g, row, def)
-		return def
+func buildMutInputData(ctx context.Context, g *genContext, baseName, name string) (*ast.Definition, error) {
+	row, err := g.readDataObject(ctx, baseName)
+	if err != nil {
+		return nil, err
 	}
-	if td, ds := g.structType(ctx, baseName); td != nil {
+	if row != nil {
+		def, err := buildObjectMutInput(ctx, g, row, name, mutInputDataSuffix)
+		if err != nil || def == nil {
+			return nil, err
+		}
+		if err := appendInsertRelationFields(ctx, g, row, def); err != nil {
+			return nil, err
+		}
+		return def, nil
+	}
+	td, ds, err := g.structType(ctx, baseName)
+	if err != nil {
+		return nil, err
+	}
+	if td != nil {
 		return buildStructMutInput(ctx, g, td, ds, name, mutInputDataSuffix)
 	}
-	return nil
+	return nil, nil
 }
 
-func buildMutData(ctx context.Context, g *genContext, baseName, name string) *ast.Definition {
-	if row, ok := g.s.readDataObject(ctx, baseName); ok {
+func buildMutData(ctx context.Context, g *genContext, baseName, name string) (*ast.Definition, error) {
+	row, err := g.readDataObject(ctx, baseName)
+	if err != nil {
+		return nil, err
+	}
+	if row != nil {
 		return buildObjectMutInput(ctx, g, row, name, mutDataSuffix)
 	}
-	if td, ds := g.structType(ctx, baseName); td != nil {
+	td, ds, err := g.structType(ctx, baseName)
+	if err != nil {
+		return nil, err
+	}
+	if td != nil {
 		return buildStructMutInput(ctx, g, td, ds, name, mutDataSuffix)
 	}
-	return nil
+	return nil, nil
 }
 
 // buildObjectMutInput builds the column part of a table's mutation input:
 // stored fields minus _stub / @sql computed / virtual; scalar members drop
 // their null constraints, structural members nest by suffix, data-object
 // typed members are skipped (relations own them).
-func buildObjectMutInput(ctx context.Context, g *genContext, row *dataObject, name, suffix string) *ast.Definition {
+func buildObjectMutInput(ctx context.Context, g *genContext, row *dataObject, name, suffix string) (*ast.Definition, error) {
 	if row.Kind != "table" {
-		return nil // views can't be mutated
+		return nil, nil // views can't be mutated
 	}
-	srcs := g.s.activeSources(ctx)
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if srcs[row.DataSource].ReadOnly {
-		return nil
+		return nil, nil
 	}
 	def := &ast.Definition{
 		Kind:     ast.InputObject,
@@ -78,7 +99,11 @@ func buildObjectMutInput(ctx context.Context, g *genContext, row *dataObject, na
 			catalogDirective(row.DataSource, srcs[row.DataSource].Engine),
 		},
 	}
-	for _, f := range g.s.readFields(ctx, row.Name) {
+	fields, err := g.readFields(ctx, row.Name)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range fields {
 		if f.Name == "_stub" || isVirtualStoreField(f) || f.DependencyDataSource != "" {
 			continue // extension fields join no derived types
 		}
@@ -89,10 +114,14 @@ func buildObjectMutInput(ctx context.Context, g *genContext, row *dataObject, na
 		typeName := typ.Name()
 		fieldType := ast.NamedType(typeName, reconPos)
 		if types.Lookup(typeName) == nil {
-			if g.s.dataObjectExists(ctx, typeName) {
+			if exists, err := g.dataObjectExists(ctx, typeName); err != nil {
+				return nil, err
+			} else if exists {
 				continue // table/view references are handled as relations
 			}
-			if td, _ := g.structType(ctx, typeName); td != nil {
+			if td, _, err := g.structType(ctx, typeName); err != nil {
+				return nil, err
+			} else if td != nil {
 				fieldType = ast.NamedType(typeName+suffix, reconPos)
 			}
 		}
@@ -105,16 +134,23 @@ func buildObjectMutInput(ctx context.Context, g *genContext, row *dataObject, na
 			Position: reconPos,
 		})
 	}
-	return def
+	return def, nil
 }
 
 // appendInsertRelationFields adds the relation subqueries the compiler puts
 // on insert inputs (addReferenceToMutInput): forward FK single, back FK and
 // M2M list — same catalog only, both endpoints writable tables. An is_m2m
 // junction contributes no forward fields of its own.
-func appendInsertRelationFields(ctx context.Context, g *genContext, row *dataObject, def *ast.Definition) {
-	srcs := g.s.activeSources(ctx)
-	for r := range g.s.Relations(ctx, row.Name) {
+func appendInsertRelationFields(ctx context.Context, g *genContext, row *dataObject, def *ast.Definition) error {
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return err
+	}
+	rels, err := g.relations(ctx, row.Name)
+	if err != nil {
+		return err
+	}
+	for _, r := range rels {
 		if r.Kind == catalog.RelationJoin {
 			continue
 		}
@@ -122,8 +158,11 @@ func appendInsertRelationFields(ctx context.Context, g *genContext, row *dataObj
 			r.Kind == catalog.RelationFK && r.Direction == catalog.RelationForward {
 			continue
 		}
-		target, ok := g.s.readDataObject(ctx, r.DataObject)
-		if !ok || target.Kind != "table" || srcs[target.DataSource].ReadOnly {
+		target, err := g.readDataObject(ctx, r.DataObject)
+		if err != nil {
+			return err
+		}
+		if target == nil || target.Kind != "table" || srcs[target.DataSource].ReadOnly {
 			continue // the other endpoint has no mutation input
 		}
 		if target.DataSource != row.DataSource {
@@ -139,18 +178,23 @@ func appendInsertRelationFields(ctx context.Context, g *genContext, row *dataObj
 			Position: reconPos,
 		})
 	}
+	return nil
 }
 
 // buildStructMutInput mirrors generateNestedMutInputData / generateNestedMutData:
 // every member except _stub, Object-typed members nest by suffix.
-func buildStructMutInput(ctx context.Context, g *genContext, td *ast.Definition, dataSource, name, suffix string) *ast.Definition {
+func buildStructMutInput(ctx context.Context, g *genContext, td *ast.Definition, dataSource, name, suffix string) (*ast.Definition, error) {
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return nil, err
+	}
 	def := &ast.Definition{
 		Kind:     ast.InputObject,
 		Name:     name,
 		Position: reconPos,
 		Directives: ast.DirectiveList{
 			directive(base.DataInputDirectiveName, strArg(base.ArgName, td.Name)),
-			catalogDirective(dataSource, g.s.activeSources(ctx)[dataSource].Engine),
+			catalogDirective(dataSource, srcs[dataSource].Engine),
 		},
 	}
 	for _, f := range td.Fields {
@@ -160,9 +204,15 @@ func buildStructMutInput(ctx context.Context, g *genContext, td *ast.Definition,
 		typeName := f.Type.Name()
 		fieldType := ast.NamedType(typeName, reconPos)
 		if types.Lookup(typeName) == nil {
-			if g.s.dataObjectExists(ctx, typeName) {
+			exists, err := g.dataObjectExists(ctx, typeName)
+			if err != nil {
+				return nil, err
+			}
+			if exists {
 				fieldType = ast.NamedType(typeName+suffix, reconPos)
-			} else if td2, _ := g.structType(ctx, typeName); td2 != nil {
+			} else if td2, _, err := g.structType(ctx, typeName); err != nil {
+				return nil, err
+			} else if td2 != nil {
 				fieldType = ast.NamedType(typeName+suffix, reconPos)
 			}
 		}
@@ -175,5 +225,5 @@ func buildStructMutInput(ctx context.Context, g *genContext, td *ast.Definition,
 			Position: reconPos,
 		})
 	}
-	return def
+	return def, nil
 }

--- a/pkg/catalog/store/gen_roots.go
+++ b/pkg/catalog/store/gen_roots.go
@@ -31,43 +31,53 @@ func (sc *rootScope) top() bool { return sc.module == "" }
 // of the name is tried against the modules table; a module without the kind
 // (or an empty store for the top-level roots) yields nil and the static stub
 // stays authoritative.
-func resolveModuleRoot(ctx context.Context, s *Store, name string) *ast.Definition {
-	g := s.genCtx()
+func resolveModuleRoot(ctx context.Context, g *genContext, name string) (*ast.Definition, error) {
 	for _, ref := range classifyModuleRootName(name) {
-		for _, module := range g.resolveModulePath(ctx, ref.Module) {
-			if def := buildModuleRoot(ctx, g, rootScope{module: module, kind: ref.Kind, name: name}); def != nil {
-				return def
+		modules, err := g.resolveModulePath(ctx, ref.Module)
+		if err != nil {
+			return nil, err
+		}
+		for _, module := range modules {
+			def, err := buildModuleRoot(ctx, g, rootScope{module: module, kind: ref.Kind, name: name})
+			if err != nil {
+				return nil, err
+			}
+			if def != nil {
+				return def, nil
 			}
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // resolveModulePath maps the underscored path from the type name back to the
 // dotted module names that produce it ("" maps to the root).
-func (g *genContext) resolveModulePath(ctx context.Context, underscored string) []string {
+func (g *genContext) resolveModulePath(ctx context.Context, underscored string) ([]string, error) {
 	if underscored == "" {
-		return []string{""}
+		return []string{""}, nil
 	}
-	return g.s.queryNames(ctx, `SELECT mm.name FROM core.catalog.modules mm
+	return g.queryNames(ctx, `SELECT mm.name FROM core.catalog.modules mm
 		WHERE replace(mm.name, '.', '_') = `+lit(underscored)+` ORDER BY mm.name`)
 }
 
-func buildModuleRoot(ctx context.Context, g *genContext, sc rootScope) *ast.Definition {
-	rows := g.s.readModuleInfo(ctx, sc.module)
+func buildModuleRoot(ctx context.Context, g *genContext, sc rootScope) (*ast.Definition, error) {
+	rows, err := g.readModuleInfo(ctx, sc.module)
+	if err != nil {
+		return nil, err
+	}
 	if len(rows) == 0 {
-		return nil // inactive / unknown module — static stubs stay authoritative
+		return nil, nil // inactive / unknown module — static stubs stay authoritative
 	}
 	sc.info = rows[0]
 	if !rootKindAvailable(sc.info, sc.kind, sc.top()) {
-		return nil
+		return nil, nil
 	}
 
 	var def *ast.Definition
 	if sc.top() {
 		def = copyRootStub(g.s.static.ForName(ctx, sc.name))
 		if def == nil {
-			return nil
+			return nil, nil
 		}
 	} else {
 		def = &ast.Definition{
@@ -80,15 +90,21 @@ func buildModuleRoot(ctx context.Context, g *genContext, sc rootScope) *ast.Defi
 					enumArg("type", rootKindEnum(sc.kind))),
 			},
 		}
-		for _, src := range g.s.moduleKindSources(ctx, sc.module, sc.kind) {
+		srcs, err := g.moduleKindSources(ctx, sc.module, sc.kind)
+		if err != nil {
+			return nil, err
+		}
+		for _, src := range srcs {
 			def.Directives = append(def.Directives, moduleCatalogDirective(src))
 		}
 	}
 
 	for i := range rootRules {
-		rootRules[i].apply(ctx, g, &sc, def)
+		if err := rootRules[i].apply(ctx, g, &sc, def); err != nil {
+			return nil, err
+		}
 	}
-	return def
+	return def, nil
 }
 
 // rootKindAvailable gates a root on the aggregated subtree flags; the
@@ -163,7 +179,7 @@ func moduleCatalogDirective(dataSource string) *ast.Directive {
 
 // moduleKindSources lists the ACTIVE sources contributing the kind to the
 // module subtree — the @module_catalog attribution set.
-func (s *Store) moduleKindSources(ctx context.Context, module string, kind sdl.ModuleObjectType) []string {
+func (g *genContext) moduleKindSources(ctx context.Context, module string, kind sdl.ModuleObjectType) ([]string, error) {
 	flag := map[sdl.ModuleObjectType]string{
 		sdl.ModuleQuery:            "md.has_data_objects",
 		sdl.ModuleMutation:         "md.has_tables AND NOT ms.read_only",
@@ -171,7 +187,7 @@ func (s *Store) moduleKindSources(ctx context.Context, module string, kind sdl.M
 		sdl.ModuleMutationFunction: "md.has_mut_functions AND NOT ms.read_only",
 		sdl.ModuleSubscription:     "md.has_subscriptions",
 	}[kind]
-	return s.queryNames(ctx, `SELECT DISTINCT md.data_source FROM core.catalog.module_data_sources md`+
+	return g.queryNames(ctx, `SELECT DISTINCT md.data_source FROM core.catalog.module_data_sources md`+
 		activeMeta("ms", "md.data_source")+`
 		WHERE md.module = `+lit(module)+` AND (`+flag+`) ORDER BY md.data_source`)
 }
@@ -209,16 +225,26 @@ var rootRules = []rootRule{
 // on mutation roots).
 var rootObjectShapesRule = rootRule{
 	name: "object_shapes",
-	apply: func(ctx context.Context, g *genContext, sc *rootScope, def *ast.Definition) {
+	apply: func(ctx context.Context, g *genContext, sc *rootScope, def *ast.Definition) error {
 		if sc.kind != sdl.ModuleQuery && sc.kind != sdl.ModuleMutation {
-			return
+			return nil
 		}
-		for _, name := range g.s.dataObjectNames(ctx, sc.module) {
-			row, ok := g.s.readDataObject(ctx, name)
-			if !ok {
+		names, err := g.dataObjectNames(ctx, sc.module)
+		if err != nil {
+			return err
+		}
+		for _, name := range names {
+			row, err := g.readDataObject(ctx, name)
+			if err != nil {
+				return err
+			}
+			if row == nil {
 				continue
 			}
-			t := g.objectTraits(ctx, row)
+			t, err := g.objectTraits(ctx, row)
+			if err != nil {
+				return err
+			}
 			for i := range queryShapes {
 				shape := &queryShapes[i]
 				if shape.rootKind != sc.kind || !shape.matches(t) {
@@ -227,6 +253,7 @@ var rootObjectShapesRule = rootRule{
 				def.Fields = append(def.Fields, shape.root(t)...)
 			}
 		}
+		return nil
 	},
 }
 
@@ -237,18 +264,25 @@ var rootObjectShapesRule = rootRule{
 // (addModuleFuncAggregations).
 var rootFunctionsRule = rootRule{
 	name: "functions",
-	apply: func(ctx context.Context, g *genContext, sc *rootScope, def *ast.Definition) {
+	apply: func(ctx context.Context, g *genContext, sc *rootScope, def *ast.Definition) error {
 		kind := functionKindOf(sc.kind)
 		if kind == "" {
-			return
+			return nil
 		}
 		if sc.top() && (sc.kind == sdl.ModuleQuery || sc.kind == sdl.ModuleMutation) {
 			// module-"" functions only; modules' functions live under Function/MutationFunction.
 		} else if sc.kind == sdl.ModuleQuery || sc.kind == sdl.ModuleMutation {
-			return
+			return nil
 		}
-		srcs := g.s.activeSources(ctx)
-		for _, fn := range g.s.readFunctions(ctx, sc.module) {
+		srcs, err := g.activeSources(ctx)
+		if err != nil {
+			return err
+		}
+		fns, err := g.readFunctions(ctx, sc.module)
+		if err != nil {
+			return err
+		}
+		for _, fn := range fns {
 			if fn.Kind != kind {
 				continue
 			}
@@ -270,7 +304,12 @@ var rootFunctionsRule = rootRule{
 				continue
 			}
 			target, isList := listReturnTarget(fn)
-			if !isList || !g.s.dataObjectExists(ctx, target) {
+			if !isList {
+				continue
+			}
+			if exists, err := g.dataObjectExists(ctx, target); err != nil {
+				return err
+			} else if !exists {
 				continue
 			}
 			catalog := func() *ast.Directive {
@@ -297,6 +336,7 @@ var rootFunctionsRule = rootRule{
 				},
 			)
 		}
+		return nil
 	},
 }
 
@@ -313,9 +353,13 @@ func listReturnTarget(fn *function) (string, bool) {
 // (Query/Mutation/Subscription top gateways stay bare).
 var rootChildGatewaysRule = rootRule{
 	name: "child_gateways",
-	apply: func(ctx context.Context, g *genContext, sc *rootScope, def *ast.Definition) {
+	apply: func(ctx context.Context, g *genContext, sc *rootScope, def *ast.Definition) error {
 		describeTop := sc.kind == sdl.ModuleFunction || sc.kind == sdl.ModuleMutationFunction
-		for _, child := range g.s.readChildModuleInfos(ctx, sc.module) {
+		children, err := g.readChildModuleInfos(ctx, sc.module)
+		if err != nil {
+			return err
+		}
+		for _, child := range children {
 			if !rootKindAvailable(child, sc.kind, false) {
 				continue
 			}
@@ -328,11 +372,16 @@ var rootChildGatewaysRule = rootRule{
 			if !sc.top() || describeTop {
 				fd.Description = "The root " + rootGatewayWord(sc.kind) + " object of the module " + child.Name
 			}
-			for _, src := range g.s.moduleKindSources(ctx, child.Name, sc.kind) {
+			srcs, err := g.moduleKindSources(ctx, child.Name, sc.kind)
+			if err != nil {
+				return err
+			}
+			for _, src := range srcs {
 				fd.Directives = append(fd.Directives, moduleCatalogDirective(src))
 			}
 			def.Fields = append(def.Fields, fd)
 		}
+		return nil
 	},
 }
 
@@ -340,9 +389,9 @@ var rootChildGatewaysRule = rootRule{
 // top-level Query/Mutation with @module_catalog per contributing source.
 var rootFunctionGatewayRule = rootRule{
 	name: "function_gateway",
-	apply: func(ctx context.Context, g *genContext, sc *rootScope, def *ast.Definition) {
+	apply: func(ctx context.Context, g *genContext, sc *rootScope, def *ast.Definition) error {
 		if !sc.top() {
-			return
+			return nil
 		}
 		var gatewayKind sdl.ModuleObjectType
 		switch sc.kind {
@@ -351,19 +400,23 @@ var rootFunctionGatewayRule = rootRule{
 		case sdl.ModuleMutation:
 			gatewayKind = sdl.ModuleMutationFunction
 		default:
-			return
+			return nil
 		}
 		fd := def.Fields.ForName("function")
 		if fd == nil {
-			return
+			return nil
 		}
-		sources := g.s.moduleKindSources(ctx, "", gatewayKind)
+		sources, err := g.moduleKindSources(ctx, "", gatewayKind)
+		if err != nil {
+			return err
+		}
 		if len(sources) == 0 {
-			return // no functions anywhere — the bare prelude field stays
+			return nil // no functions anywhere — the bare prelude field stays
 		}
 		fd.Description = "Functions"
 		for _, src := range sources {
 			fd.Directives = append(fd.Directives, moduleCatalogDirective(src))
 		}
+		return nil
 	},
 }

--- a/pkg/catalog/store/gen_roots.go
+++ b/pkg/catalog/store/gen_roots.go
@@ -250,18 +250,27 @@ var rootObjectShapesRule = rootRule{
 				if shape.rootKind != sc.kind || !shape.matches(t) {
 					continue
 				}
-				def.Fields = append(def.Fields, shape.root(t)...)
+				shapeFields := shape.root(t)
+				// Root fields of an extension-owned object carry @dependency
+				// so dependency tracking drops them with the extension.
+				if t.src.IsExtension {
+					for _, fd := range shapeFields {
+						fd.Directives = append(fd.Directives, dependencyDirective(row.DataSource))
+					}
+				}
+				def.Fields = append(def.Fields, shapeFields...)
 			}
 		}
 		return nil
 	},
 }
 
-// rootFunctionsRule adds the module's functions of the root's kind. On the
-// top-level roots the module-"" functions attach directly to Query/Mutation
-// (RootTypeAssembler behavior). On FUNCTION module roots, list-of-data-object
-// functions additionally get their aggregation twin pair
-// (addModuleFuncAggregations).
+// rootFunctionsRule adds the module's functions of the root's kind. Functions
+// NEVER attach to Query/Mutation directly — module-"" functions live under the
+// Function/MutationFunction roots and Query/Mutation expose them through the
+// `function` gateway (FunctionRule emits Function-type extensions only). On
+// FUNCTION module roots, list-of-data-object functions additionally get their
+// aggregation twin pair (addModuleFuncAggregations).
 var rootFunctionsRule = rootRule{
 	name: "functions",
 	apply: func(ctx context.Context, g *genContext, sc *rootScope, def *ast.Definition) error {
@@ -269,9 +278,7 @@ var rootFunctionsRule = rootRule{
 		if kind == "" {
 			return nil
 		}
-		if sc.top() && (sc.kind == sdl.ModuleQuery || sc.kind == sdl.ModuleMutation) {
-			// module-"" functions only; modules' functions live under Function/MutationFunction.
-		} else if sc.kind == sdl.ModuleQuery || sc.kind == sdl.ModuleMutation {
+		if sc.kind == sdl.ModuleQuery || sc.kind == sdl.ModuleMutation {
 			return nil
 		}
 		srcs, err := g.activeSources(ctx)

--- a/pkg/catalog/store/gen_shapes.go
+++ b/pkg/catalog/store/gen_shapes.go
@@ -22,14 +22,21 @@ type objectTraits struct {
 	srcs   map[string]activeSource
 }
 
-func (g *genContext) objectTraits(ctx context.Context, row *dataObject) *objectTraits {
-	srcs := g.s.activeSources(ctx)
+func (g *genContext) objectTraits(ctx context.Context, row *dataObject) (*objectTraits, error) {
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return nil, err
+	}
+	fields, err := g.readFields(ctx, row.Name)
+	if err != nil {
+		return nil, err
+	}
 	return &objectTraits{
 		row:    row,
-		fields: g.s.readFields(ctx, row.Name),
+		fields: fields,
 		src:    srcs[row.DataSource],
 		srcs:   srcs,
-	}
+	}, nil
 }
 
 // queryName is the marker/root base name: the ORIGINAL (unprefixed) name for

--- a/pkg/catalog/store/gen_shared.go
+++ b/pkg/catalog/store/gen_shared.go
@@ -29,13 +29,19 @@ type sharedObjectEntry struct {
 
 // sharedObjects lists every ACTIVE non-M2M data object with the traits the
 // shared-type members branch on.
-func (g *genContext) sharedObjects(ctx context.Context) []*sharedObjectEntry {
-	names := g.s.queryNames(ctx, `SELECT o.name FROM core.catalog.data_objects o`+
+func (g *genContext) sharedObjects(ctx context.Context) ([]*sharedObjectEntry, error) {
+	names, err := g.queryNames(ctx, `SELECT o.name FROM core.catalog.data_objects o`+
 		activeMeta("m", "o.data_source")+` ORDER BY o.name`)
+	if err != nil {
+		return nil, err
+	}
 	var out []*sharedObjectEntry
 	for _, name := range names {
-		row, ok := g.s.readDataObject(ctx, name)
-		if !ok || (row.Properties != nil && row.Properties.IsM2M) {
+		row, err := g.readDataObject(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		if row == nil || (row.Properties != nil && row.Properties.IsM2M) {
 			continue
 		}
 		e := &sharedObjectEntry{
@@ -49,7 +55,10 @@ func (g *genContext) sharedObjects(ctx context.Context) []*sharedObjectEntry {
 			e.info.RequiredArgs = row.Properties.RequiredArgs
 			e.hasEmbeddings = row.Properties.Embeddings != nil
 		}
-		fields := g.s.readFields(ctx, name)
+		fields, err := g.readFields(ctx, name)
+		if err != nil {
+			return nil, err
+		}
 		e.spatial = fieldsHaveGeometry(fields)
 		e.hasVector = e.hasEmbeddings
 		if !e.hasVector {
@@ -62,15 +71,31 @@ func (g *genContext) sharedObjects(ctx context.Context) []*sharedObjectEntry {
 		}
 		out = append(out, e)
 	}
-	return out
+	return out, nil
 }
 
-func buildJoinShared(ctx context.Context, g *genContext) *ast.Definition {
-	objs := g.sharedObjects(ctx)
-	if len(objs) == 0 {
-		return nil
+// sharedBuildScope loads the object list and source meta every shared-type
+// builder starts from; empty objs = the builder yields nil.
+func sharedBuildScope(ctx context.Context, g *genContext) ([]*sharedObjectEntry, map[string]activeSource, error) {
+	objs, err := g.sharedObjects(ctx)
+	if err != nil {
+		return nil, nil, err
 	}
-	srcs := g.s.activeSources(ctx)
+	if len(objs) == 0 {
+		return nil, nil, nil
+	}
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return objs, srcs, nil
+}
+
+func buildJoinShared(ctx context.Context, g *genContext) (*ast.Definition, error) {
+	objs, srcs, err := sharedBuildScope(ctx, g)
+	if err != nil || len(objs) == 0 {
+		return nil, err
+	}
 	def := &ast.Definition{
 		Kind:       ast.Object,
 		Name:       "_join",
@@ -84,15 +109,14 @@ func buildJoinShared(ctx context.Context, g *genContext) *ast.Definition {
 		}
 		def.Fields = append(def.Fields, sharedMemberTrio(obj, args, srcs)...)
 	}
-	return def
+	return def, nil
 }
 
-func buildJoinAggShared(ctx context.Context, g *genContext) *ast.Definition {
-	objs := g.sharedObjects(ctx)
-	if len(objs) == 0 {
-		return nil
+func buildJoinAggShared(ctx context.Context, g *genContext) (*ast.Definition, error) {
+	objs, srcs, err := sharedBuildScope(ctx, g)
+	if err != nil || len(objs) == 0 {
+		return nil, err
 	}
-	srcs := g.s.activeSources(ctx)
 	def := &ast.Definition{
 		Kind:       ast.Object,
 		Name:       "_join_aggregation",
@@ -104,15 +128,18 @@ func buildJoinAggShared(ctx context.Context, g *genContext) *ast.Definition {
 		args = append(args, rules.VectorSearchArgs(obj.hasVector, obj.hasEmbeddings, reconPos)...)
 		def.Fields = append(def.Fields, sharedAggMember(obj, args, srcs))
 	}
-	return def
+	return def, nil
 }
 
-func buildSpatialShared(ctx context.Context, g *genContext) *ast.Definition {
-	objs := spatialOnly(g.sharedObjects(ctx))
-	if len(objs) == 0 {
-		return nil
+func buildSpatialShared(ctx context.Context, g *genContext) (*ast.Definition, error) {
+	objs, srcs, err := sharedBuildScope(ctx, g)
+	if err != nil {
+		return nil, err
 	}
-	srcs := g.s.activeSources(ctx)
+	objs = spatialOnly(objs)
+	if len(objs) == 0 {
+		return nil, nil
+	}
 	def := &ast.Definition{
 		Kind:       ast.Object,
 		Name:       "_spatial",
@@ -122,15 +149,18 @@ func buildSpatialShared(ctx context.Context, g *genContext) *ast.Definition {
 	for _, obj := range objs {
 		def.Fields = append(def.Fields, sharedMemberTrio(obj, spatialMemberArgs(obj), srcs)...)
 	}
-	return def
+	return def, nil
 }
 
-func buildSpatialAggShared(ctx context.Context, g *genContext) *ast.Definition {
-	objs := spatialOnly(g.sharedObjects(ctx))
-	if len(objs) == 0 {
-		return nil
+func buildSpatialAggShared(ctx context.Context, g *genContext) (*ast.Definition, error) {
+	objs, srcs, err := sharedBuildScope(ctx, g)
+	if err != nil {
+		return nil, err
 	}
-	srcs := g.s.activeSources(ctx)
+	objs = spatialOnly(objs)
+	if len(objs) == 0 {
+		return nil, nil
+	}
 	def := &ast.Definition{
 		Kind:       ast.Object,
 		Name:       "_spatial_aggregation",
@@ -142,17 +172,20 @@ func buildSpatialAggShared(ctx context.Context, g *genContext) *ast.Definition {
 		args = append(args, rules.VectorSearchArgs(obj.hasVector, obj.hasEmbeddings, reconPos)...)
 		def.Fields = append(def.Fields, sharedAggMember(obj, args, srcs))
 	}
-	return def
+	return def, nil
 }
 
 // buildH3DataShared mirrors H3Rule: the _spatial member trio with the four
 // h3-specific arguments appended.
-func buildH3DataShared(ctx context.Context, g *genContext) *ast.Definition {
-	objs := spatialOnly(g.sharedObjects(ctx))
-	if len(objs) == 0 {
-		return nil
+func buildH3DataShared(ctx context.Context, g *genContext) (*ast.Definition, error) {
+	objs, srcs, err := sharedBuildScope(ctx, g)
+	if err != nil {
+		return nil, err
 	}
-	srcs := g.s.activeSources(ctx)
+	objs = spatialOnly(objs)
+	if len(objs) == 0 {
+		return nil, nil
+	}
 	def := &ast.Definition{
 		Kind:       ast.Object,
 		Name:       "_h3_data_query",
@@ -165,7 +198,7 @@ func buildH3DataShared(ctx context.Context, g *genContext) *ast.Definition {
 		}
 		def.Fields = append(def.Fields, sharedMemberTrio(obj, args, srcs)...)
 	}
-	return def
+	return def, nil
 }
 
 func spatialOnly(objs []*sharedObjectEntry) []*sharedObjectEntry {

--- a/pkg/catalog/store/gen_shared.go
+++ b/pkg/catalog/store/gen_shared.go
@@ -22,6 +22,7 @@ type sharedObjectEntry struct {
 	filterName    string
 	info          *base.ObjectInfo
 	dataSource    string
+	isExtension   bool
 	hasVector     bool
 	hasEmbeddings bool
 	spatial       bool
@@ -35,6 +36,10 @@ func (g *genContext) sharedObjects(ctx context.Context) ([]*sharedObjectEntry, e
 	if err != nil {
 		return nil, err
 	}
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return nil, err
+	}
 	var out []*sharedObjectEntry
 	for _, name := range names {
 		row, err := g.readDataObject(ctx, name)
@@ -45,10 +50,11 @@ func (g *genContext) sharedObjects(ctx context.Context) ([]*sharedObjectEntry, e
 			continue
 		}
 		e := &sharedObjectEntry{
-			name:       name,
-			filterName: name + filterSuffix,
-			info:       &base.ObjectInfo{Name: name, OriginalName: row.OriginalName},
-			dataSource: row.DataSource,
+			name:        name,
+			filterName:  name + filterSuffix,
+			info:        &base.ObjectInfo{Name: name, OriginalName: row.OriginalName},
+			dataSource:  row.DataSource,
+			isExtension: srcs[row.DataSource].IsExtension,
 		}
 		if row.Properties != nil {
 			e.info.InputArgsName = row.Properties.ArgsTypeName
@@ -222,7 +228,14 @@ func spatialMemberArgs(obj *sharedObjectEntry) func() ast.ArgumentDefinitionList
 // set every shared query type carries per object. args is a factory — each
 // member gets its own argument list instance.
 func sharedMemberTrio(obj *sharedObjectEntry, args func() ast.ArgumentDefinitionList, srcs map[string]activeSource) []*ast.FieldDefinition {
-	catalog := func() *ast.Directive { return catalogDirective(obj.dataSource, srcs[obj.dataSource].Engine) }
+	dirs := func(head ...*ast.Directive) ast.DirectiveList {
+		out := ast.DirectiveList(head)
+		out = append(out, catalogDirective(obj.dataSource, srcs[obj.dataSource].Engine))
+		if obj.isExtension {
+			out = append(out, dependencyDirective(obj.dataSource))
+		}
+		return out
+	}
 	aggQuery := func(isBucket bool) *ast.Directive {
 		return directive(base.FieldAggregationQueryDirectiveName,
 			boolArg(base.ArgIsBucket, isBucket),
@@ -234,24 +247,22 @@ func sharedMemberTrio(obj *sharedObjectEntry, args func() ast.ArgumentDefinition
 			Name:      obj.name,
 			Type:      ast.ListType(ast.NamedType(obj.name, reconPos), reconPos),
 			Arguments: args(),
-			Directives: ast.DirectiveList{
-				directive("query", strArg(base.ArgName, obj.name), enumArg("type", "SELECT")),
-				catalog(),
-			},
+			Directives: dirs(
+				directive("query", strArg(base.ArgName, obj.name), enumArg("type", "SELECT"))),
 			Position: reconPos,
 		},
 		{
 			Name:       obj.name + "_aggregation",
 			Type:       ast.NamedType("_"+obj.name+"_aggregation", reconPos),
 			Arguments:  args(),
-			Directives: ast.DirectiveList{aggQuery(false), catalog()},
+			Directives: dirs(aggQuery(false)),
 			Position:   reconPos,
 		},
 		{
 			Name:       obj.name + "_bucket_aggregation",
 			Type:       ast.ListType(ast.NamedType("_"+obj.name+"_aggregation_bucket", reconPos), reconPos),
 			Arguments:  args(),
-			Directives: ast.DirectiveList{aggQuery(true), catalog()},
+			Directives: dirs(aggQuery(true)),
 			Position:   reconPos,
 		},
 	}
@@ -260,19 +271,23 @@ func sharedMemberTrio(obj *sharedObjectEntry, args func() ast.ArgumentDefinition
 // sharedAggMember is the single aggregation member the *_aggregation shared
 // types carry per object.
 func sharedAggMember(obj *sharedObjectEntry, args ast.ArgumentDefinitionList, srcs map[string]activeSource) *ast.FieldDefinition {
+	dirs := ast.DirectiveList{
+		directive(base.FieldAggregationQueryDirectiveName,
+			boolArg(base.ArgIsBucket, false),
+			strArg(base.ArgName, obj.name),
+		),
+		catalogDirective(obj.dataSource, srcs[obj.dataSource].Engine),
+	}
+	if obj.isExtension {
+		dirs = append(dirs, dependencyDirective(obj.dataSource))
+	}
+	dirs = append(dirs, fieldAggregationMarker(obj.name))
 	return &ast.FieldDefinition{
-		Name:      obj.name,
-		Type:      ast.NamedType("_"+obj.name+"_aggregation", reconPos),
-		Arguments: args,
-		Directives: ast.DirectiveList{
-			directive(base.FieldAggregationQueryDirectiveName,
-				boolArg(base.ArgIsBucket, false),
-				strArg(base.ArgName, obj.name),
-			),
-			catalogDirective(obj.dataSource, srcs[obj.dataSource].Engine),
-			fieldAggregationMarker(obj.name),
-		},
-		Position: reconPos,
+		Name:       obj.name,
+		Type:       ast.NamedType("_"+obj.name+"_aggregation", reconPos),
+		Arguments:  args,
+		Directives: dirs,
+		Position:   reconPos,
 	}
 }
 

--- a/pkg/catalog/store/logical.go
+++ b/pkg/catalog/store/logical.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"iter"
 	"slices"
 	"strings"
@@ -18,6 +19,10 @@ import (
 // through the reconstruction layer, relations synthesized from the physical fk
 // legs (see relations.go). Listing order follows the interface contract:
 // ORDER BY name (functions: kind order, then name).
+//
+// The interface has no error channel — each surface method resolves through an
+// error-returning session (genContext) and, on a read failure, logs it here
+// and serves EMPTY (never a partial result).
 var _ catalog.LogicalModel = (*Store)(nil)
 
 // Module resolves a module by full dotted name ("" = root); nil when absent or
@@ -27,7 +32,12 @@ var _ catalog.LogicalModel = (*Store)(nil)
 // by data_source_meta.read_only (all-read-only sources → no mutations and no
 // mutation functions).
 func (s *Store) Module(ctx context.Context, name string) *catalog.ModuleInfo {
-	rows := s.readModuleInfo(ctx, name)
+	g := s.genCtx()
+	rows, err := g.readModuleInfo(ctx, name)
+	if err != nil {
+		logReadErr("module "+name, err)
+		return nil
+	}
 	if len(rows) == 0 {
 		if name != "" {
 			return nil
@@ -37,15 +47,31 @@ func (s *Store) Module(ctx context.Context, name string) *catalog.ModuleInfo {
 			sdl.ModuleQuery: sdl.ModuleTypeName("", sdl.ModuleQuery),
 		}}
 	}
-	return s.moduleInfo(ctx, rows[0])
+	info, err := g.moduleInfo(ctx, rows[0])
+	if err != nil {
+		logReadErr("module "+name, err)
+		return nil
+	}
+	return info
 }
 
 // Modules iterates the DIRECT child modules of parent — children, activity and
 // root kinds all come from ONE grouped query.
 func (s *Store) Modules(ctx context.Context, parent string) iter.Seq[*catalog.ModuleInfo] {
 	return func(yield func(*catalog.ModuleInfo) bool) {
-		for _, row := range s.readChildModuleInfos(ctx, parent) {
-			if !yield(s.moduleInfo(ctx, row)) {
+		g := s.genCtx()
+		rows, err := g.readChildModuleInfos(ctx, parent)
+		if err != nil {
+			logReadErr("modules of "+parent, err)
+			return
+		}
+		for _, row := range rows {
+			info, err := g.moduleInfo(ctx, row)
+			if err != nil {
+				logReadErr("modules of "+parent, err)
+				return
+			}
+			if !yield(info) {
 				return
 			}
 		}
@@ -64,7 +90,7 @@ type moduleInfoRow struct {
 	HasSubscriptions bool
 }
 
-func (s *Store) moduleInfo(ctx context.Context, row *moduleInfoRow) *catalog.ModuleInfo {
+func (g *genContext) moduleInfo(ctx context.Context, row *moduleInfoRow) (*catalog.ModuleInfo, error) {
 	roots := map[sdl.ModuleObjectType]string{}
 	set := func(kind sdl.ModuleObjectType, present bool) {
 		if present {
@@ -76,12 +102,16 @@ func (s *Store) moduleInfo(ctx context.Context, row *moduleInfoRow) *catalog.Mod
 	set(sdl.ModuleFunction, row.HasFunctions)
 	set(sdl.ModuleMutationFunction, row.HasMutFunctions)
 	set(sdl.ModuleSubscription, row.HasSubscriptions)
+	sources, err := g.moduleMemberSources(ctx, row.Name)
+	if err != nil {
+		return nil, err
+	}
 	return &catalog.ModuleInfo{
 		Name:        row.Name,
 		Description: row.Description,
 		RootTypes:   roots,
-		DataSources: s.moduleMemberSources(ctx, row.Name),
-	}
+		DataSources: sources,
+	}, nil
 }
 
 // moduleKindFlags is the flat kind aggregate over closure rows: the hierarchy
@@ -96,7 +126,7 @@ const moduleKindFlags = `bool_or(md.has_data_objects),
 // readModuleInfo aggregates ONE module row with its subtree kind flags ("" =
 // the root, aggregated over the root closure rows). A module none of whose
 // closure sources is active yields no row — the activity gate is the join.
-func (s *Store) readModuleInfo(ctx context.Context, name string) []*moduleInfoRow {
+func (g *genContext) readModuleInfo(ctx context.Context, name string) ([]*moduleInfoRow, error) {
 	query := `SELECT mm.name, mm.description, ` + moduleKindFlags + `
 		FROM core.catalog.modules mm
 		JOIN core.catalog.module_data_sources md ON md.module = mm.name` +
@@ -109,17 +139,17 @@ func (s *Store) readModuleInfo(ctx context.Context, name string) []*moduleInfoRo
 			FROM core.catalog.module_data_sources md` + activeMeta("ms", "md.data_source") + `
 			WHERE md.module = ''`
 	}
-	return s.queryModuleInfos(ctx, query)
+	return g.queryModuleInfos(ctx, query)
 }
 
 // readChildModuleInfos lists the DIRECT children of parent with their kind
 // flags — children, activity and kinds in one grouped query.
-func (s *Store) readChildModuleInfos(ctx context.Context, parent string) []*moduleInfoRow {
+func (g *genContext) readChildModuleInfos(ctx context.Context, parent string) ([]*moduleInfoRow, error) {
 	cond := `mm.parent = ` + lit(parent)
 	if parent == "" {
 		cond = `mm.parent IS NULL`
 	}
-	return s.queryModuleInfos(ctx, `SELECT mm.name, mm.description, `+moduleKindFlags+`
+	return g.queryModuleInfos(ctx, `SELECT mm.name, mm.description, `+moduleKindFlags+`
 		FROM core.catalog.modules mm
 		JOIN core.catalog.module_data_sources md ON md.module = mm.name`+
 		activeMeta("ms", "md.data_source")+`
@@ -128,17 +158,20 @@ func (s *Store) readChildModuleInfos(ctx context.Context, parent string) []*modu
 		ORDER BY mm.name`)
 }
 
-func (s *Store) queryModuleInfos(ctx context.Context, query string) []*moduleInfoRow {
-	conn, err := s.pool.Conn(ctx)
+// queryModuleInfos runs one aggregated module query, memoized per session by
+// the SQL text.
+func (g *genContext) queryModuleInfos(ctx context.Context, query string) ([]*moduleInfoRow, error) {
+	if out, ok := g.moduleInfos[query]; ok {
+		return out, nil
+	}
+	conn, err := g.s.pool.Conn(ctx)
 	if err != nil {
-		readErr("modules", err)
-		return nil
+		return nil, fmt.Errorf("read modules: %w", err)
 	}
 	defer conn.Close()
 	rows, err := conn.Query(ctx, query)
 	if err != nil {
-		readErr("modules", err)
-		return nil
+		return nil, fmt.Errorf("read modules: %w", err)
 	}
 	defer rows.Close()
 	var out []*moduleInfoRow
@@ -147,8 +180,7 @@ func (s *Store) queryModuleInfos(ctx context.Context, query string) []*moduleInf
 		var desc sql.NullString
 		var q, mut, fn, mfn, sub sql.NullBool
 		if err := rows.Scan(&r.Name, &desc, &q, &mut, &fn, &mfn, &sub); err != nil {
-			readErr("modules", err)
-			return nil
+			return nil, fmt.Errorf("read modules: %w", err)
 		}
 		if !q.Valid && r.Name == "" {
 			continue // empty root aggregate — no active rows at all
@@ -162,16 +194,23 @@ func (s *Store) queryModuleInfos(ctx context.Context, query string) []*moduleInf
 		out = append(out, &r)
 	}
 	if err := rows.Err(); err != nil {
-		readErr("modules", err)
-		return nil
+		return nil, fmt.Errorf("read modules: %w", err)
 	}
-	return out
+	if g.moduleInfos == nil {
+		g.moduleInfos = map[string][]*moduleInfoRow{}
+	}
+	g.moduleInfos[query] = out
+	return out, nil
 }
 
 // DataObject resolves a data object by type name (activity-gated), nil for
 // anything else.
 func (s *Store) DataObject(ctx context.Context, name string) *sdl.Object {
-	def := reconstructDataObject(ctx, s, name)
+	def, err := reconstructDataObject(ctx, s.genCtx(), name)
+	if err != nil {
+		logReadErr("data object "+name, err)
+		return nil
+	}
 	if def == nil || !sdl.IsDataObject(def) {
 		return nil
 	}
@@ -181,12 +220,22 @@ func (s *Store) DataObject(ctx context.Context, name string) *sdl.Object {
 // DataObjects iterates the data objects that are members of a module.
 func (s *Store) DataObjects(ctx context.Context, module string) iter.Seq[*sdl.Object] {
 	return func(yield func(*sdl.Object) bool) {
-		for _, name := range s.dataObjectNames(ctx, module) {
-			info := s.DataObject(ctx, name)
-			if info == nil {
+		g := s.genCtx()
+		names, err := g.dataObjectNames(ctx, module)
+		if err != nil {
+			logReadErr("data objects of "+module, err)
+			return
+		}
+		for _, name := range names {
+			def, err := reconstructDataObject(ctx, g, name)
+			if err != nil {
+				logReadErr("data object "+name, err)
+				return
+			}
+			if def == nil || !sdl.IsDataObject(def) {
 				continue
 			}
-			if !yield(info) {
+			if !yield(sdl.DataObjectInfo(def)) {
 				return
 			}
 		}
@@ -196,8 +245,12 @@ func (s *Store) DataObjects(ctx context.Context, module string) iter.Seq[*sdl.Ob
 // Function resolves a callable member of a module by name ((module, name) is
 // the storage primary key — no root probing needed).
 func (s *Store) Function(ctx context.Context, module, name string) *catalog.FunctionEntry {
-	row, ok := s.readFunction(ctx, module, name)
-	if !ok {
+	row, err := s.genCtx().readFunction(ctx, module, name)
+	if err != nil {
+		logReadErr("function "+module+"."+name, err)
+		return nil
+	}
+	if row == nil {
 		return nil
 	}
 	return functionEntry(row)
@@ -207,7 +260,11 @@ func (s *Store) Function(ctx context.Context, module, name string) *catalog.Func
 // subscription kinds in that order, by name within each kind.
 func (s *Store) Functions(ctx context.Context, module string) iter.Seq[*catalog.FunctionEntry] {
 	return func(yield func(*catalog.FunctionEntry) bool) {
-		rows := s.readFunctions(ctx, module)
+		rows, err := s.genCtx().readFunctions(ctx, module)
+		if err != nil {
+			logReadErr("functions of "+module, err)
+			return
+		}
 		slices.SortFunc(rows, func(a, b *function) int {
 			if c := functionKindRank(a.Kind) - functionKindRank(b.Kind); c != 0 {
 				return c
@@ -254,7 +311,24 @@ func functionKindRank(kind string) int {
 	}
 }
 
-// Relations synthesizes the logical edges of a data object from the physical
+// Relations iterates the logical edges of a data object (see
+// genContext.relations for the synthesis rules).
+func (s *Store) Relations(ctx context.Context, object string) iter.Seq[*catalog.RelationInfo] {
+	return func(yield func(*catalog.RelationInfo) bool) {
+		rels, err := s.genCtx().relations(ctx, object)
+		if err != nil {
+			logReadErr("relations of "+object, err)
+			return
+		}
+		for _, rel := range rels {
+			if !yield(rel) {
+				return
+			}
+		}
+	}
+}
+
+// relations synthesizes the logical edges of a data object from the physical
 // legs (verified against the live etalon):
 //   - own legs → FK FORWARD (a junction shows its two legs this way);
 //   - a leg from an is_m2m junction → M2M FORWARD to each co-endpoint
@@ -262,96 +336,111 @@ func functionKindRank(kind string) int {
 //     field/description from the leg's destination side) — and no FK BACK;
 //   - any other incoming leg → FK BACK (keys stay canonical);
 //   - own declared @join fields targeting a data object → JOIN FORWARD.
-func (s *Store) Relations(ctx context.Context, object string) iter.Seq[*catalog.RelationInfo] {
-	return func(yield func(*catalog.RelationInfo) bool) {
-		var rels []*catalog.RelationInfo
+func (g *genContext) relations(ctx context.Context, object string) ([]*catalog.RelationInfo, error) {
+	var rels []*catalog.RelationInfo
 
-		for _, r := range s.relationsBySource(ctx, object) {
-			rels = append(rels, &catalog.RelationInfo{
-				Name:            r.Name,
-				Direction:       catalog.RelationForward,
-				Kind:            catalog.RelationFK,
-				FieldName:       r.SourceField,
-				Description:     r.SourceFieldDescription,
-				DataObject:      r.Destination,
-				SourceKeys:      r.SourceKeys,
-				DestinationKeys: r.DestinationKeys,
-				DataSource:      r.DataSource,
-			})
-		}
-
-		for _, r := range s.relationsByDestination(ctx, object) {
-			if r.m2mJunction {
-				for _, co := range s.relationsBySource(ctx, r.Source) {
-					if co.Name == r.Name {
-						continue
-					}
-					rels = append(rels, &catalog.RelationInfo{
-						Name:            r.Name,
-						Direction:       catalog.RelationForward,
-						Kind:            catalog.RelationM2M,
-						FieldName:       orDefault(r.DestinationField, r.Source),
-						Description:     r.DestinationFieldDescription,
-						DataObject:      co.Destination,
-						Through:         r.Source,
-						SourceKeys:      r.DestinationKeys,
-						DestinationKeys: r.SourceKeys,
-						DataSource:      r.DataSource,
-					})
-				}
-				continue
-			}
-			// An explicitly EMPTY references_query means the DEFAULT (the
-			// declaring object name) — the compiler never distinguishes.
-			rels = append(rels, &catalog.RelationInfo{
-				Name:            r.Name,
-				Direction:       catalog.RelationBack,
-				Kind:            catalog.RelationFK,
-				FieldName:       orDefault(r.DestinationField, r.Source),
-				Description:     r.DestinationFieldDescription,
-				DataObject:      r.Source,
-				SourceKeys:      r.SourceKeys,
-				DestinationKeys: r.DestinationKeys,
-				DataSource:      r.DataSource,
-			})
-		}
-
-		for _, f := range s.readFields(ctx, object) {
-			j := f.Properties.Join
-			if j == nil || !s.dataObjectExists(ctx, j.ReferencesName) {
-				continue
-			}
-			rels = append(rels, &catalog.RelationInfo{
-				Name:            f.Name,
-				Direction:       catalog.RelationForward,
-				Kind:            catalog.RelationJoin,
-				FieldName:       f.Name,
-				Description:     f.Description,
-				DataObject:      j.ReferencesName,
-				SourceKeys:      j.SourceFields,
-				DestinationKeys: j.ReferencesFields,
-				DataSource:      f.DataSource,
-			})
-		}
-
-		slices.SortFunc(rels, func(a, b *catalog.RelationInfo) int {
-			if c := strings.Compare(a.Name, b.Name); c != 0 {
-				return c
-			}
-			if c := strings.Compare(string(a.Kind), string(b.Kind)); c != 0 {
-				return c
-			}
-			if c := strings.Compare(string(a.Direction), string(b.Direction)); c != 0 {
-				return c
-			}
-			return strings.Compare(a.FieldName, b.FieldName)
-		})
-		for _, rel := range rels {
-			if !yield(rel) {
-				return
-			}
-		}
+	own, err := g.relationsBySource(ctx, object)
+	if err != nil {
+		return nil, err
 	}
+	for _, r := range own {
+		rels = append(rels, &catalog.RelationInfo{
+			Name:            r.Name,
+			Direction:       catalog.RelationForward,
+			Kind:            catalog.RelationFK,
+			FieldName:       r.SourceField,
+			Description:     r.SourceFieldDescription,
+			DataObject:      r.Destination,
+			SourceKeys:      r.SourceKeys,
+			DestinationKeys: r.DestinationKeys,
+			DataSource:      r.DataSource,
+		})
+	}
+
+	incoming, err := g.relationsByDestination(ctx, object)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range incoming {
+		if r.m2mJunction {
+			cos, err := g.relationsBySource(ctx, r.Source)
+			if err != nil {
+				return nil, err
+			}
+			for _, co := range cos {
+				if co.Name == r.Name {
+					continue
+				}
+				rels = append(rels, &catalog.RelationInfo{
+					Name:            r.Name,
+					Direction:       catalog.RelationForward,
+					Kind:            catalog.RelationM2M,
+					FieldName:       orDefault(r.DestinationField, r.Source),
+					Description:     r.DestinationFieldDescription,
+					DataObject:      co.Destination,
+					Through:         r.Source,
+					SourceKeys:      r.DestinationKeys,
+					DestinationKeys: r.SourceKeys,
+					DataSource:      r.DataSource,
+				})
+			}
+			continue
+		}
+		// An explicitly EMPTY references_query means the DEFAULT (the
+		// declaring object name) — the compiler never distinguishes.
+		rels = append(rels, &catalog.RelationInfo{
+			Name:            r.Name,
+			Direction:       catalog.RelationBack,
+			Kind:            catalog.RelationFK,
+			FieldName:       orDefault(r.DestinationField, r.Source),
+			Description:     r.DestinationFieldDescription,
+			DataObject:      r.Source,
+			SourceKeys:      r.SourceKeys,
+			DestinationKeys: r.DestinationKeys,
+			DataSource:      r.DataSource,
+		})
+	}
+
+	fields, err := g.readFields(ctx, object)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range fields {
+		j := f.Properties.Join
+		if j == nil {
+			continue
+		}
+		if exists, err := g.dataObjectExists(ctx, j.ReferencesName); err != nil {
+			return nil, err
+		} else if !exists {
+			continue
+		}
+		rels = append(rels, &catalog.RelationInfo{
+			Name:            f.Name,
+			Direction:       catalog.RelationForward,
+			Kind:            catalog.RelationJoin,
+			FieldName:       f.Name,
+			Description:     f.Description,
+			DataObject:      j.ReferencesName,
+			SourceKeys:      j.SourceFields,
+			DestinationKeys: j.ReferencesFields,
+			DataSource:      f.DataSource,
+		})
+	}
+
+	slices.SortFunc(rels, func(a, b *catalog.RelationInfo) int {
+		if c := strings.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		if c := strings.Compare(string(a.Kind), string(b.Kind)); c != 0 {
+			return c
+		}
+		if c := strings.Compare(string(a.Direction), string(b.Direction)); c != 0 {
+			return c
+		}
+		return strings.Compare(a.FieldName, b.FieldName)
+	})
+	return rels, nil
 }
 
 // Type resolves a type definition by name — the ForName resolver chain.
@@ -364,11 +453,20 @@ func (s *Store) Type(ctx context.Context, name string) *ast.Definition {
 // re-attached the same way ForName serves them.
 func (s *Store) SourceTypes(ctx context.Context) iter.Seq2[string, *ast.Definition] {
 	return func(yield func(string, *ast.Definition) bool) {
-		rows := s.readSourceTypes(ctx)
+		g := s.genCtx()
+		rows, err := g.readSourceTypes(ctx)
+		if err != nil {
+			logReadErr("source types", err)
+			return
+		}
 		if len(rows) == 0 {
 			return
 		}
-		engines := s.activeEngines(ctx)
+		engines, err := g.activeEngines(ctx)
+		if err != nil {
+			logReadErr("source types", err)
+			return
+		}
 		for _, row := range rows {
 			def := attachCatalog(parseStoredDefinition(row.Name, row.Definition), row.DataSource, engines)
 			if def == nil {
@@ -390,8 +488,8 @@ func (s *Store) SystemTypes(ctx context.Context) iter.Seq2[string, *ast.Definiti
 
 // moduleMemberSources lists the distinct data sources of the module's DIRECT
 // members (objects + functions), sorted — the ModuleInfo.DataSources contract.
-func (s *Store) moduleMemberSources(ctx context.Context, module string) []string {
-	return s.queryNames(ctx, `SELECT src FROM (
+func (g *genContext) moduleMemberSources(ctx context.Context, module string) ([]string, error) {
+	return g.queryNames(ctx, `SELECT src FROM (
 		SELECT o.data_source AS src FROM core.catalog.data_objects o`+activeMeta("m1", "o.data_source")+`
 			WHERE o.module = `+lit(module)+`
 		UNION
@@ -400,22 +498,25 @@ func (s *Store) moduleMemberSources(ctx context.Context, module string) []string
 		) ORDER BY src`)
 }
 
-func (s *Store) dataObjectNames(ctx context.Context, module string) []string {
-	return s.queryNames(ctx, `SELECT o.name FROM core.catalog.data_objects o`+
+func (g *genContext) dataObjectNames(ctx context.Context, module string) ([]string, error) {
+	return g.queryNames(ctx, `SELECT o.name FROM core.catalog.data_objects o`+
 		activeMeta("m", "o.data_source")+`
 		WHERE o.module = `+lit(module)+` ORDER BY o.name`)
 }
 
-func (s *Store) dataObjectExists(ctx context.Context, name string) bool {
-	return len(s.queryNames(ctx, `SELECT o.name FROM core.catalog.data_objects o`+
-		activeMeta("m", "o.data_source")+` WHERE o.name = `+lit(name))) > 0
+func (g *genContext) dataObjectExists(ctx context.Context, name string) (bool, error) {
+	names, err := g.queryNames(ctx, `SELECT o.name FROM core.catalog.data_objects o`+
+		activeMeta("m", "o.data_source")+` WHERE o.name = `+lit(name))
+	return len(names) > 0, err
 }
 
-func (s *Store) readFunctions(ctx context.Context, module string) []*function {
-	conn, err := s.pool.Conn(ctx)
+func (g *genContext) readFunctions(ctx context.Context, module string) ([]*function, error) {
+	if out, ok := g.functions[module]; ok {
+		return out, nil
+	}
+	conn, err := g.s.pool.Conn(ctx)
 	if err != nil {
-		readErr("functions", err)
-		return nil
+		return nil, fmt.Errorf("read functions of %s: %w", module, err)
 	}
 	defer conn.Close()
 	rows, err := conn.Query(ctx, `SELECT f.module, f.name, f.kind, f.data_source, f.returns, f.is_table,
@@ -423,38 +524,38 @@ func (s *Store) readFunctions(ctx context.Context, module string) []*function {
 		FROM core.catalog.functions f`+activeMeta("m", "f.data_source")+`
 		WHERE f.module = `+lit(module)+` ORDER BY f.name`)
 	if err != nil {
-		readErr("functions", err)
-		return nil
+		return nil, fmt.Errorf("read functions of %s: %w", module, err)
 	}
 	defer rows.Close()
 	var out []*function
 	for rows.Next() {
 		row, err := scanFunction(rows.Scan)
 		if err != nil {
-			readErr("functions", err)
-			return nil
+			return nil, fmt.Errorf("read functions of %s: %w", module, err)
 		}
+		g.touch(row.DataSource)
 		out = append(out, row)
 	}
 	if err := rows.Err(); err != nil {
-		readErr("functions", err)
-		return nil
+		return nil, fmt.Errorf("read functions of %s: %w", module, err)
 	}
-	return out
+	if g.functions == nil {
+		g.functions = map[string][]*function{}
+	}
+	g.functions[module] = out
+	return out, nil
 }
 
-func (s *Store) readSourceTypes(ctx context.Context) []*sourceType {
-	conn, err := s.pool.Conn(ctx)
+func (g *genContext) readSourceTypes(ctx context.Context) ([]*sourceType, error) {
+	conn, err := g.s.pool.Conn(ctx)
 	if err != nil {
-		readErr("types", err)
-		return nil
+		return nil, fmt.Errorf("read source types: %w", err)
 	}
 	defer conn.Close()
 	rows, err := conn.Query(ctx, `SELECT t.name, t.kind, t.data_source, t.module, t.definition, t.description
 		FROM core.catalog.types t`+activeMeta("m", "t.data_source")+` ORDER BY t.name`)
 	if err != nil {
-		readErr("types", err)
-		return nil
+		return nil, fmt.Errorf("read source types: %w", err)
 	}
 	defer rows.Close()
 	var out []*sourceType
@@ -462,44 +563,48 @@ func (s *Store) readSourceTypes(ctx context.Context) []*sourceType {
 		var r sourceType
 		var desc sql.NullString
 		if err := rows.Scan(&r.Name, &r.Kind, &r.DataSource, &r.Module, &r.Definition, &desc); err != nil {
-			readErr("types", err)
-			return nil
+			return nil, fmt.Errorf("read source types: %w", err)
 		}
 		r.Description = desc.String
 		out = append(out, &r)
 	}
 	if err := rows.Err(); err != nil {
-		readErr("types", err)
-		return nil
+		return nil, fmt.Errorf("read source types: %w", err)
 	}
-	return out
+	return out, nil
 }
 
-func (s *Store) queryNames(ctx context.Context, query string) []string {
-	conn, err := s.pool.Conn(ctx)
+// queryNames runs one single-column name query, memoized per session by the
+// SQL text (covers dataObjectExists / dataObjectNames / moduleKindSources /
+// resolveModulePath / lastListReturningModuleFunction).
+func (g *genContext) queryNames(ctx context.Context, query string) ([]string, error) {
+	if out, ok := g.nameRows[query]; ok {
+		return out, nil
+	}
+	conn, err := g.s.pool.Conn(ctx)
 	if err != nil {
-		readErr("names", err)
-		return nil
+		return nil, fmt.Errorf("read names: %w", err)
 	}
 	defer conn.Close()
 	rows, err := conn.Query(ctx, query)
 	if err != nil {
-		readErr("names", err)
-		return nil
+		return nil, fmt.Errorf("read names: %w", err)
 	}
 	defer rows.Close()
 	var out []string
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
-			readErr("names", err)
-			return nil
+			return nil, fmt.Errorf("read names: %w", err)
 		}
 		out = append(out, name)
 	}
 	if err := rows.Err(); err != nil {
-		readErr("names", err)
-		return nil
+		return nil, fmt.Errorf("read names: %w", err)
 	}
-	return out
+	if g.nameRows == nil {
+		g.nameRows = map[string][]string{}
+	}
+	g.nameRows[query] = out
+	return out, nil
 }

--- a/pkg/catalog/store/logical.go
+++ b/pkg/catalog/store/logical.go
@@ -260,11 +260,14 @@ func (s *Store) Function(ctx context.Context, module, name string) *catalog.Func
 // subscription kinds in that order, by name within each kind.
 func (s *Store) Functions(ctx context.Context, module string) iter.Seq[*catalog.FunctionEntry] {
 	return func(yield func(*catalog.FunctionEntry) bool) {
-		rows, err := s.genCtx().readFunctions(ctx, module)
+		memoized, err := s.genCtx().readFunctions(ctx, module)
 		if err != nil {
 			logReadErr("functions of "+module, err)
 			return
 		}
+		// Sort a copy — the memoized slice's ORDER BY name order is a reader
+		// contract other consumers rely on.
+		rows := slices.Clone(memoized)
 		slices.SortFunc(rows, func(a, b *function) int {
 			if c := functionKindRank(a.Kind) - functionKindRank(b.Kind); c != 0 {
 				return c
@@ -504,10 +507,13 @@ func (g *genContext) dataObjectNames(ctx context.Context, module string) ([]stri
 		WHERE o.module = `+lit(module)+` ORDER BY o.name`)
 }
 
+// dataObjectExists probes through readDataObject: memoized, applies the full
+// visibility gate (source activity AND declared dependencies) and records the
+// found object's sources as provenance — a definition that branched on this
+// probe is indexed under the target's sources.
 func (g *genContext) dataObjectExists(ctx context.Context, name string) (bool, error) {
-	names, err := g.queryNames(ctx, `SELECT o.name FROM core.catalog.data_objects o`+
-		activeMeta("m", "o.data_source")+` WHERE o.name = `+lit(name))
-	return len(names) > 0, err
+	row, err := g.readDataObject(ctx, name)
+	return row != nil, err
 }
 
 func (g *genContext) readFunctions(ctx context.Context, module string) ([]*function, error) {

--- a/pkg/catalog/store/names.go
+++ b/pkg/catalog/store/names.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"context"
+)
+
+// NameExists reports whether ForName would serve the name — the validate-only
+// classification pass (write-time name-collision checks §5.1, cheap
+// negatives): the same per-class EXISTS probes the resolver chain runs,
+// without building any definition. It over-approximates module roots whose
+// kind gates need row flags; a read failure logs and classifies as NOT
+// served.
+func (s *Store) NameExists(ctx context.Context, name string) bool {
+	ok, err := s.nameExists(ctx, name)
+	if err != nil {
+		logReadErr("name exists "+name, err)
+		return false
+	}
+	return ok
+}
+
+func (s *Store) nameExists(ctx context.Context, name string) (bool, error) {
+	if _, ok := topLevelRoots[name]; ok {
+		return true, nil
+	}
+	// System types and the shared-type stubs live in the static layer.
+	if s.static.ForName(ctx, name) != nil {
+		return true, nil
+	}
+	g := s.genCtx()
+	if exists, err := g.dataObjectExists(ctx, name); err != nil || exists {
+		return exists, err
+	}
+	if exists, err := g.typeExists(ctx, name); err != nil || exists {
+		return exists, err
+	}
+	for _, ref := range classifyModuleRootName(name) {
+		modules, err := g.resolveModulePath(ctx, ref.Module)
+		if err != nil {
+			return false, err
+		}
+		if len(modules) > 0 {
+			return true, nil
+		}
+	}
+	for i := range derivedRules {
+		base, ok := derivedRules[i].match(name)
+		if !ok {
+			continue
+		}
+		// Derived types are built over data objects AND structural residual
+		// types (buildFilter / buildMutInput* / buildAggregation fallbacks).
+		if exists, err := g.dataObjectExists(ctx, base); err != nil || exists {
+			return exists, err
+		}
+		if exists, err := g.typeExists(ctx, base); err != nil || exists {
+			return exists, err
+		}
+	}
+	return false, nil
+}
+
+// typeExists probes a catalog.types row (activity-gated).
+func (g *genContext) typeExists(ctx context.Context, name string) (bool, error) {
+	names, err := g.queryNames(ctx, `SELECT t.name FROM core.catalog.types t`+
+		activeMeta("m", "t.data_source")+` WHERE t.name = `+lit(name))
+	return len(names) > 0, err
+}

--- a/pkg/catalog/store/reconstruct.go
+++ b/pkg/catalog/store/reconstruct.go
@@ -20,45 +20,84 @@ import (
 // resolver. Order matters: module roots come before the system layer because
 // Query/Mutation/Subscription are @system-classified (the static prelude holds
 // stubs) yet must be SYNTHESIZED from their module members.
-//
-// (Future — huge schemas: a resolver's cheap classification will consult an
-// in-memory name index / bloom filter refreshed on write, so a miss costs no DB
-// round-trip. The resolver structure keeps that a drop-in.)
-type resolver func(ctx context.Context, s *Store, name string) *ast.Definition
+type resolver func(ctx context.Context, g *genContext, name string) (*ast.Definition, error)
 
-var resolvers = []resolver{
-	resolveModuleRoot,  // 4: Query / Mutation / _module_*_query — synthesized from members
-	resolveSharedType,  // 6: _join / _spatial / … — synthesized from active objects
-	resolveSystemType,  // 1: scalars / __* / @system — static prelude
-	resolveDataObject,  // 3: catalog.data_objects — generated object type
-	resolveSourceType,  // 2: catalog.types — parsed from stored SDL
-	resolveDerivedType, // 5: _X_aggregation / X_filter / … — generated from base X
+// resolverEntry pairs a resolver with its caching class: system definitions
+// come from the in-memory static layer and are never cached; global
+// definitions depend on the whole active-source set and index under
+// allSources; everything else indexes under the sources its session
+// actually read rows from.
+type resolverEntry struct {
+	resolve resolver
+	global  bool
+	system  bool
 }
 
-// ForName resolves a type definition by name (nil when absent).
+var resolvers = []resolverEntry{
+	{resolve: resolveModuleRoot, global: true}, // 4: Query / Mutation / _module_*_query — synthesized from members
+	{resolve: resolveSharedType, global: true}, // 6: _join / _spatial / … — synthesized from active objects
+	{resolve: resolveSystemType, system: true}, // 1: scalars / __* / @system — static prelude
+	{resolve: resolveDataObject},               // 3: catalog.data_objects — generated object type
+	{resolve: resolveSourceType},               // 2: catalog.types — parsed from stored SDL
+	{resolve: resolveDerivedType},              // 5: _X_aggregation / X_filter / … — generated from base X
+}
+
+// ForName resolves a type definition by name (nil when absent): cache hit →
+// singleflight-collapsed resolution through the chain, on a fresh read
+// session. The catalog.Provider surface has no error channel, so a read
+// failure is logged here and served as nil — never cached (absence is a nil
+// WITHOUT an error and is simply not cached either).
 func (s *Store) ForName(ctx context.Context, name string) *ast.Definition {
-	for _, resolve := range resolvers {
-		if def := resolve(ctx, s, name); def != nil {
-			return def
-		}
+	if def := s.cache.get(name); def != nil {
+		return def
 	}
-	return nil
+	v, _, _ := s.sf.Do("DEF:"+name, func() (any, error) {
+		if def := s.cache.get(name); def != nil {
+			return def, nil
+		}
+		gen := s.gen.Load()
+		g := s.genCtx()
+		for i := range resolvers {
+			e := &resolvers[i]
+			def, err := e.resolve(ctx, g, name)
+			if err != nil {
+				logReadErr("resolve "+name, err)
+				return nil, nil
+			}
+			if def == nil {
+				continue
+			}
+			if !e.system {
+				sources := []string{allSources}
+				if !e.global {
+					sources = g.sourceList()
+				}
+				s.cache.put(name, sources, def, func() bool { return s.gen.Load() == gen })
+			}
+			return def, nil
+		}
+		return nil, nil
+	})
+	if v == nil {
+		return nil
+	}
+	return v.(*ast.Definition)
 }
 
 // resolveSystemType (1) serves the binary-owned system layer.
-func resolveSystemType(ctx context.Context, s *Store, name string) *ast.Definition {
-	return s.static.ForName(ctx, name)
+func resolveSystemType(ctx context.Context, g *genContext, name string) (*ast.Definition, error) {
+	return g.s.static.ForName(ctx, name), nil
 }
 
 // resolveSourceType (2) reconstructs a residual source type from stored SDL.
-func resolveSourceType(ctx context.Context, s *Store, name string) *ast.Definition {
-	return s.reconstructType(ctx, name)
+func resolveSourceType(ctx context.Context, g *genContext, name string) (*ast.Definition, error) {
+	return g.reconstructType(ctx, name)
 }
 
 // resolveDataObject (3) generates the compiled object type: the reconstructed
 // base object plus the fieldRules contributions (gen.go).
-func resolveDataObject(ctx context.Context, s *Store, name string) *ast.Definition {
-	return reconstructDataObject(ctx, s, name)
+func resolveDataObject(ctx context.Context, g *genContext, name string) (*ast.Definition, error) {
+	return reconstructDataObject(ctx, g, name)
 }
 
 // reconstructType parses a residual source type from its stored SDL
@@ -66,17 +105,17 @@ func resolveDataObject(ctx context.Context, s *Store, name string) *ast.Definiti
 // compiler tags every definition, but the SDL is stored pre-tagging; nil when
 // the name is not a stored type. Structural Object types also get the scalar
 // field arguments the passthrough applies before storing its compiled copy.
-func (s *Store) reconstructType(ctx context.Context, name string) *ast.Definition {
-	def, dataSource, err := s.readType(ctx, name)
-	if err != nil {
-		readErr("type", err)
-		return nil
-	}
-	if def == nil {
-		return nil
+func (g *genContext) reconstructType(ctx context.Context, name string) (*ast.Definition, error) {
+	def, dataSource, err := g.readType(ctx, name)
+	if err != nil || def == nil {
+		return nil, err
 	}
 	applyScalarFieldArguments(def)
-	return attachCatalog(def, dataSource, s.activeEngines(ctx))
+	engines, err := g.activeEngines(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return attachCatalog(def, dataSource, engines), nil
 }
 
 // applyScalarFieldArguments mirrors setScalarFieldArguments on read: non-list
@@ -109,10 +148,20 @@ func attachCatalog(def *ast.Definition, dataSource string, engines map[string]st
 	return def
 }
 
-func (s *Store) readType(ctx context.Context, name string) (*ast.Definition, string, error) {
-	conn, err := s.pool.Conn(ctx)
+// readType reads a catalog.types row, memoizing the STORED text per session —
+// a fresh AST is parsed per call because callers mutate the returned
+// definition (attachCatalog, applyScalarFieldArguments). Absent = (nil, "",
+// nil).
+func (g *genContext) readType(ctx context.Context, name string) (*ast.Definition, string, error) {
+	if row, ok := g.typeRows[name]; ok {
+		if row == nil {
+			return nil, "", nil
+		}
+		return parseStoredDefinition(name, row.definition), row.dataSource, nil
+	}
+	conn, err := g.s.pool.Conn(ctx)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("read type %s: %w", name, err)
 	}
 	defer conn.Close()
 	var definition, dataSource string
@@ -120,11 +169,20 @@ func (s *Store) readType(ctx context.Context, name string) (*ast.Definition, str
 		`SELECT t.definition, t.data_source FROM core.catalog.types t`+activeMeta("m", "t.data_source")+
 			` WHERE t.name = `+lit(name)).Scan(&definition, &dataSource)
 	if err == sql.ErrNoRows {
+		if g.typeRows == nil {
+			g.typeRows = map[string]*typeRow{}
+		}
+		g.typeRows[name] = nil
 		return nil, "", nil
 	}
 	if err != nil {
-		return nil, "", fmt.Errorf("catalog read type %s: %w", name, err)
+		return nil, "", fmt.Errorf("read type %s: %w", name, err)
 	}
+	if g.typeRows == nil {
+		g.typeRows = map[string]*typeRow{}
+	}
+	g.typeRows[name] = &typeRow{definition: definition, dataSource: dataSource}
+	g.touch(dataSource)
 	return parseStoredDefinition(name, definition), dataSource, nil
 }
 

--- a/pkg/catalog/store/reconstruct.go
+++ b/pkg/catalog/store/reconstruct.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
 	"github.com/hugr-lab/query-engine/pkg/catalog/types"
@@ -187,9 +188,15 @@ func (g *genContext) readType(ctx context.Context, name string) (*ast.Definition
 }
 
 // parseStoredDefinition parses one stored SDL definition (catalog.types rows).
+// A parse failure means a corrupt stored row (writes are validated) — logged,
+// classified as absent.
 func parseStoredDefinition(name, definition string) *ast.Definition {
 	doc, err := parser.ParseSchema(&ast.Source{Name: "catalog:" + name, Input: definition})
 	if err != nil || len(doc.Definitions) == 0 {
+		if err != nil {
+			slog.Warn("catalog store: stored definition does not parse",
+				"type", name, "error", err)
+		}
 		return nil
 	}
 	return doc.Definitions[0]

--- a/pkg/catalog/store/reconstruct_function.go
+++ b/pkg/catalog/store/reconstruct_function.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -13,12 +14,12 @@ import (
 // root. Directives come from the function pair table (pairs_function.go),
 // arguments from emitFunctionArgs (@arg_default / @deprecated re-attached);
 // @catalog(name, engine) is attached by the root rules (gen_roots.go).
-func reconstructFunction(ctx context.Context, s *Store, module, name string) *ast.FieldDefinition {
-	row, ok := s.readFunction(ctx, module, name)
-	if !ok {
-		return nil
+func reconstructFunction(ctx context.Context, g *genContext, module, name string) (*ast.FieldDefinition, error) {
+	row, err := g.readFunction(ctx, module, name)
+	if err != nil || row == nil {
+		return nil, err
 	}
-	return functionField(row)
+	return functionField(row), nil
 }
 
 // functionField builds the root-field definition from a function row.
@@ -33,11 +34,16 @@ func functionField(row *function) *ast.FieldDefinition {
 	}
 }
 
-func (s *Store) readFunction(ctx context.Context, module, name string) (*function, bool) {
-	conn, err := s.pool.Conn(ctx)
+// readFunction reads one function row by its (module, name) primary key;
+// absent = (nil, nil).
+func (g *genContext) readFunction(ctx context.Context, module, name string) (*function, error) {
+	key := pkKey(module, name)
+	if row, ok := g.function[key]; ok {
+		return row, nil
+	}
+	conn, err := g.s.pool.Conn(ctx)
 	if err != nil {
-		readErr("function", err)
-		return nil, false
+		return nil, fmt.Errorf("read function %s.%s: %w", module, name, err)
 	}
 	defer conn.Close()
 	row, err := scanFunction(conn.QueryRow(ctx, `SELECT f.module, f.name, f.kind, f.data_source, f.returns, f.is_table,
@@ -46,11 +52,20 @@ func (s *Store) readFunction(ctx context.Context, module, name string) (*functio
 		WHERE f.module = `+lit(module)+` AND f.name = `+lit(name)).Scan)
 	if err != nil {
 		if err != sql.ErrNoRows {
-			readErr("function", err)
+			return nil, fmt.Errorf("read function %s.%s: %w", module, name, err)
 		}
-		return nil, false
+		if g.function == nil {
+			g.function = map[string]*function{}
+		}
+		g.function[key] = nil
+		return nil, nil
 	}
-	return row, true
+	if g.function == nil {
+		g.function = map[string]*function{}
+	}
+	g.function[key] = row
+	g.touch(row.DataSource)
+	return row, nil
 }
 
 // scanFunction fills a function row from the canonical column list (module,

--- a/pkg/catalog/store/reconstruct_object.go
+++ b/pkg/catalog/store/reconstruct_object.go
@@ -116,7 +116,13 @@ func reconstructDataObject(ctx context.Context, g *genContext, name string) (*as
 	for _, f := range t.fields {
 		fd := reconstructField(f)
 		if f.DependencyDataSource != "" {
-			// Extension-source fields carry @dependency instead of @catalog.
+			// Extension-source fields carry @dependency; VIRTUAL ones
+			// additionally carry @catalog of the source their data comes from
+			// — resolved into the field's data_source at WRITE time
+			// (resolveVirtualAttribution), read back verbatim here.
+			if isVirtualStoreField(f) {
+				fd.Directives = append(fd.Directives, catalogDirective(f.DataSource, t.srcs[f.DataSource].Engine))
+			}
 			fd.Directives = append(fd.Directives,
 				directive(base.DependencyDirectiveName, strArg(base.ArgName, f.DependencyDataSource)))
 		} else if f.DataSource != row.DataSource || isVirtualStoreField(f) {
@@ -261,12 +267,44 @@ func referencesDirective(r *relation, targetDesc, sourceDesc string) *ast.Direct
 	)
 }
 
+// dependencyDirective is the @dependency(name:) marker dependency tracking
+// reads: stamped on extension-contributed fields and on every GENERATED
+// member of an extension-owned object.
+func dependencyDirective(name string) *ast.Directive {
+	return directive(base.DependencyDirectiveName, strArg(base.ArgName, name))
+}
+
+// joinMachineryTarget resolves whether a declared @join field gets its
+// generated surface (subquery args, aggregation twins, aggregation members).
+// EXTENSION-contributed joins (the only legal cross-source form — the
+// validator rejects @join to a foreign object in a regular source) get the
+// machinery whenever the target is visible; a same-source declared join
+// additionally requires the attribution match (a legacy cross-source row
+// reads as a bare field). The lookup runs through the memoized session
+// readers, so the target's source lands in the provenance set either way — a
+// target flag flip evicts the cached definition.
+func (g *genContext) joinMachineryTarget(ctx context.Context, f *field) (string, bool, error) {
+	target := parseFieldType(f.FieldType).Name()
+	row, err := g.readDataObject(ctx, target)
+	if err != nil {
+		return "", false, err
+	}
+	if row == nil {
+		return target, false, nil
+	}
+	if f.DependencyDataSource == "" && row.DataSource != f.DataSource {
+		return target, false, nil
+	}
+	return target, true, nil
+}
+
 // activeSource is the per-source meta the generation layer branches on
 // (activeSources / activeEngines read it for ACTIVE sources only).
 type activeSource struct {
-	Engine   string
-	ReadOnly bool
-	AsModule bool
+	Engine      string
+	ReadOnly    bool
+	AsModule    bool
+	IsExtension bool
 }
 
 // activeSources reads the active-source meta map, memoized per session (the
@@ -282,7 +320,7 @@ func (g *genContext) activeSources(ctx context.Context) (map[string]activeSource
 		return nil, fmt.Errorf("read source meta: %w", err)
 	}
 	defer conn.Close()
-	rows, err := conn.Query(ctx, `SELECT data_source, engine, read_only, as_module FROM core.catalog.data_source_meta
+	rows, err := conn.Query(ctx, `SELECT data_source, engine, read_only, as_module, is_extension FROM core.catalog.data_source_meta
 		WHERE loaded AND NOT disabled AND NOT suspended`)
 	if err != nil {
 		return nil, fmt.Errorf("read source meta: %w", err)
@@ -292,7 +330,7 @@ func (g *genContext) activeSources(ctx context.Context) (map[string]activeSource
 	for rows.Next() {
 		var source string
 		var meta activeSource
-		if err := rows.Scan(&source, &meta.Engine, &meta.ReadOnly, &meta.AsModule); err != nil {
+		if err := rows.Scan(&source, &meta.Engine, &meta.ReadOnly, &meta.AsModule, &meta.IsExtension); err != nil {
 			return nil, fmt.Errorf("read source meta: %w", err)
 		}
 		out[source] = meta
@@ -318,7 +356,11 @@ func (g *genContext) activeEngines(ctx context.Context) (map[string]string, erro
 
 // --- catalog.* readers (fill the shared entity models) ---
 
-// readDataObject reads one data-object row; absent = (nil, nil).
+// readDataObject reads one data-object row; absent = (nil, nil). An object
+// whose declared @dependency sources (cross-source views, requirements: the
+// validator enforces the declaration) are not ALL active reads as absent —
+// the dependency sources are still recorded as provenance, so a flag flip on
+// a dependency evicts every cached definition that consulted this object.
 func (g *genContext) readDataObject(ctx context.Context, name string) (*dataObject, error) {
 	if row, ok := g.objects[name]; ok {
 		return row, nil
@@ -349,11 +391,25 @@ func (g *genContext) readDataObject(ctx context.Context, name string) (*dataObje
 	if props.Valid {
 		_ = json.Unmarshal([]byte(props.String), r.Properties)
 	}
+	g.touch(r.DataSource)
 	if g.objects == nil {
 		g.objects = map[string]*dataObject{}
 	}
+	if len(r.Properties.Dependencies) > 0 {
+		g.touch(r.Properties.Dependencies...)
+		srcs, err := g.activeSources(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, dep := range r.Properties.Dependencies {
+			if _, ok := srcs[dep]; !ok {
+				// An unregistered dependency counts as inactive too.
+				g.objects[name] = nil
+				return nil, nil
+			}
+		}
+	}
 	g.objects[name] = &r
-	g.touch(r.DataSource)
 	return &r, nil
 }
 
@@ -376,6 +432,7 @@ func (g *genContext) readFields(ctx context.Context, typeName string) ([]*field,
 	}
 	defer rows.Close()
 	var out []*field
+	hasDependencies := false
 	for rows.Next() {
 		f := field{TypeName: typeName, Properties: &fieldProperties{}}
 		var props, args, dependency, deprecated, desc sql.NullString
@@ -391,11 +448,34 @@ func (g *genContext) readFields(ctx context.Context, typeName string) ([]*field,
 		if args.Valid {
 			_ = json.Unmarshal([]byte(args.String), &f.Args)
 		}
+		// Provenance is recorded for EVERY row — including fields hidden by
+		// the dependency gate below, so a dependency flag flip evicts the
+		// cached definitions built without them.
 		g.touch(f.DataSource, f.DependencyDataSource)
+		hasDependencies = hasDependencies || f.DependencyDataSource != ""
 		out = append(out, &f)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("read fields of %s: %w", typeName, err)
+	}
+	// A field whose dependency source (@dependency — the source its data
+	// comes from) is inactive is hidden, mirroring the compiled provider's
+	// read-time gate on dependency_catalog (db/read.go).
+	if hasDependencies {
+		srcs, err := g.activeSources(ctx)
+		if err != nil {
+			return nil, err
+		}
+		visible := out[:0]
+		for _, f := range out {
+			if f.DependencyDataSource != "" {
+				if _, ok := srcs[f.DependencyDataSource]; !ok {
+					continue
+				}
+			}
+			visible = append(visible, f)
+		}
+		out = visible
 	}
 	if g.fieldRows == nil {
 		g.fieldRows = map[string][]*field{}

--- a/pkg/catalog/store/reconstruct_object.go
+++ b/pkg/catalog/store/reconstruct_object.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 
 	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -23,13 +24,15 @@ import (
 //     twins, extra fields, shared members — gen_fields.go).
 //
 // All reads are activity-gated.
-func reconstructDataObject(ctx context.Context, s *Store, name string) *ast.Definition {
-	row, ok := s.readDataObject(ctx, name)
-	if !ok {
-		return nil
+func reconstructDataObject(ctx context.Context, g *genContext, name string) (*ast.Definition, error) {
+	row, err := g.readDataObject(ctx, name)
+	if err != nil || row == nil {
+		return nil, err
 	}
-	g := s.genCtx()
-	t := g.objectTraits(ctx, row)
+	t, err := g.objectTraits(ctx, row)
+	if err != nil {
+		return nil, err
+	}
 	def := &ast.Definition{
 		Kind:        ast.Object,
 		Name:        row.Name,
@@ -40,23 +43,38 @@ func reconstructDataObject(ctx context.Context, s *Store, name string) *ast.Defi
 	def.Directives = append(def.Directives, catalogDirective(row.DataSource, t.src.Engine))
 
 	// Enriched @references: own physical legs, then the m2m projections.
-	fwd := s.relationsBySource(ctx, name)
+	fwd, err := g.relationsBySource(ctx, name)
+	if err != nil {
+		return nil, err
+	}
 	for _, r := range fwd {
 		targetDesc := ""
-		if target, ok := s.readDataObject(ctx, r.Destination); ok {
+		if target, err := g.readDataObject(ctx, r.Destination); err != nil {
+			return nil, err
+		} else if target != nil {
 			targetDesc = target.Description
 		}
 		def.Directives = append(def.Directives, referencesDirective(r, targetDesc, row.Description))
 	}
-	for _, leg := range s.relationsByDestination(ctx, name) {
+	legs, err := g.relationsByDestination(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	for _, leg := range legs {
 		if !leg.m2mJunction {
 			continue
 		}
 		junctionDesc := ""
-		if junction, ok := s.readDataObject(ctx, leg.Source); ok {
+		if junction, err := g.readDataObject(ctx, leg.Source); err != nil {
+			return nil, err
+		} else if junction != nil {
 			junctionDesc = junction.Description
 		}
-		for _, co := range s.relationsBySource(ctx, leg.Source) {
+		cos, err := g.relationsBySource(ctx, leg.Source)
+		if err != nil {
+			return nil, err
+		}
+		for _, co := range cos {
 			if co.Name == leg.Name {
 				continue
 			}
@@ -67,7 +85,11 @@ func reconstructDataObject(ctx context.Context, s *Store, name string) *ast.Defi
 	// Derived-type markers + the queryShapes @query/@mutation set.
 	def.Directives = append(def.Directives,
 		directive(base.FilterInputDirectiveName, strArg(base.ArgName, row.Name+filterSuffix)))
-	if t.needsListFilter(len(fwd) > 0, s.isM2MEndpoint(ctx, name)) {
+	m2mEndpoint, err := g.isM2MEndpoint(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if t.needsListFilter(len(fwd) > 0, m2mEndpoint) {
 		def.Directives = append(def.Directives,
 			directive(base.FilterListInputDirectiveName, strArg(base.ArgName, row.Name+listFilterSuffix)))
 	}
@@ -82,7 +104,11 @@ func reconstructDataObject(ctx context.Context, s *Store, name string) *ast.Defi
 	// old compiler's module-function precedence, replicated by the assembler
 	// (replaceOrAddQueryDirective); the LAST function in (module, name) order
 	// wins.
-	if fn := s.lastListReturningModuleFunction(ctx, row.Name); fn != "" {
+	fn, err := g.lastListReturningModuleFunction(ctx, row.Name)
+	if err != nil {
+		return nil, err
+	}
+	if fn != "" {
 		replaceQueryMarkerName(def, "AGGREGATE", fn+"_aggregation")
 		replaceQueryMarkerName(def, "AGGREGATE_BUCKET", fn+"_bucket_aggregation")
 	}
@@ -109,25 +135,27 @@ func reconstructDataObject(ctx context.Context, s *Store, name string) *ast.Defi
 	}
 
 	for i := range fieldRules {
-		fieldRules[i].apply(ctx, g, t, def)
+		if err := fieldRules[i].apply(ctx, g, t, def); err != nil {
+			return nil, err
+		}
 	}
-	return def
+	return def, nil
 }
 
 // lastListReturningModuleFunction returns the name of the LAST (module, name)
 // ordered module function (kind=function, module != ”) returning a list of
 // the object — the one whose aggregation names win the def markers.
-func (s *Store) lastListReturningModuleFunction(ctx context.Context, typeName string) string {
+func (g *genContext) lastListReturningModuleFunction(ctx context.Context, typeName string) (string, error) {
 	variants := lit("["+typeName+"]") + `, ` + lit("["+typeName+"!]") + `, ` +
 		lit("["+typeName+"]!") + `, ` + lit("["+typeName+"!]!")
-	names := s.queryNames(ctx, `SELECT f.name FROM core.catalog.functions f`+
+	names, err := g.queryNames(ctx, `SELECT f.name FROM core.catalog.functions f`+
 		activeMeta("m", "f.data_source")+`
 		WHERE f.kind = 'function' AND f.module <> '' AND f.returns IN (`+variants+`)
 		ORDER BY f.module, f.name`)
-	if len(names) == 0 {
-		return ""
+	if err != nil || len(names) == 0 {
+		return "", err
 	}
-	return names[len(names)-1]
+	return names[len(names)-1], nil
 }
 
 func replaceQueryMarkerName(def *ast.Definition, queryType, name string) {
@@ -154,13 +182,17 @@ func (t *objectTraits) needsListFilter(hasBackProjections, isM2MEndpoint bool) b
 }
 
 // isM2MEndpoint reports whether some is_m2m junction leg points at the object.
-func (s *Store) isM2MEndpoint(ctx context.Context, name string) bool {
-	for _, leg := range s.relationsByDestination(ctx, name) {
+func (g *genContext) isM2MEndpoint(ctx context.Context, name string) (bool, error) {
+	legs, err := g.relationsByDestination(ctx, name)
+	if err != nil {
+		return false, err
+	}
+	for _, leg := range legs {
 		if leg.m2mJunction {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // m2mReferencesProjection is the endpoint-oriented @references the compiler
@@ -237,18 +269,23 @@ type activeSource struct {
 	AsModule bool
 }
 
-func (s *Store) activeSources(ctx context.Context) map[string]activeSource {
-	conn, err := s.pool.Conn(ctx)
+// activeSources reads the active-source meta map, memoized per session (the
+// single hottest lookup — the generation rules consult it repeatedly). The
+// meta itself records no touched source: a definition's dependency on a
+// source comes from the ROWS it reads, not from the meta consult.
+func (g *genContext) activeSources(ctx context.Context) (map[string]activeSource, error) {
+	if g.haveSources {
+		return g.sources, nil
+	}
+	conn, err := g.s.pool.Conn(ctx)
 	if err != nil {
-		readErr("sources", err)
-		return nil
+		return nil, fmt.Errorf("read source meta: %w", err)
 	}
 	defer conn.Close()
 	rows, err := conn.Query(ctx, `SELECT data_source, engine, read_only, as_module FROM core.catalog.data_source_meta
 		WHERE loaded AND NOT disabled AND NOT suspended`)
 	if err != nil {
-		readErr("sources", err)
-		return nil
+		return nil, fmt.Errorf("read source meta: %w", err)
 	}
 	defer rows.Close()
 	out := map[string]activeSource{}
@@ -256,34 +293,39 @@ func (s *Store) activeSources(ctx context.Context) map[string]activeSource {
 		var source string
 		var meta activeSource
 		if err := rows.Scan(&source, &meta.Engine, &meta.ReadOnly, &meta.AsModule); err != nil {
-			readErr("sources", err)
-			return nil
+			return nil, fmt.Errorf("read source meta: %w", err)
 		}
 		out[source] = meta
 	}
 	if err := rows.Err(); err != nil {
-		readErr("sources", err)
-		return nil
+		return nil, fmt.Errorf("read source meta: %w", err)
 	}
-	return out
+	g.sources, g.haveSources = out, true
+	return out, nil
 }
 
-func (s *Store) activeEngines(ctx context.Context) map[string]string {
-	srcs := s.activeSources(ctx)
+func (g *genContext) activeEngines(ctx context.Context) (map[string]string, error) {
+	srcs, err := g.activeSources(ctx)
+	if err != nil {
+		return nil, err
+	}
 	out := make(map[string]string, len(srcs))
 	for name, meta := range srcs {
 		out[name] = meta.Engine
 	}
-	return out
+	return out, nil
 }
 
 // --- catalog.* readers (fill the shared entity models) ---
 
-func (s *Store) readDataObject(ctx context.Context, name string) (*dataObject, bool) {
-	conn, err := s.pool.Conn(ctx)
+// readDataObject reads one data-object row; absent = (nil, nil).
+func (g *genContext) readDataObject(ctx context.Context, name string) (*dataObject, error) {
+	if row, ok := g.objects[name]; ok {
+		return row, nil
+	}
+	conn, err := g.s.pool.Conn(ctx)
 	if err != nil {
-		readErr("data_object", err)
-		return nil, false
+		return nil, fmt.Errorf("read data object %s: %w", name, err)
 	}
 	defer conn.Close()
 	r := dataObject{Properties: &dataObjectProperties{}}
@@ -295,22 +337,33 @@ func (s *Store) readDataObject(ctx context.Context, name string) (*dataObject, b
 		Scan(&r.Name, &r.OriginalName, &r.DataSource, &r.Module, &r.Kind, &props, &desc)
 	if err != nil {
 		if err != sql.ErrNoRows {
-			readErr("data_object", err)
+			return nil, fmt.Errorf("read data object %s: %w", name, err)
 		}
-		return nil, false
+		if g.objects == nil {
+			g.objects = map[string]*dataObject{}
+		}
+		g.objects[name] = nil
+		return nil, nil
 	}
 	r.Description = desc.String
 	if props.Valid {
 		_ = json.Unmarshal([]byte(props.String), r.Properties)
 	}
-	return &r, true
+	if g.objects == nil {
+		g.objects = map[string]*dataObject{}
+	}
+	g.objects[name] = &r
+	g.touch(r.DataSource)
+	return &r, nil
 }
 
-func (s *Store) readFields(ctx context.Context, typeName string) []*field {
-	conn, err := s.pool.Conn(ctx)
+func (g *genContext) readFields(ctx context.Context, typeName string) ([]*field, error) {
+	if out, ok := g.fieldRows[typeName]; ok {
+		return out, nil
+	}
+	conn, err := g.s.pool.Conn(ctx)
 	if err != nil {
-		readErr("fields", err)
-		return nil
+		return nil, fmt.Errorf("read fields of %s: %w", typeName, err)
 	}
 	defer conn.Close()
 	rows, err := conn.Query(ctx, `SELECT f.name, f.field_type, f.properties::JSON::VARCHAR,
@@ -319,8 +372,7 @@ func (s *Store) readFields(ctx context.Context, typeName string) []*field {
 		FROM core.catalog.fields f`+activeMeta("m", "f.data_source")+`
 		WHERE f.type_name = `+lit(typeName)+` ORDER BY f.ordinal, f.name`)
 	if err != nil {
-		readErr("fields", err)
-		return nil
+		return nil, fmt.Errorf("read fields of %s: %w", typeName, err)
 	}
 	defer rows.Close()
 	var out []*field
@@ -328,8 +380,7 @@ func (s *Store) readFields(ctx context.Context, typeName string) []*field {
 		f := field{TypeName: typeName, Properties: &fieldProperties{}}
 		var props, args, dependency, deprecated, desc sql.NullString
 		if err := rows.Scan(&f.Name, &f.FieldType, &props, &args, &f.DataSource, &dependency, &f.IsPK, &f.Ordinal, &deprecated, &desc); err != nil {
-			readErr("fields", err)
-			return nil
+			return nil, fmt.Errorf("read fields of %s: %w", typeName, err)
 		}
 		f.DependencyDataSource = dependency.String
 		f.DeprecationReason = deprecated.String
@@ -340,11 +391,15 @@ func (s *Store) readFields(ctx context.Context, typeName string) []*field {
 		if args.Valid {
 			_ = json.Unmarshal([]byte(args.String), &f.Args)
 		}
+		g.touch(f.DataSource, f.DependencyDataSource)
 		out = append(out, &f)
 	}
 	if err := rows.Err(); err != nil {
-		readErr("fields", err)
-		return nil
+		return nil, fmt.Errorf("read fields of %s: %w", typeName, err)
 	}
-	return out
+	if g.fieldRows == nil {
+		g.fieldRows = map[string][]*field{}
+	}
+	g.fieldRows[typeName] = out
+	return out, nil
 }

--- a/pkg/catalog/store/reconstruct_test.go
+++ b/pkg/catalog/store/reconstruct_test.go
@@ -157,7 +157,8 @@ func TestReconstructDataObjectBase(t *testing.T) {
 func TestReconstructFunction(t *testing.T) {
 	store, ctx := writtenStore(t)
 
-	fn := reconstructFunction(ctx, store, "sales", "order_status")
+	fn, err := reconstructFunction(ctx, store.genCtx(), "sales", "order_status")
+	require.NoError(t, err)
 	require.NotNil(t, fn)
 	assert.Equal(t, "order_status", fn.Name)
 	assert.Equal(t, "String", fn.Type.String())
@@ -175,8 +176,10 @@ func TestReconstructFunction(t *testing.T) {
 	require.NotNil(t, mode)
 	assert.Equal(t, "unused", dirArg(mode.Directives.ForName("deprecated"), "reason"))
 
-	// Absent function → nil.
-	assert.Nil(t, reconstructFunction(ctx, store, "sales", "no_such_fn"))
+	// Absent function → nil without an error.
+	absent, err := reconstructFunction(ctx, store.genCtx(), "sales", "no_such_fn")
+	require.NoError(t, err)
+	assert.Nil(t, absent)
 }
 
 func dirArg(d *ast.Directive, name string) string {

--- a/pkg/catalog/store/relations.go
+++ b/pkg/catalog/store/relations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 )
 
 // Relation readers. Rows are the PHYSICAL fk legs written by collect (an m2m
@@ -38,39 +39,60 @@ const relationColumns = `r.source, r.name, r.kind, r.destination, r.m2m_object,
 	r.source_field, r.source_field_description, r.destination_field, r.destination_field_description,
 	r.field_declared, r.data_source`
 
-// relationsBySource reads the relations DECLARED BY an object (its fk legs).
-func (s *Store) relationsBySource(ctx context.Context, source string) []*relation {
-	edges := s.readRelations(ctx, `SELECT `+relationColumns+`, false
+// relationsBySource reads the relations DECLARED BY an object (its fk legs),
+// memoized per session.
+func (g *genContext) relationsBySource(ctx context.Context, source string) ([]*relation, error) {
+	if out, ok := g.relSrc[source]; ok {
+		return out, nil
+	}
+	edges, err := g.readRelations(ctx, `SELECT `+relationColumns+`, false
 		FROM core.catalog.relations r`+activeMeta("m", "r.data_source")+`
 		WHERE r.source = `+lit(source)+` ORDER BY r.name`)
+	if err != nil {
+		return nil, fmt.Errorf("read relations of %s: %w", source, err)
+	}
 	out := make([]*relation, 0, len(edges))
 	for _, e := range edges {
 		out = append(out, &e.relation)
 	}
-	return out
+	if g.relSrc == nil {
+		g.relSrc = map[string][]*relation{}
+	}
+	g.relSrc[source] = out
+	return out, nil
 }
 
 // relationsByDestination reads the relations POINTING AT an object, flagging
-// legs whose source is an is_m2m junction.
-func (s *Store) relationsByDestination(ctx context.Context, destination string) []*relationEdge {
-	return s.readRelations(ctx, `SELECT `+relationColumns+`,
+// legs whose source is an is_m2m junction; memoized per session.
+func (g *genContext) relationsByDestination(ctx context.Context, destination string) ([]*relationEdge, error) {
+	if out, ok := g.relDst[destination]; ok {
+		return out, nil
+	}
+	out, err := g.readRelations(ctx, `SELECT `+relationColumns+`,
 		COALESCE(json_extract_string(j.properties::JSON, '$.is_m2m') = 'true', false)
 		FROM core.catalog.relations r`+activeMeta("m", "r.data_source")+`
 		LEFT JOIN core.catalog.data_objects j ON j.name = r.source
 		WHERE r.destination = `+lit(destination)+` ORDER BY r.name`)
+	if err != nil {
+		return nil, fmt.Errorf("read relations at %s: %w", destination, err)
+	}
+	if g.relDst == nil {
+		g.relDst = map[string][]*relationEdge{}
+	}
+	g.relDst[destination] = out
+	return out, nil
 }
 
-func (s *Store) readRelations(ctx context.Context, query string) []*relationEdge {
-	conn, err := s.pool.Conn(ctx)
+// readRelations runs one relation query.
+func (g *genContext) readRelations(ctx context.Context, query string) ([]*relationEdge, error) {
+	conn, err := g.s.pool.Conn(ctx)
 	if err != nil {
-		readErr("relations", err)
-		return nil
+		return nil, err
 	}
 	defer conn.Close()
 	rows, err := conn.Query(ctx, query)
 	if err != nil {
-		readErr("relations", err)
-		return nil
+		return nil, err
 	}
 	defer rows.Close()
 	var out []*relationEdge
@@ -80,8 +102,7 @@ func (s *Store) readRelations(ctx context.Context, query string) []*relationEdge
 		if err := rows.Scan(&e.Source, &e.Name, &e.Kind, &e.Destination, &m2mObject,
 			&srcKeys, &dstKeys, &srcField, &srcDesc, &dstField, &dstDesc,
 			&e.FieldDeclared, &e.DataSource, &e.m2mJunction); err != nil {
-			readErr("relations", err)
-			return nil
+			return nil, err
 		}
 		e.M2MObject = m2mObject.String
 		e.SourceField = srcField.String
@@ -94,11 +115,11 @@ func (s *Store) readRelations(ctx context.Context, query string) []*relationEdge
 		if dstKeys.Valid {
 			_ = json.Unmarshal([]byte(dstKeys.String), &e.DestinationKeys)
 		}
+		g.touch(e.DataSource)
 		out = append(out, &e)
 	}
 	if err := rows.Err(); err != nil {
-		readErr("relations", err)
-		return nil
+		return nil, err
 	}
-	return out
+	return out, nil
 }

--- a/pkg/catalog/store/store.go
+++ b/pkg/catalog/store/store.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 
 	"github.com/hugr-lab/query-engine/pkg/catalog/static"
 	"github.com/hugr-lab/query-engine/pkg/data-sources/sources"
 	"github.com/hugr-lab/query-engine/pkg/db"
+	"golang.org/x/sync/singleflight"
 )
 
-// readErr logs a read-side DB failure. The catalog.Provider read surface has
-// no error channel (nil covers both "absent" and "failed"), so readers log
-// here and return EMPTY — never a partial result that would silently truncate
-// a generated type. Distinguishable propagation comes with the read cache /
-// CanServe step.
-func readErr(op string, err error) {
+// logReadErr reports a read failure at a Provider surface (ForName, the
+// logical model, NameExists). The read interfaces have no error channel, so the
+// surface logs the propagated error here and serves EMPTY; the failed result
+// is never cached (absence is a nil WITHOUT an error).
+func logReadErr(op string, err error) {
 	slog.Error("catalog store: read failed", "op", op, "error", err)
 }
 
@@ -36,6 +37,9 @@ type Config struct {
 	// IsReadonly rejects all writes (cluster workers read the already-populated
 	// catalog schema).
 	IsReadonly bool
+	// Cache configures the read-side definition cache; the zero value takes
+	// the defaults (set Disabled to switch it off).
+	Cache CacheConfig
 }
 
 // Store is the entity-storage catalog provider. It holds the in-memory system
@@ -56,6 +60,13 @@ type Store struct {
 	// base directives) assembled at startup. Source entities are stored in
 	// catalog.*; system types live only here.
 	static *static.Provider
+
+	// cache holds compiled definitions by name (nil = disabled); gen is the
+	// invalidation clock its installs check against; sf collapses concurrent
+	// resolutions of the same name.
+	cache *defCache
+	gen   atomic.Uint64
+	sf    singleflight.Group
 }
 
 // New assembles the system layer and returns a Store bound to the CoreDB pool.
@@ -72,7 +83,44 @@ func New(_ context.Context, pool *db.Pool, cfg Config, embedder Embedder) (*Stor
 		isReadonly: cfg.IsReadonly,
 		embedder:   embedder,
 		static:     sp,
+		cache:      newDefCache(cfg.Cache),
 	}, nil
+}
+
+// invalidateSource drops every cached artifact a write to the source could
+// have changed: the definition cache's source and allSources buckets, plus
+// the affected object FAMILIES (an object plus its derived types — the
+// write-side closure for cross-source absence dependencies: relations
+// pointing at foreign objects and module functions returning lists of them
+// influence definitions whose builds saw no row of this source). The
+// invalidation clock is bumped FIRST so in-flight resolutions discard their
+// results.
+func (s *Store) invalidateSource(source string, affected map[string]struct{}) {
+	s.gen.Add(1)
+	if len(affected) == 0 {
+		s.cache.invalidate(source, nil)
+		return
+	}
+	s.cache.invalidate(source, func(name string) bool {
+		if _, ok := affected[name]; ok {
+			return true
+		}
+		for i := range derivedRules {
+			if base, ok := derivedRules[i].match(name); ok {
+				if _, hit := affected[base]; hit {
+					return true
+				}
+			}
+		}
+		return false
+	})
+}
+
+// invalidateAll is the conservative fallback when the affected-object set
+// could not be computed (a read failure during the write path).
+func (s *Store) invalidateAll() {
+	s.gen.Add(1)
+	s.cache.invalidateAll()
 }
 
 // System returns the in-memory system-type layer. The writer skips

--- a/pkg/catalog/store/writer.go
+++ b/pkg/catalog/store/writer.go
@@ -29,7 +29,9 @@ var litEngine = engines.NewDuckDB()
 // content hash — an unchanged version makes writeSource a no-op. Engine is the
 // source's engine type string (re-attached as @catalog(name, engine) on read);
 // ReadOnly is the per-source option gating mutation generation. Prefix and
-// AsModule are the compile options that shape names at read time.
+// AsModule are the compile options that shape names at read time. IsExtension
+// marks an extension source — generated members of its objects carry
+// @dependency(name: <source>).
 type SourceState struct {
 	Name         string
 	Version      string
@@ -38,12 +40,20 @@ type SourceState struct {
 	ReadOnly     bool
 	Prefix       string
 	AsModule     bool
+	IsExtension  bool
 	Loaded       bool
 	Disabled     bool
 	Suspended    bool
 }
 
-func (s SourceState) storedVersion() string { return writerFormatVersion + "|" + s.Version }
+// storedVersion mixes the format version, the caller's content hash AND the
+// compile options into the stored version — a meta-only change (engine string,
+// read_only, prefix, as_module, is_extension) must rewrite and invalidate
+// too, not slip through the content gate.
+func (s SourceState) storedVersion() string {
+	return fmt.Sprintf("%s|%s|%s|%t|%s|%t|%t",
+		writerFormatVersion, s.Version, s.Engine, s.ReadOnly, s.Prefix, s.AsModule, s.IsExtension)
+}
 
 // writeSource persists one source's collected rows into the catalog namespace
 // (the Add / Reload primitive). It is version-gated: if the stored version
@@ -79,13 +89,18 @@ func (s *Store) writeSource(ctx context.Context, d *desired, state SourceState) 
 	}
 	defer conn.Close()
 
+	// Virtual fields are attributed to the source their DATA comes from,
+	// resolved by the declared reference at WRITE time — the read side then
+	// takes @catalog straight from the field row and the standard activity
+	// gate hides the field with that source.
+	if err := resolveVirtualAttribution(txCtx, conn, d); err != nil {
+		return false, fmt.Errorf("catalog write %s: %w", state.Name, err)
+	}
+
 	// The cross-source invalidation closure needs the OLD rows (about to be
 	// deleted) and the incoming ones; a failure here never fails the write —
 	// the cache then invalidates wholesale.
-	affected, affectedErr := affectedByStored(txCtx, conn, state.Name)
-	if affectedErr == nil {
-		addAffectedDesired(affected, d)
-	}
+	affected, affectedErr := affectedObjects(txCtx, conn, state.Name, d)
 
 	if err := deleteSourceRows(txCtx, conn, state.Name); err != nil {
 		return false, err
@@ -105,6 +120,9 @@ func (s *Store) writeSource(ctx context.Context, d *desired, state SourceState) 
 
 	committed = true
 	if err := s.pool.Commit(txCtx); err != nil {
+		// The commit may have succeeded server-side despite the client error —
+		// invalidate conservatively.
+		s.invalidateAll()
 		return false, fmt.Errorf("catalog write %s commit: %w", state.Name, err)
 	}
 	if affectedErr != nil {
@@ -115,66 +133,272 @@ func (s *Store) writeSource(ctx context.Context, d *desired, state SourceState) 
 	return true, nil
 }
 
-// affectedByStored collects the data-object names whose COMPILED shape can
-// depend on the source's stored relations (both endpoints gain/lose nav
-// fields, markers and derived-type members) and module functions returning
-// object lists (they rename the object's aggregation markers). These are the
-// absence dependencies the read-side source index cannot see — a definition
-// built BEFORE such rows existed recorded no dependency on this source.
-func affectedByStored(ctx context.Context, conn *db.Connection, dataSource string) (map[string]struct{}, error) {
+// resolveVirtualAttribution stamps each virtual field row with the data
+// source its DATA comes from, resolved through the declared reference: the
+// referenced FUNCTION's source (by module, name) for @function_call and
+// @table_function_call_join, the referenced OBJECT's source for @join. The
+// incoming batch resolves first, then the stored catalog. An unresolvable
+// reference keeps the declared attribution — the engine writes an extension
+// AFTER its dependencies, and a reload re-resolves.
+func resolveVirtualAttribution(ctx context.Context, conn *db.Connection, d *desired) error {
+	lookupFunc := func(module, name string) (string, error) {
+		if fn, ok := d.functions[pkKey(module, name)]; ok {
+			return fn.DataSource, nil
+		}
+		var ds string
+		err := conn.QueryRow(ctx, `SELECT data_source FROM core.catalog.functions
+			WHERE module = `+lit(module)+` AND name = `+lit(name)).Scan(&ds)
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		if err != nil {
+			return "", err
+		}
+		return ds, nil
+	}
+	lookupObject := func(name string) (string, error) {
+		if row, ok := d.dataObjects[name]; ok {
+			return row.DataSource, nil
+		}
+		var ds string
+		err := conn.QueryRow(ctx, `SELECT data_source FROM core.catalog.data_objects
+			WHERE name = `+lit(name)).Scan(&ds)
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		if err != nil {
+			return "", err
+		}
+		return ds, nil
+	}
+	for _, f := range d.fields {
+		p := f.Properties
+		if p == nil {
+			continue
+		}
+		var src string
+		var err error
+		switch {
+		case p.Join != nil:
+			src, err = lookupObject(p.Join.ReferencesName)
+		case p.FunctionCall != nil:
+			src, err = lookupFunc(p.FunctionCall.Function.Module, p.FunctionCall.Function.Name)
+		case p.TableFunctionCallJoin != nil:
+			src, err = lookupFunc(p.TableFunctionCallJoin.Function.Module, p.TableFunctionCallJoin.Function.Name)
+		default:
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if src != "" {
+			f.DataSource = src
+		}
+	}
+	return nil
+}
+
+// affectedObjects collects the names whose COMPILED shape can depend on the
+// source's rows — the absence dependencies the read-side provenance index
+// cannot see (a definition built BEFORE such rows existed recorded no
+// dependency on this source). Both the STORED rows (about to be deleted /
+// flag-flipped) and the incoming desired rows (nil for delete / flags)
+// contribute:
+//   - the source's relations: both endpoints gain/lose nav fields, markers
+//     and derived-type members;
+//   - relations of ANY source whose endpoint is one of this source's objects
+//     (extension-declared legs live under the DECLARING source);
+//   - the source's module functions returning object lists (they rename the
+//     target's aggregation markers);
+//   - the objects the source's fields extend (cross-source `extend type`);
+//   - fields of ANY source TYPED with one of this source's object/type names
+//     (@join targets — the field type IS the target — and structural member
+//     references);
+//   - fields of ANY source whose @function_call / @table_function_call_join
+//     binding references one of this source's functions (module, name) — the
+//     effective @catalog of such fields is computed from the function's
+//     source (virtualFieldSource).
+//
+// All lookups read DECLARED rows (types, references_name, function bindings) —
+// a reverse index computed at write time, no heuristics.
+func affectedObjects(ctx context.Context, conn *db.Connection, dataSource string, d *desired) (map[string]struct{}, error) {
 	out := map[string]struct{}{}
 	ds := lit(dataSource)
-	rows, err := conn.Query(ctx, `SELECT r.source, r.destination FROM core.catalog.relations r
-		WHERE r.data_source = `+ds)
-	if err != nil {
-		return nil, err
-	}
-	for rows.Next() {
-		var source, destination string
-		if err := rows.Scan(&source, &destination); err != nil {
-			rows.Close()
-			return nil, err
+
+	scanInto := func(query string, cols int) error {
+		rows, err := conn.Query(ctx, query)
+		if err != nil {
+			return err
 		}
-		out[source] = struct{}{}
-		out[destination] = struct{}{}
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return nil, err
+		defer rows.Close()
+		for rows.Next() {
+			a, b := "", ""
+			dest := []any{&a}
+			if cols == 2 {
+				dest = append(dest, &b)
+			}
+			if err := rows.Scan(dest...); err != nil {
+				return err
+			}
+			out[a] = struct{}{}
+			if cols == 2 {
+				out[b] = struct{}{}
+			}
+		}
+		return rows.Err()
 	}
 
-	rows, err = conn.Query(ctx, `SELECT f.returns FROM core.catalog.functions f
+	// Rows OWNED by the source.
+	if err := scanInto(`SELECT r.source, r.destination FROM core.catalog.relations r
+		WHERE r.data_source = `+ds, 2); err != nil {
+		return nil, err
+	}
+	if err := scanInto(`SELECT DISTINCT f.type_name FROM core.catalog.fields f
+		WHERE f.data_source = `+ds+` OR f.dependency_data_source = `+ds, 1); err != nil {
+		return nil, err
+	}
+	rows, err := conn.Query(ctx, `SELECT f.returns FROM core.catalog.functions f
 		WHERE f.data_source = `+ds+` AND f.kind = 'function' AND f.module <> ''`)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 	for rows.Next() {
 		var returns string
 		if err := rows.Scan(&returns); err != nil {
+			rows.Close()
 			return nil, err
 		}
 		if target, isList := listReturnTarget(&function{Returns: returns}); isList {
 			out[target] = struct{}{}
 		}
 	}
-	return out, rows.Err()
-}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
-// addAffectedDesired folds the incoming desired rows into the affected set.
-func addAffectedDesired(out map[string]struct{}, d *desired) {
-	for _, r := range d.relations {
-		out[r.Source] = struct{}{}
-		out[r.Destination] = struct{}{}
-	}
-	for _, fn := range d.functions {
-		if fn.Kind != "function" || fn.Module == "" {
-			continue
+	// The source's entity NAMES (old stored + incoming) drive the reverse
+	// lookups: rows of OTHER sources referencing them.
+	names := map[string]struct{}{}
+	if err := func() error {
+		rows, err := conn.Query(ctx, `SELECT o.name FROM core.catalog.data_objects o WHERE o.data_source = `+ds+`
+			UNION SELECT t.name FROM core.catalog.types t WHERE t.data_source = `+ds)
+		if err != nil {
+			return err
 		}
-		if target, isList := listReturnTarget(fn); isList {
-			out[target] = struct{}{}
+		defer rows.Close()
+		for rows.Next() {
+			var name string
+			if err := rows.Scan(&name); err != nil {
+				return err
+			}
+			names[name] = struct{}{}
+		}
+		return rows.Err()
+	}(); err != nil {
+		return nil, err
+	}
+	if d != nil {
+		for name := range d.dataObjects {
+			names[name] = struct{}{}
+		}
+		for name := range d.types {
+			names[name] = struct{}{}
+		}
+		for _, r := range d.relations {
+			out[r.Source] = struct{}{}
+			out[r.Destination] = struct{}{}
+		}
+		for _, f := range d.fields {
+			out[f.TypeName] = struct{}{}
+		}
+		for _, fn := range d.functions {
+			if fn.Kind != "function" || fn.Module == "" {
+				continue
+			}
+			if target, isList := listReturnTarget(fn); isList {
+				out[target] = struct{}{}
+			}
 		}
 	}
+	if len(names) > 0 {
+		list := make([]string, 0, len(names))
+		for _, name := range sortedKeys(names) {
+			list = append(list, lit(name))
+		}
+		in := strings.Join(list, ", ")
+		if err := scanInto(`SELECT r.source, r.destination FROM core.catalog.relations r
+			WHERE r.source IN (`+in+`) OR r.destination IN (`+in+`)`, 2); err != nil {
+			return nil, err
+		}
+		// trim strips the list/non-null wrapping ([X!]! → X) — the field TYPE
+		// is the declared reference target for @join and structural members.
+		if err := scanInto(`SELECT DISTINCT f.type_name FROM core.catalog.fields f
+			WHERE trim(f.field_type, '[]!') IN (`+in+`)`, 1); err != nil {
+			return nil, err
+		}
+	}
+
+	// The source's FUNCTIONS (old stored + incoming) drive the function-call
+	// reverse lookup: @function_call / @table_function_call_join fields are
+	// typed with the function's RETURN, so the type match above cannot see
+	// them — match the declared (module, name) binding instead.
+	functions := map[string]struct{}{}
+	if err := func() error {
+		rows, err := conn.Query(ctx, `SELECT f.module, f.name FROM core.catalog.functions f
+			WHERE f.data_source = `+ds)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var module, name string
+			if err := rows.Scan(&module, &name); err != nil {
+				return err
+			}
+			functions[pkKey(module, name)] = struct{}{}
+		}
+		return rows.Err()
+	}(); err != nil {
+		return nil, err
+	}
+	if d != nil {
+		for key := range d.functions {
+			functions[key] = struct{}{}
+		}
+	}
+	if len(functions) > 0 {
+		rows, err := conn.Query(ctx, `SELECT f.type_name,
+			json_extract_string(f.properties::JSON, '$.function_call.function.module'),
+			json_extract_string(f.properties::JSON, '$.function_call.function.name'),
+			json_extract_string(f.properties::JSON, '$.table_function_call_join.function.module'),
+			json_extract_string(f.properties::JSON, '$.table_function_call_join.function.name')
+			FROM core.catalog.fields f
+			WHERE json_extract(f.properties::JSON, '$.function_call') IS NOT NULL
+			OR json_extract(f.properties::JSON, '$.table_function_call_join') IS NOT NULL`)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var typeName string
+			var fcModule, fcName, tfModule, tfName sql.NullString
+			if err := rows.Scan(&typeName, &fcModule, &fcName, &tfModule, &tfName); err != nil {
+				return nil, err
+			}
+			if _, ok := functions[pkKey(fcModule.String, fcName.String)]; ok {
+				out[typeName] = struct{}{}
+				continue
+			}
+			if _, ok := functions[pkKey(tfModule.String, tfName.String)]; ok {
+				out[typeName] = struct{}{}
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
 }
 
 // deleteSource removes a source's rows, meta and dependencies (the unregister
@@ -197,7 +421,7 @@ func (s *Store) deleteSource(ctx context.Context, dataSource string) error {
 	}
 	defer conn.Close()
 
-	affected, affectedErr := affectedByStored(txCtx, conn, dataSource)
+	affected, affectedErr := affectedObjects(txCtx, conn, dataSource, nil)
 
 	if err := deleteSourceRows(txCtx, conn, dataSource); err != nil {
 		return err
@@ -216,6 +440,9 @@ func (s *Store) deleteSource(ctx context.Context, dataSource string) error {
 	}
 	committed = true
 	if err := s.pool.Commit(txCtx); err != nil {
+		// The commit may have succeeded server-side despite the client error —
+		// invalidate conservatively.
+		s.invalidateAll()
 		return fmt.Errorf("catalog delete %s: %w", dataSource, err)
 	}
 	if affectedErr != nil {
@@ -237,7 +464,7 @@ func (s *Store) setFlags(ctx context.Context, dataSource string, loaded, disable
 	defer conn.Close()
 	// Flag flips change VISIBILITY, not rows — the affected closure reads the
 	// (surviving) rows either before hiding or after unhiding.
-	affected, affectedErr := affectedByStored(ctx, conn, dataSource)
+	affected, affectedErr := affectedObjects(ctx, conn, dataSource, nil)
 	_, err = conn.Exec(ctx, `UPDATE core.catalog.data_source_meta SET loaded = `+lit(loaded)+
 		`, disabled = `+lit(disabled)+`, suspended = `+lit(suspended)+
 		` WHERE data_source = `+lit(dataSource))
@@ -396,14 +623,14 @@ func pruneOrphanModules(ctx context.Context, conn *db.Connection) error {
 // upsertMeta stamps the source's version, capabilities and flags.
 func upsertMeta(ctx context.Context, conn *db.Connection, state SourceState) error {
 	stmt := `INSERT INTO core.catalog.data_source_meta
-		(data_source, version, capabilities, engine, read_only, prefix, as_module, loaded, disabled, suspended, loaded_at)
+		(data_source, version, capabilities, engine, read_only, prefix, as_module, is_extension, loaded, disabled, suspended, loaded_at)
 		VALUES (` + lit(state.Name) + `, ` + lit(state.storedVersion()) + `, ` + lit(capabilitiesText(state.Capabilities)) + `, ` +
 		lit(state.Engine) + `, ` + lit(state.ReadOnly) + `, ` +
-		lit(nilIfEmpty(state.Prefix)) + `, ` + lit(state.AsModule) + `, ` +
+		lit(nilIfEmpty(state.Prefix)) + `, ` + lit(state.AsModule) + `, ` + lit(state.IsExtension) + `, ` +
 		lit(state.Loaded) + `, ` + lit(state.Disabled) + `, ` + lit(state.Suspended) + `, CURRENT_TIMESTAMP)
 		ON CONFLICT (data_source) DO UPDATE SET version = EXCLUDED.version,
 		capabilities = EXCLUDED.capabilities, engine = EXCLUDED.engine, read_only = EXCLUDED.read_only,
-		prefix = EXCLUDED.prefix, as_module = EXCLUDED.as_module,
+		prefix = EXCLUDED.prefix, as_module = EXCLUDED.as_module, is_extension = EXCLUDED.is_extension,
 		loaded = EXCLUDED.loaded, disabled = EXCLUDED.disabled, suspended = EXCLUDED.suspended, loaded_at = EXCLUDED.loaded_at`
 	if _, err := conn.Exec(ctx, stmt); err != nil {
 		return fmt.Errorf("catalog meta upsert %s: %w", state.Name, err)

--- a/pkg/catalog/store/writer.go
+++ b/pkg/catalog/store/writer.go
@@ -79,6 +79,14 @@ func (s *Store) writeSource(ctx context.Context, d *desired, state SourceState) 
 	}
 	defer conn.Close()
 
+	// The cross-source invalidation closure needs the OLD rows (about to be
+	// deleted) and the incoming ones; a failure here never fails the write —
+	// the cache then invalidates wholesale.
+	affected, affectedErr := affectedByStored(txCtx, conn, state.Name)
+	if affectedErr == nil {
+		addAffectedDesired(affected, d)
+	}
+
 	if err := deleteSourceRows(txCtx, conn, state.Name); err != nil {
 		return false, err
 	}
@@ -99,7 +107,74 @@ func (s *Store) writeSource(ctx context.Context, d *desired, state SourceState) 
 	if err := s.pool.Commit(txCtx); err != nil {
 		return false, fmt.Errorf("catalog write %s commit: %w", state.Name, err)
 	}
+	if affectedErr != nil {
+		s.invalidateAll()
+	} else {
+		s.invalidateSource(state.Name, affected)
+	}
 	return true, nil
+}
+
+// affectedByStored collects the data-object names whose COMPILED shape can
+// depend on the source's stored relations (both endpoints gain/lose nav
+// fields, markers and derived-type members) and module functions returning
+// object lists (they rename the object's aggregation markers). These are the
+// absence dependencies the read-side source index cannot see — a definition
+// built BEFORE such rows existed recorded no dependency on this source.
+func affectedByStored(ctx context.Context, conn *db.Connection, dataSource string) (map[string]struct{}, error) {
+	out := map[string]struct{}{}
+	ds := lit(dataSource)
+	rows, err := conn.Query(ctx, `SELECT r.source, r.destination FROM core.catalog.relations r
+		WHERE r.data_source = `+ds)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var source, destination string
+		if err := rows.Scan(&source, &destination); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		out[source] = struct{}{}
+		out[destination] = struct{}{}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	rows, err = conn.Query(ctx, `SELECT f.returns FROM core.catalog.functions f
+		WHERE f.data_source = `+ds+` AND f.kind = 'function' AND f.module <> ''`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var returns string
+		if err := rows.Scan(&returns); err != nil {
+			return nil, err
+		}
+		if target, isList := listReturnTarget(&function{Returns: returns}); isList {
+			out[target] = struct{}{}
+		}
+	}
+	return out, rows.Err()
+}
+
+// addAffectedDesired folds the incoming desired rows into the affected set.
+func addAffectedDesired(out map[string]struct{}, d *desired) {
+	for _, r := range d.relations {
+		out[r.Source] = struct{}{}
+		out[r.Destination] = struct{}{}
+	}
+	for _, fn := range d.functions {
+		if fn.Kind != "function" || fn.Module == "" {
+			continue
+		}
+		if target, isList := listReturnTarget(fn); isList {
+			out[target] = struct{}{}
+		}
+	}
 }
 
 // deleteSource removes a source's rows, meta and dependencies (the unregister
@@ -122,6 +197,8 @@ func (s *Store) deleteSource(ctx context.Context, dataSource string) error {
 	}
 	defer conn.Close()
 
+	affected, affectedErr := affectedByStored(txCtx, conn, dataSource)
+
 	if err := deleteSourceRows(txCtx, conn, dataSource); err != nil {
 		return err
 	}
@@ -141,6 +218,11 @@ func (s *Store) deleteSource(ctx context.Context, dataSource string) error {
 	if err := s.pool.Commit(txCtx); err != nil {
 		return fmt.Errorf("catalog delete %s: %w", dataSource, err)
 	}
+	if affectedErr != nil {
+		s.invalidateAll()
+	} else {
+		s.invalidateSource(dataSource, affected)
+	}
 	return nil
 }
 
@@ -153,11 +235,19 @@ func (s *Store) setFlags(ctx context.Context, dataSource string, loaded, disable
 		return fmt.Errorf("catalog set flags %s: %w", dataSource, err)
 	}
 	defer conn.Close()
+	// Flag flips change VISIBILITY, not rows — the affected closure reads the
+	// (surviving) rows either before hiding or after unhiding.
+	affected, affectedErr := affectedByStored(ctx, conn, dataSource)
 	_, err = conn.Exec(ctx, `UPDATE core.catalog.data_source_meta SET loaded = `+lit(loaded)+
 		`, disabled = `+lit(disabled)+`, suspended = `+lit(suspended)+
 		` WHERE data_source = `+lit(dataSource))
 	if err != nil {
 		return fmt.Errorf("catalog set flags %s: %w", dataSource, err)
+	}
+	if affectedErr != nil {
+		s.invalidateAll()
+	} else {
+		s.invalidateSource(dataSource, affected)
 	}
 	return nil
 }

--- a/pkg/catalog/store/writer_test.go
+++ b/pkg/catalog/store/writer_test.go
@@ -95,8 +95,9 @@ func TestWriteSourceRoundTrip(t *testing.T) {
 		 FROM core.catalog.module_data_sources WHERE module = 'sales.reports'`),
 		"the view-only submodule contributes no table/function kinds")
 
-	// --- meta stamped with the writer-format version + options ---
-	assert.Equal(t, []string{"f7|v1|true|false|false"}, rows(t, pool,
+	// --- meta stamped with the writer-format version + options (the options
+	// are part of the stored version so meta-only changes rewrite too) ---
+	assert.Equal(t, []string{"f7|v1|duckdb|false|shop|true|false|true|false|false"}, rows(t, pool,
 		`SELECT version, loaded, disabled, suspended FROM core.catalog.data_source_meta WHERE data_source = 'test'`))
 	assert.Equal(t, []string{"duckdb|false|shop|true"}, rows(t, pool,
 		`SELECT engine, read_only, prefix, as_module FROM core.catalog.data_source_meta WHERE data_source = 'test'`))
@@ -116,7 +117,7 @@ func TestWriteSourceRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, changed3)
 	assert.Equal(t, []string{"5"}, rows(t, pool, `SELECT count(*) FROM core.catalog.data_objects WHERE data_source = 'test'`))
-	assert.Equal(t, []string{"f7|v2"}, rows(t, pool,
+	assert.Equal(t, []string{"f7|v2|duckdb|false|shop|true|false"}, rows(t, pool,
 		`SELECT version FROM core.catalog.data_source_meta WHERE data_source = 'test'`))
 
 	// --- setFlags mirrors flags into the meta; rows stay ---

--- a/pkg/data-sources/sources/runtime/core-db/hugr_catalog.sql
+++ b/pkg/data-sources/sources/runtime/core-db/hugr_catalog.sql
@@ -50,6 +50,10 @@ CREATE TABLE IF NOT EXISTS {{ if isAttachedDuckdb }}core.{{ end }}catalog.data_s
     -- drives module query/mutation field naming.
     prefix       VARCHAR,
     as_module    BOOLEAN NOT NULL,
+    -- is_extension marks an extension source: generated members of its
+    -- objects (root fields, shared members, _join/_spatial) carry
+    -- @dependency(name: <source>) so dependency tracking can drop them.
+    is_extension BOOLEAN NOT NULL DEFAULT false,
     loaded       BOOLEAN NOT NULL,
     disabled     BOOLEAN NOT NULL,
     suspended    BOOLEAN NOT NULL,


### PR DESCRIPTION
Phase 3 (Ш5) of the catalog entity storage (design 034, follows #142). All engine changes stay inside `pkg/catalog/store`; a small compiler-rule addition formalizes the cross-source contract. The store is still not wired into the engine (flag switch comes with the CatalogManager step).

## Read-side definition cache

- `defCache` — port of the compiled provider's `schemaCache`: expirable LRU keyed by type name with a source→names index. A definition is indexed under exactly the data sources whose rows its resolution session read (row-level provenance); module roots and shared types index under a pseudo-source `*` evicted on every invalidation.
- `ForName` collapses concurrent resolutions per name via singleflight; an invalidation clock (`Store.gen`) is checked before indexing and re-checked after the LRU install (plus a reindex after `Add`) to close the put-vs-invalidate and background-expiry races.
- Invalidation on `writeSource` (only when rows were rewritten — the version gate keeps the cache), `deleteSource` and `setFlags` evicts the source bucket, the `*` bucket, and the affected object **families** via a write-side reverse closure (relations by endpoint, fields by declared type, function bindings by module+name, list-returning functions). Commit error → conservative `invalidateAll`. Compile options are folded into the stored version so meta-only changes rewrite too.

## Read session + Go error propagation

- `genContext` is the read session of one request: every `catalog.*` reader is a method on it with per-request memoization, returning `(T, error)` — absent rows are nil results **without** an error. Errors propagate through the whole generation chain to the Provider surfaces (`ForName`, the logical model), which log and serve empty; an errored result is never cached.
- `NameExists(ctx, name)` — validate-only classification (write-time collision checks, cheap negatives) without building definitions.

## Cross-source contract + dependency tracking

- **A regular source describes only its own data.** `@join` / `@function_call` / `@table_function_call_join` referencing another source's object/function is a compile error outside an extension source (`validate_join`, `validate_function_call`). Cross-source artifacts (wiring, cross-source views) live in **extension** sources.
- **Visibility** mirrors the compiled provider's read-time gates: an object whose declared `@dependency` sources are inactive reads as absent (cross-source views); a field whose `@dependency` source is inactive is hidden; the dependency sources are recorded as provenance so a flag flip evicts the dependents.
- **Virtual-field attribution**: a virtual field is attributed to the source its DATA comes from, resolved by the declared reference at WRITE time (`resolveVirtualAttribution` — function by module+name for function_call/TFCJ, object by references_name for join) and read back verbatim as `@catalog`; the standard activity gate then hides it with that source.
- **Generation**: every generated member of an extension-owned object carries `@dependency` (root fields, shared `_join`/`_spatial` members and their aggregations); the new `is_extension` column on `data_source_meta` drives it. TFCJ `@catalog` now names the FUNCTION's source (compiler fix in `gen_extension_fields` + store parity). Functions attach only to Function/MutationFunction roots + the `function` gateway, never to Query/Mutation directly.

## Verification

- Goldens + the live corpus (6 real schemas, 1680 types) at unchanged parity **with the cache enabled**, plus a cache-parity double-read per name.
- Multi-source golden redesigned to 5 sources (shop / ro / audit / func / ext) with all cross-source artifacts in the extension; `TestMultiSourceFlagPlay` drives enable/disable cycles through the cache; object/field dependency gates, cross-source closure, error-not-cached, NameExists classification.
- Full `pkg/catalog` + `integration-test/compiler` green; **both e2e suites green** (main 235/0, hugrapp 39/0). Migration 0.0.19 regenerated (`is_extension` column) — held until release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)