### PR TITLE
Catalog store: full read Provider, annotation overlay + vector seeding (design-034)

### DIFF
--- a/pkg/catalog/catalogs.go
+++ b/pkg/catalog/catalogs.go
@@ -352,37 +352,3 @@ func (c *memoryCatalog) removeCatalog(ctx context.Context, name string) error {
 	}
 	return p.DropCatalog(ctx, name, true)
 }
-
-// Description delegation — proxies to the underlying MutableProvider.
-
-func (c *memoryCatalog) SetDefinitionDescription(ctx context.Context, name, desc, longDesc string) error {
-	p, ok := c.provider.(base.MutableProvider)
-	if !ok {
-		return errors.New("provider does not support mutable operations")
-	}
-	return p.SetDefinitionDescription(ctx, name, desc, longDesc)
-}
-
-func (c *memoryCatalog) SetFieldDescription(ctx context.Context, typeName, fieldName, desc, longDesc string) error {
-	p, ok := c.provider.(base.MutableProvider)
-	if !ok {
-		return errors.New("provider does not support mutable operations")
-	}
-	return p.SetFieldDescription(ctx, typeName, fieldName, desc, longDesc)
-}
-
-func (c *memoryCatalog) SetModuleDescription(ctx context.Context, name, desc, longDesc string) error {
-	p, ok := c.provider.(base.MutableProvider)
-	if !ok {
-		return errors.New("provider does not support mutable operations")
-	}
-	return p.SetModuleDescription(ctx, name, desc, longDesc)
-}
-
-func (c *memoryCatalog) SetCatalogDescription(ctx context.Context, name, desc, longDesc string) error {
-	p, ok := c.provider.(base.MutableProvider)
-	if !ok {
-		return errors.New("provider does not support mutable operations")
-	}
-	return p.SetCatalogDescription(ctx, name, desc, longDesc)
-}

--- a/pkg/catalog/compiler/base/constants.go
+++ b/pkg/catalog/compiler/base/constants.go
@@ -207,6 +207,7 @@ const (
 	DescNestedOrderBy   = "Sort options for the nested result set"
 	DescNestedLimit     = "Limit the number of returned nested objects"
 	DescNestedOffset    = "Skip the first n nested objects"
+	DescMutationData    = "The record data"
 )
 
 // Directive argument name constants (shared between sdl and rules).

--- a/pkg/catalog/compiler/base/interfaces.go
+++ b/pkg/catalog/compiler/base/interfaces.go
@@ -47,21 +47,35 @@ type Provider interface {
 	Types(ctx context.Context) iter.Seq2[string, *ast.Definition]
 }
 
-// MutableProvider is a mutable container for schema definitions.
+// MutableProvider is a mutable container for compiled schema definitions.
+// It carries the compiler write path (per-source Update, DropCatalog) — the
+// description-annotation surface is split out into SchemaAnnotator so a
+// provider can curate descriptions without owning full compilation semantics.
 type MutableProvider interface {
 	Provider
 
+	DropCatalog(ctx context.Context, name string, cascade bool) error
+	Update(ctx context.Context, changes DefinitionsSource) error
+}
+
+// SchemaAnnotator curates human descriptions over an already-compiled schema.
+// It is orthogonal to compilation: an annotator overrides the description /
+// long-description of types, fields, arguments, modules and catalogs without
+// re-running the compiler. The store applies these as an overlay at
+// reconstruction time; the legacy DB provider persists them into its schema
+// tables. Callers reach it via type assertion, like SuspendableProvider.
+type SchemaAnnotator interface {
 	// SetDefinitionDescription updates a type's description and long description.
 	SetDefinitionDescription(ctx context.Context, name, desc, longDesc string) error
 	// SetFieldDescription updates a field's description and long description.
 	SetFieldDescription(ctx context.Context, typeName, fieldName, desc, longDesc string) error
+	// SetArgumentDescription updates a field argument's description and long
+	// description (typeName.fieldName identifies the field carrying the argument).
+	SetArgumentDescription(ctx context.Context, typeName, fieldName, argName, desc, longDesc string) error
 	// SetModuleDescription updates a module's description and long description.
 	SetModuleDescription(ctx context.Context, name, desc, longDesc string) error
 	// SetCatalogDescription updates a catalog's description and long description.
 	SetCatalogDescription(ctx context.Context, name, desc, longDesc string) error
-
-	DropCatalog(ctx context.Context, name string, cascade bool) error
-	Update(ctx context.Context, changes DefinitionsSource) error
 }
 
 // SuspendableProvider is optionally implemented by providers that support

--- a/pkg/catalog/compiler/base/interfaces.go
+++ b/pkg/catalog/compiler/base/interfaces.go
@@ -49,8 +49,9 @@ type Provider interface {
 
 // MutableProvider is a mutable container for compiled schema definitions.
 // It carries the compiler write path (per-source Update, DropCatalog) — the
-// description-annotation surface is split out into SchemaAnnotator so a
-// provider can curate descriptions without owning full compilation semantics.
+// description-annotation surface is split out into the annotator interfaces
+// (LogicalAnnotator / GraphQLAnnotator) so a provider can curate descriptions
+// without owning full compilation semantics.
 type MutableProvider interface {
 	Provider
 
@@ -58,24 +59,49 @@ type MutableProvider interface {
 	Update(ctx context.Context, changes DefinitionsSource) error
 }
 
-// SchemaAnnotator curates human descriptions over an already-compiled schema.
-// It is orthogonal to compilation: an annotator overrides the description /
-// long-description of types, fields, arguments, modules and catalogs without
-// re-running the compiler. The store applies these as an overlay at
-// reconstruction time; the legacy DB provider persists them into its schema
-// tables. Callers reach it via type assertion, like SuspendableProvider.
-type SchemaAnnotator interface {
-	// SetDefinitionDescription updates a type's description and long description.
-	SetDefinitionDescription(ctx context.Context, name, desc, longDesc string) error
-	// SetFieldDescription updates a field's description and long description.
+// LogicalAnnotator curates human descriptions over the LOGICAL model — the
+// source-level entities the CoreDB entity_* views expose: modules, data
+// objects, residual source-defined types, object fields (including relation
+// navigation fields), functions and data sources. The keys mirror exactly how
+// those views select their overlay from catalog.annotations, so a curation
+// written here also feeds the vector search MCP discovery runs over the same
+// rows. The store applies these as a description overlay at reconstruction
+// time; callers reach it via type assertion, like SuspendableProvider.
+type LogicalAnnotator interface {
+	// SetModuleDescription curates a module's description (entity_kind=module).
+	SetModuleDescription(ctx context.Context, module, desc, longDesc string) error
+	// SetDataObjectDescription curates a data object's description
+	// (entity_kind=data_object, key = compiled object type name).
+	SetDataObjectDescription(ctx context.Context, name, desc, longDesc string) error
+	// SetSourceTypeDescription curates a residual source-defined type's
+	// description (entity_kind=type).
+	SetSourceTypeDescription(ctx context.Context, name, desc, longDesc string) error
+	// SetObjectFieldDescription curates a data-object field's description,
+	// including relation navigation fields (entity_kind=field, key=owner.field).
+	SetObjectFieldDescription(ctx context.Context, owner, field, desc, longDesc string) error
+	// SetFunctionDescription curates a function's description (entity_kind=
+	// function, key = module.name, or name when module is empty; parent=module).
+	SetFunctionDescription(ctx context.Context, module, name, desc, longDesc string) error
+	// SetDataSourceDescription curates a data source's description
+	// (entity_kind=data_source).
+	SetDataSourceDescription(ctx context.Context, name, desc, longDesc string) error
+}
+
+// GraphQLAnnotator curates human descriptions over the GENERATED GraphQL
+// schema surface — the synthetic types (aggregations, filters, mutation
+// inputs, module roots, shared query types), their fields and their arguments,
+// which have no logical-model entity to hang a description on. Its keys live in
+// a separate namespace (gql_type / gql_field / gql_argument) so they never
+// collide with the logical annotations, and the store applies them AFTER the
+// logical layer, so a GraphQL curation wins over a logical one.
+type GraphQLAnnotator interface {
+	// SetDefinitionDescription curates a generated type's description (gql_type).
+	SetDefinitionDescription(ctx context.Context, typeName, desc, longDesc string) error
+	// SetFieldDescription curates a field's description (gql_field, key=type.field).
 	SetFieldDescription(ctx context.Context, typeName, fieldName, desc, longDesc string) error
-	// SetArgumentDescription updates a field argument's description and long
-	// description (typeName.fieldName identifies the field carrying the argument).
+	// SetArgumentDescription curates a field argument's description
+	// (gql_argument, key=type.field.arg).
 	SetArgumentDescription(ctx context.Context, typeName, fieldName, argName, desc, longDesc string) error
-	// SetModuleDescription updates a module's description and long description.
-	SetModuleDescription(ctx context.Context, name, desc, longDesc string) error
-	// SetCatalogDescription updates a catalog's description and long description.
-	SetCatalogDescription(ctx context.Context, name, desc, longDesc string) error
 }
 
 // SuspendableProvider is optionally implemented by providers that support

--- a/pkg/catalog/store/annotate.go
+++ b/pkg/catalog/store/annotate.go
@@ -118,8 +118,9 @@ func (s *Store) curate(ctx context.Context, kind, key, parent, desc, longDesc st
 // empty description is stored as NULL. When vec is non-nil it is written and
 // updated on conflict; when nil the vec column is left untouched so a load-time
 // seed vector survives a text-only curation (or a clear). The vector is
-// rendered as a SQL literal like the rest of the writer (litEngine); the
-// DOUBLE[] literal casts to the column's FLOAT[]/vector on insert.
+// rendered as a cross-engine text literal (vecLiteral) and CURRENT_TIMESTAMP is
+// used for updated_at — the statement shapes the CoreDB inventory pins as
+// working on both DuckDB and attached PostgreSQL (core-db/hugr_catalog_test.go).
 func (s *Store) upsertAnnotation(ctx context.Context, kind, key, parent, desc, longDesc string, vec qetypes.Vector) error {
 	conn, err := s.pool.Conn(ctx)
 	if err != nil {
@@ -131,15 +132,15 @@ func (s *Store) upsertAnnotation(ctx context.Context, kind, key, parent, desc, l
 	vals := `VALUES (` + lit(kind) + `, ` + lit(key) + `, ` + lit(nilIfEmpty(parent)) + `, ` +
 		lit(nilIfEmpty(desc)) + `, ` + lit(nilIfEmpty(longDesc))
 	set := `ON CONFLICT (entity_kind, entity_key) DO UPDATE SET
-		parent = excluded.parent, description = excluded.description,
-		long_description = excluded.long_description`
+		parent = EXCLUDED.parent, description = EXCLUDED.description,
+		long_description = EXCLUDED.long_description`
 	var stmt string
 	if vec != nil {
-		stmt = head + `, vec, updated_at) ` + vals + `, ` + lit([]float64(vec)) + `, now()::TIMESTAMP) ` +
-			set + `, vec = excluded.vec, updated_at = excluded.updated_at`
+		stmt = head + `, vec, updated_at) ` + vals + `, ` + vecLiteral(vec) + `, CURRENT_TIMESTAMP) ` +
+			set + `, vec = EXCLUDED.vec, updated_at = EXCLUDED.updated_at`
 	} else {
-		stmt = head + `, updated_at) ` + vals + `, now()::TIMESTAMP) ` +
-			set + `, updated_at = excluded.updated_at`
+		stmt = head + `, updated_at) ` + vals + `, CURRENT_TIMESTAMP) ` +
+			set + `, updated_at = EXCLUDED.updated_at`
 	}
 	if _, err := conn.Exec(ctx, stmt); err != nil {
 		return fmt.Errorf("set annotation %s %s: %w", kind, key, err)

--- a/pkg/catalog/store/annotate.go
+++ b/pkg/catalog/store/annotate.go
@@ -37,24 +37,30 @@ func (s *Store) SetModuleDescription(ctx context.Context, module, desc, longDesc
 
 // SetDataObjectDescription curates a data object's description; evicts that type.
 func (s *Store) SetDataObjectDescription(ctx context.Context, name, desc, longDesc string) error {
-	return s.curate(ctx, kindDataObject, name, "", desc, longDesc, []string{name})
+	return s.curate(ctx, kindDataObject, name, "", desc, longDesc, func() { s.evictType(name) })
 }
 
 // SetSourceTypeDescription curates a residual source type's description; evicts it.
 func (s *Store) SetSourceTypeDescription(ctx context.Context, name, desc, longDesc string) error {
-	return s.curate(ctx, kindType, name, "", desc, longDesc, []string{name})
+	return s.curate(ctx, kindType, name, "", desc, longDesc, func() { s.evictType(name) })
 }
 
 // SetObjectFieldDescription curates a data-object field (incl. a relation
-// navigation field); evicts the owning object type.
+// navigation field); evicts the owning type AND its cached derived types
+// (filters / mutation inputs / aggregations), whose same-named fields inherit
+// the description at reconstruction.
 func (s *Store) SetObjectFieldDescription(ctx context.Context, owner, field, desc, longDesc string) error {
-	return s.curate(ctx, kindField, fieldKey(owner, field), owner, desc, longDesc, []string{owner})
+	return s.curate(ctx, kindField, fieldKey(owner, field), owner, desc, longDesc, func() { s.evictTypeFamily(owner) })
 }
 
 // SetFunctionDescription curates a function (keyed module.name, parent=module);
 // evicts every module root that could expose it as a direct field.
 func (s *Store) SetFunctionDescription(ctx context.Context, module, name, desc, longDesc string) error {
-	return s.curate(ctx, kindFunction, functionKey(module, name), module, desc, longDesc, functionRootTypes(module))
+	return s.curate(ctx, kindFunction, functionKey(module, name), module, desc, longDesc, func() {
+		for _, root := range functionRootTypes(module) {
+			s.evictType(root)
+		}
+	})
 }
 
 // SetDataSourceDescription curates a data source (no ForName surface — data
@@ -67,19 +73,20 @@ func (s *Store) SetDataSourceDescription(ctx context.Context, name, desc, longDe
 
 // SetDefinitionDescription curates a generated type's description; evicts it.
 func (s *Store) SetDefinitionDescription(ctx context.Context, typeName, desc, longDesc string) error {
-	return s.curate(ctx, kindGQLType, typeName, "", desc, longDesc, []string{typeName})
+	return s.curate(ctx, kindGQLType, typeName, "", desc, longDesc, func() { s.evictType(typeName) })
 }
 
 // SetFieldDescription curates a generated field's description; evicts its type.
 func (s *Store) SetFieldDescription(ctx context.Context, typeName, fieldName, desc, longDesc string) error {
-	return s.curate(ctx, kindGQLField, fieldKey(typeName, fieldName), typeName, desc, longDesc, []string{typeName})
+	return s.curate(ctx, kindGQLField, fieldKey(typeName, fieldName), typeName, desc, longDesc,
+		func() { s.evictType(typeName) })
 }
 
 // SetArgumentDescription curates a generated field argument's description;
 // evicts the owning type.
 func (s *Store) SetArgumentDescription(ctx context.Context, typeName, fieldName, argName, desc, longDesc string) error {
 	return s.curate(ctx, kindGQLArgument, argumentKey(typeName, fieldName, argName),
-		fieldKey(typeName, fieldName), desc, longDesc, []string{typeName})
+		fieldKey(typeName, fieldName), desc, longDesc, func() { s.evictType(typeName) })
 }
 
 // functionRootTypes are the module roots that may carry a function as a direct
@@ -93,11 +100,11 @@ func functionRootTypes(module string) []string {
 	}
 }
 
-// curate upserts one annotation row and evicts the affected reconstructed
-// types. The embedding vector is computed from the curated text (nil when
-// embeddings are off or the text is empty — a clear); the upsert then preserves
-// any existing seed vector.
-func (s *Store) curate(ctx context.Context, kind, key, parent, desc, longDesc string, evict []string) error {
+// curate upserts one annotation row and runs the caller's cache eviction (nil
+// when the curation has no ForName surface). The embedding vector is computed
+// from the curated text (nil when embeddings are off or the text is empty — a
+// clear); the upsert then preserves any existing seed vector.
+func (s *Store) curate(ctx context.Context, kind, key, parent, desc, longDesc string, evict func()) error {
 	if s.isReadonly {
 		return errReadonly
 	}
@@ -108,8 +115,8 @@ func (s *Store) curate(ctx context.Context, kind, key, parent, desc, longDesc st
 	if err := s.upsertAnnotation(ctx, kind, key, parent, desc, longDesc, vec); err != nil {
 		return err
 	}
-	for _, name := range evict {
-		s.evictType(name)
+	if evict != nil {
+		evict()
 	}
 	return nil
 }

--- a/pkg/catalog/store/annotate.go
+++ b/pkg/catalog/store/annotate.go
@@ -1,0 +1,148 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
+	"github.com/hugr-lab/query-engine/pkg/catalog/sdl"
+	qetypes "github.com/hugr-lab/query-engine/types"
+)
+
+// The store implements both curation surfaces. LogicalAnnotator writes the
+// source-level entity kinds the entity_* views read; GraphQLAnnotator writes
+// the generated-surface kinds. Every write upserts one catalog.annotations row
+// by (entity_kind, entity_key) — text plus, when an embedder is configured, the
+// text's embedding vector so MCP vector search is current — and then evicts the
+// affected reconstructed types from the definition cache. An empty description
+// stores NULL (clearing the curation, the generated text shows through again)
+// and leaves the vec column untouched so any load-time seed vector survives.
+var (
+	_ base.LogicalAnnotator = (*Store)(nil)
+	_ base.GraphQLAnnotator = (*Store)(nil)
+)
+
+// errReadonly rejects curation on a read-only store (cluster workers read the
+// already-populated catalog schema).
+var errReadonly = errors.New("catalog store: read-only, cannot annotate")
+
+// --- LogicalAnnotator ---
+
+// SetModuleDescription curates a module (no ForName surface — module
+// descriptions reach clients through the logical model / entity_modules view).
+func (s *Store) SetModuleDescription(ctx context.Context, module, desc, longDesc string) error {
+	return s.curate(ctx, kindModule, module, "", desc, longDesc, nil)
+}
+
+// SetDataObjectDescription curates a data object's description; evicts that type.
+func (s *Store) SetDataObjectDescription(ctx context.Context, name, desc, longDesc string) error {
+	return s.curate(ctx, kindDataObject, name, "", desc, longDesc, []string{name})
+}
+
+// SetSourceTypeDescription curates a residual source type's description; evicts it.
+func (s *Store) SetSourceTypeDescription(ctx context.Context, name, desc, longDesc string) error {
+	return s.curate(ctx, kindType, name, "", desc, longDesc, []string{name})
+}
+
+// SetObjectFieldDescription curates a data-object field (incl. a relation
+// navigation field); evicts the owning object type.
+func (s *Store) SetObjectFieldDescription(ctx context.Context, owner, field, desc, longDesc string) error {
+	return s.curate(ctx, kindField, fieldKey(owner, field), owner, desc, longDesc, []string{owner})
+}
+
+// SetFunctionDescription curates a function (keyed module.name, parent=module);
+// evicts every module root that could expose it as a direct field.
+func (s *Store) SetFunctionDescription(ctx context.Context, module, name, desc, longDesc string) error {
+	return s.curate(ctx, kindFunction, functionKey(module, name), module, desc, longDesc, functionRootTypes(module))
+}
+
+// SetDataSourceDescription curates a data source (no ForName surface — data
+// source descriptions reach clients through the entity_data_sources view).
+func (s *Store) SetDataSourceDescription(ctx context.Context, name, desc, longDesc string) error {
+	return s.curate(ctx, kindDataSource, name, "", desc, longDesc, nil)
+}
+
+// --- GraphQLAnnotator ---
+
+// SetDefinitionDescription curates a generated type's description; evicts it.
+func (s *Store) SetDefinitionDescription(ctx context.Context, typeName, desc, longDesc string) error {
+	return s.curate(ctx, kindGQLType, typeName, "", desc, longDesc, []string{typeName})
+}
+
+// SetFieldDescription curates a generated field's description; evicts its type.
+func (s *Store) SetFieldDescription(ctx context.Context, typeName, fieldName, desc, longDesc string) error {
+	return s.curate(ctx, kindGQLField, fieldKey(typeName, fieldName), typeName, desc, longDesc, []string{typeName})
+}
+
+// SetArgumentDescription curates a generated field argument's description;
+// evicts the owning type.
+func (s *Store) SetArgumentDescription(ctx context.Context, typeName, fieldName, argName, desc, longDesc string) error {
+	return s.curate(ctx, kindGQLArgument, argumentKey(typeName, fieldName, argName),
+		fieldKey(typeName, fieldName), desc, longDesc, []string{typeName})
+}
+
+// functionRootTypes are the module roots that may carry a function as a direct
+// field — the eviction targets for a function-description write (the function's
+// kind is not known at the call site, so all three candidates are evicted).
+func functionRootTypes(module string) []string {
+	return []string{
+		sdl.ModuleTypeName(module, base.ModuleFunction),
+		sdl.ModuleTypeName(module, base.ModuleMutationFunction),
+		sdl.ModuleTypeName(module, base.ModuleSubscription),
+	}
+}
+
+// curate upserts one annotation row and evicts the affected reconstructed
+// types. The embedding vector is computed from the curated text (nil when
+// embeddings are off or the text is empty — a clear); the upsert then preserves
+// any existing seed vector.
+func (s *Store) curate(ctx context.Context, kind, key, parent, desc, longDesc string, evict []string) error {
+	if s.isReadonly {
+		return errReadonly
+	}
+	vec, err := s.embed(ctx, embeddingText(longDesc, desc, ""))
+	if err != nil {
+		return err
+	}
+	if err := s.upsertAnnotation(ctx, kind, key, parent, desc, longDesc, vec); err != nil {
+		return err
+	}
+	for _, name := range evict {
+		s.evictType(name)
+	}
+	return nil
+}
+
+// upsertAnnotation writes one curation row by (entity_kind, entity_key). An
+// empty description is stored as NULL. When vec is non-nil it is written and
+// updated on conflict; when nil the vec column is left untouched so a load-time
+// seed vector survives a text-only curation (or a clear). The vector is
+// rendered as a SQL literal like the rest of the writer (litEngine); the
+// DOUBLE[] literal casts to the column's FLOAT[]/vector on insert.
+func (s *Store) upsertAnnotation(ctx context.Context, kind, key, parent, desc, longDesc string, vec qetypes.Vector) error {
+	conn, err := s.pool.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("set annotation %s %s: %w", kind, key, err)
+	}
+	defer conn.Close()
+	head := `INSERT INTO core.catalog.annotations
+		(entity_kind, entity_key, parent, description, long_description`
+	vals := `VALUES (` + lit(kind) + `, ` + lit(key) + `, ` + lit(nilIfEmpty(parent)) + `, ` +
+		lit(nilIfEmpty(desc)) + `, ` + lit(nilIfEmpty(longDesc))
+	set := `ON CONFLICT (entity_kind, entity_key) DO UPDATE SET
+		parent = excluded.parent, description = excluded.description,
+		long_description = excluded.long_description`
+	var stmt string
+	if vec != nil {
+		stmt = head + `, vec, updated_at) ` + vals + `, ` + lit([]float64(vec)) + `, now()::TIMESTAMP) ` +
+			set + `, vec = excluded.vec, updated_at = excluded.updated_at`
+	} else {
+		stmt = head + `, updated_at) ` + vals + `, now()::TIMESTAMP) ` +
+			set + `, updated_at = excluded.updated_at`
+	}
+	if _, err := conn.Exec(ctx, stmt); err != nil {
+		return fmt.Errorf("set annotation %s %s: %w", kind, key, err)
+	}
+	return nil
+}

--- a/pkg/catalog/store/annotate_test.go
+++ b/pkg/catalog/store/annotate_test.go
@@ -1,0 +1,134 @@
+//go:build duckdb_arrow
+
+package store
+
+import (
+	"context"
+	"testing"
+
+	coredb "github.com/hugr-lab/query-engine/pkg/data-sources/sources/runtime/core-db"
+	"github.com/hugr-lab/query-engine/pkg/db"
+	qetypes "github.com/hugr-lab/query-engine/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogicalAnnotatorWrite exercises the write→read curation loop through the
+// LogicalAnnotator surface: a Set*Description upserts the annotation and evicts
+// the affected type, so a subsequent ForName reflects the change even when the
+// type was cached before the write. Writing an empty description clears the
+// curation (the generated text shows through again).
+func TestLogicalAnnotatorWrite(t *testing.T) {
+	store, ctx := storeForSources(t, genMultiFixtures)
+
+	// Prime the cache with the pre-annotation definitions.
+	require.Empty(t, store.ForName(ctx, "shop_items").Description)
+	require.Equal(t, "Query shop_items objects",
+		store.ForName(ctx, "_module_shop_query").Fields.ForName("items").Description)
+
+	// Data-object description — the cached definition is evicted, the read reflects it.
+	require.NoError(t, store.SetDataObjectDescription(ctx, "shop_items", "Curated item", "long form"))
+	assert.Equal(t, "Curated item", store.ForName(ctx, "shop_items").Description)
+
+	// Object field description.
+	require.NoError(t, store.SetObjectFieldDescription(ctx, "shop_items", "name", "The item name", ""))
+	assert.Equal(t, "The item name", store.ForName(ctx, "shop_items").Fields.ForName("name").Description)
+
+	// Function description keyed module.name, surfaced on the module function root.
+	require.NoError(t, store.SetFunctionDescription(ctx, "tools", "slugify", "Slugify a string", ""))
+	assert.Equal(t, "Slugify a string",
+		store.ForName(ctx, "_module_tools_function").Fields.ForName("slugify").Description)
+
+	// Clearing: an empty description reverts to the generated text.
+	require.NoError(t, store.SetDataObjectDescription(ctx, "shop_items", "", ""))
+	assert.Empty(t, store.ForName(ctx, "shop_items").Description, "empty write clears the curation")
+
+	// Module / data-source curation lands as rows (no ForName surface yet).
+	require.NoError(t, store.SetModuleDescription(ctx, "shop", "The shop module", ""))
+	require.NoError(t, store.SetDataSourceDescription(ctx, "shop", "The shop source", ""))
+	assert.Equal(t, []string{"module|shop|The shop module", "data_source|shop|The shop source"},
+		annotationRows(t, store.pool, "shop"))
+
+	// Upsert semantics: a second write to the same key replaces, not duplicates.
+	require.NoError(t, store.SetModuleDescription(ctx, "shop", "Updated module", ""))
+	assert.Equal(t, []string{"module|shop|Updated module", "data_source|shop|The shop source"},
+		annotationRows(t, store.pool, "shop"))
+}
+
+// TestGraphQLAnnotatorWrite curates the generated surface (a root field and its
+// argument) and reads the change back through ForName.
+func TestGraphQLAnnotatorWrite(t *testing.T) {
+	store, ctx := storeForSources(t, genMultiFixtures)
+
+	require.NoError(t, store.SetFieldDescription(ctx, "_module_shop_query", "items", "Curated items", ""))
+	require.NoError(t, store.SetArgumentDescription(ctx, "_module_shop_query", "items", "limit", "Max rows", ""))
+
+	items := store.ForName(ctx, "_module_shop_query").Fields.ForName("items")
+	require.NotNil(t, items)
+	assert.Equal(t, "Curated items", items.Description)
+	assert.Equal(t, "Max rows", items.Arguments.ForName("limit").Description)
+}
+
+// TestAnnotatorReadonly rejects curation on a read-only store, on both surfaces.
+func TestAnnotatorReadonly(t *testing.T) {
+	ctx := context.Background()
+	pool, err := db.NewPool("")
+	require.NoError(t, err)
+	t.Cleanup(func() { pool.Close() })
+	require.NoError(t, coredb.New(coredb.Config{VectorSize: 8}).Attach(ctx, pool))
+	store, err := New(ctx, pool, Config{VecSize: 8, IsReadonly: true}, nil)
+	require.NoError(t, err)
+
+	assert.ErrorIs(t, store.SetDataObjectDescription(ctx, "shop_items", "x", ""), errReadonly)
+	assert.ErrorIs(t, store.SetModuleDescription(ctx, "shop", "x", ""), errReadonly)
+	assert.ErrorIs(t, store.SetDefinitionDescription(ctx, "shop_items_filter", "x", ""), errReadonly)
+}
+
+// TestAnnotatorEmbeds pins the vector side: with an embedder configured, a
+// curation write stores an embedding vector in the annotation row. A clearing
+// write (empty text) leaves the vec column UNTOUCHED — reconciling a stale
+// curated vector with the entity's load-time seed is the seed step's job.
+func TestAnnotatorEmbeds(t *testing.T) {
+	ctx := context.Background()
+	pool, err := db.NewPool("")
+	require.NoError(t, err)
+	t.Cleanup(func() { pool.Close() })
+	require.NoError(t, coredb.New(coredb.Config{VectorSize: 8}).Attach(ctx, pool))
+	store, err := New(ctx, pool, Config{VecSize: 8}, fakeEmbedder{dim: 8})
+	require.NoError(t, err)
+
+	vecPresent := func() []string {
+		return rows(t, store.pool, `SELECT vec IS NOT NULL, description IS NOT NULL
+			FROM core.catalog.annotations WHERE entity_kind = 'module' AND entity_key = 'shop'`)
+	}
+
+	require.NoError(t, store.SetModuleDescription(ctx, "shop", "The shop module", ""))
+	assert.Equal(t, []string{"true|true"}, vecPresent(), "curation stores text and vector")
+
+	// Clearing nulls the text but leaves the vector untouched.
+	require.NoError(t, store.SetModuleDescription(ctx, "shop", "", ""))
+	assert.Equal(t, []string{"true|false"}, vecPresent(), "clear nulls text, keeps vec")
+}
+
+// fakeEmbedder returns a fixed-size zero vector — enough to exercise the write
+// path without a real embedding backend.
+type fakeEmbedder struct{ dim int }
+
+func (f fakeEmbedder) CreateEmbedding(_ context.Context, _ string) (*qetypes.EmbeddingResult, error) {
+	return &qetypes.EmbeddingResult{Vector: make(qetypes.Vector, f.dim)}, nil
+}
+
+func (f fakeEmbedder) CreateEmbeddings(_ context.Context, inputs []string) (*qetypes.EmbeddingsResult, error) {
+	out := make([]qetypes.Vector, len(inputs))
+	for i := range out {
+		out[i] = make(qetypes.Vector, f.dim)
+	}
+	return &qetypes.EmbeddingsResult{Vectors: out}, nil
+}
+
+// annotationRows returns "entity_kind|entity_key|description" for a key.
+func annotationRows(t *testing.T, pool *db.Pool, key string) []string {
+	t.Helper()
+	return rows(t, pool, `SELECT entity_kind, entity_key, description FROM core.catalog.annotations
+		WHERE entity_key = `+lit(key)+` ORDER BY entity_kind DESC`)
+}

--- a/pkg/catalog/store/annotate_test.go
+++ b/pkg/catalog/store/annotate_test.go
@@ -30,9 +30,14 @@ func TestLogicalAnnotatorWrite(t *testing.T) {
 	require.NoError(t, store.SetDataObjectDescription(ctx, "shop_items", "Curated item", "long form"))
 	assert.Equal(t, "Curated item", store.ForName(ctx, "shop_items").Description)
 
-	// Object field description.
+	// Object field description. The derived types were CACHED above the write —
+	// the family evict makes them reflect the inherited curation too.
+	require.NotNil(t, store.ForName(ctx, "shop_items_filter")) // prime the derived cache
 	require.NoError(t, store.SetObjectFieldDescription(ctx, "shop_items", "name", "The item name", ""))
 	assert.Equal(t, "The item name", store.ForName(ctx, "shop_items").Fields.ForName("name").Description)
+	assert.Equal(t, "The item name",
+		store.ForName(ctx, "shop_items_filter").Fields.ForName("name").Description,
+		"cached filter evicted with the base — inherits the new curation")
 
 	// Function description keyed module.name, surfaced on the module function root.
 	require.NoError(t, store.SetFunctionDescription(ctx, "tools", "slugify", "Slugify a string", ""))

--- a/pkg/catalog/store/annotations.go
+++ b/pkg/catalog/store/annotations.go
@@ -69,9 +69,28 @@ func argumentKey(typeName, fieldName, argName string) string {
 // reconstructed definition: the def-level description (data_object / type) and
 // the field descriptions (field, incl. relation navigation fields), plus — for
 // function-exposing module roots — the function field descriptions keyed by
-// module.name. The rows come from one name-anchored query; function rows need a
-// second query because they are keyed by module.name, not by the root name.
+// module.name. Derived types (filters / mutation inputs / aggregations) first
+// INHERIT their base entity's field curation onto same-named fields, so
+// curating shop_items.name implicitly shows on shop_items_filter.name and
+// _shop_items_aggregation.name; direct rows (and the GraphQL layer) still win.
 func (s *Store) applyLogicalAnnotations(ctx context.Context, g *genContext, def *ast.Definition, rows []annotationRow) error {
+	// A derived type (filter / mutation input / aggregation) inherits its base's
+	// field descriptions onto same-named fields. The base name comes from the
+	// session (recorded by resolveDerivedType from the matched rule — never
+	// parsed back from directives, whose input markers are directional), and the
+	// base is read through ForName — cached, and already carrying defaults AND
+	// curation. Only derived rules record a base, so the chain is one level deep
+	// and the shared query types (_join_aggregation — a shared rule) keep their
+	// more specific default wording.
+	if owner := g.derivedBase; owner != "" && owner != def.Name {
+		if baseDef := s.ForName(ctx, owner); baseDef != nil {
+			for _, f := range def.Fields {
+				if bf := baseDef.Fields.ForName(f.Name); bf != nil && bf.Description != "" {
+					f.Description = bf.Description
+				}
+			}
+		}
+	}
 	prefix := def.Name + "."
 	for _, a := range rows {
 		switch a.kind {

--- a/pkg/catalog/store/annotations.go
+++ b/pkg/catalog/store/annotations.go
@@ -6,45 +6,101 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
 // The annotation overlay is the curation layer applied at the end of ForName,
 // AFTER the default descriptions: a row in catalog.annotations overrides the
-// description of a type, field or argument by name. Identity is
-// (entity_kind, entity_key) and the entity_key is a dot-path locating the
-// target (hugr_catalog.sql D-notes): a type is keyed by its name, a field by
-// "<type>.<field>", an argument by "<type>.<field>.<arg>". The overlay is
-// source-agnostic (never activity-gated) and orphan rows are legal; a row with
-// a NULL description is a vector seed (D24) and leaves the generated text
-// intact. This is the single key convention shared with the SchemaAnnotator
-// writer.
+// generated description of the reconstructed definition. Two layers stack in
+// order (logical first, GraphQL second, each overriding the previous), keyed
+// EXACTLY the way the CoreDB entity_* views select their overlay so a single
+// annotations table drives both the reconstructed schema and MCP vector search.
+//
+//	LOGICAL (the source-level model the entity_* views expose):
+//	  module        entity_key = module name                        (no ForName surface)
+//	  data_object   entity_key = compiled object type name          → def.Description
+//	  type          entity_key = residual source type name          → def.Description
+//	  field         entity_key = "owner.field" (incl. relation nav) → field.Description
+//	  function      entity_key = "module.name" (or "name"); parent=module → root field.Description
+//	  data_source   entity_key = data source name                   (no ForName surface)
+//
+//	GRAPHQL (the generated surface with no logical entity to key on):
+//	  gql_type      entity_key = type name          → def.Description
+//	  gql_field     entity_key = "type.field"       → field.Description
+//	  gql_argument  entity_key = "type.field.arg"   → argument.Description
+//
+// A row with a NULL description is a vector-only seed (D24) and is skipped by
+// the reader — it leaves the generated text intact. These key conventions are
+// the single contract shared with the LogicalAnnotator / GraphQLAnnotator
+// writers (annotate.go).
 
 const (
-	annotationType     = "type"
-	annotationField    = "field"
-	annotationArgument = "argument"
+	// Logical kinds (mirror the entity_* view annotation joins).
+	kindModule     = "module"
+	kindDataObject = "data_object"
+	kindType       = "type"
+	kindField      = "field"
+	kindFunction   = "function"
+	kindDataSource = "data_source"
+
+	// GraphQL kinds (a separate namespace for the generated surface).
+	kindGQLType     = "gql_type"
+	kindGQLField    = "gql_field"
+	kindGQLArgument = "gql_argument"
 )
 
-// applyAnnotations overrides def's descriptions — the type itself, its fields
-// and their arguments — from catalog.annotations. One query loads the type row
-// and every field/argument row beneath it (entity_key prefix); rows are routed
-// by entity_kind and located by their dot-path key.
-func (s *Store) applyAnnotations(ctx context.Context, g *genContext, def *ast.Definition) error {
-	rows, err := g.readAnnotations(ctx, def.Name)
-	if err != nil {
-		return err
+// fieldKey / functionKey / argKey build the entity_key for each kind — the
+// write side of the convention the overlay reads back.
+func fieldKey(owner, field string) string { return owner + "." + field }
+
+func functionKey(module, name string) string {
+	if module == "" {
+		return name
 	}
+	return module + "." + name
+}
+
+func argumentKey(typeName, fieldName, argName string) string {
+	return typeName + "." + fieldName + "." + argName
+}
+
+// applyLogicalAnnotations overlays the logical-model curation onto a
+// reconstructed definition: the def-level description (data_object / type) and
+// the field descriptions (field, incl. relation navigation fields), plus — for
+// function-exposing module roots — the function field descriptions keyed by
+// module.name. The rows come from one name-anchored query; function rows need a
+// second query because they are keyed by module.name, not by the root name.
+func (s *Store) applyLogicalAnnotations(ctx context.Context, g *genContext, def *ast.Definition, rows []annotationRow) error {
 	prefix := def.Name + "."
 	for _, a := range rows {
 		switch a.kind {
-		case annotationType:
+		case kindDataObject, kindType:
 			def.Description = a.description
-		case annotationField:
+		case kindField:
 			if f := def.Fields.ForName(strings.TrimPrefix(a.key, prefix)); f != nil {
 				f.Description = a.description
 			}
-		case annotationArgument:
+		}
+	}
+	return s.applyFunctionAnnotations(ctx, g, def)
+}
+
+// applyGraphQLAnnotations overlays the generated-surface curation (gql_type /
+// gql_field / gql_argument), which runs after the logical layer so a GraphQL
+// curation wins. Field and argument rows share the "type.…" prefix and are
+// routed by kind; an argument key is "type.field.arg".
+func (s *Store) applyGraphQLAnnotations(def *ast.Definition, rows []annotationRow) {
+	prefix := def.Name + "."
+	for _, a := range rows {
+		switch a.kind {
+		case kindGQLType:
+			def.Description = a.description
+		case kindGQLField:
+			if f := def.Fields.ForName(strings.TrimPrefix(a.key, prefix)); f != nil {
+				f.Description = a.description
+			}
+		case kindGQLArgument:
 			fieldName, argName, ok := strings.Cut(strings.TrimPrefix(a.key, prefix), ".")
 			if !ok {
 				continue
@@ -56,20 +112,90 @@ func (s *Store) applyAnnotations(ctx context.Context, g *genContext, def *ast.De
 			}
 		}
 	}
+}
+
+// applyFunctionAnnotations overlays the logical function descriptions onto a
+// function-exposing module root (Function / MutationFunction / Subscription and
+// their _module_* variants). Functions are keyed by module.name, so the fields
+// are matched by resolving the root's module and the direct functions of the
+// root's kind, then reading the annotations for their exact keys.
+func (s *Store) applyFunctionAnnotations(ctx context.Context, g *genContext, def *ast.Definition) error {
+	module, fnKind, ok := rootDirectFunctionKind(def)
+	if !ok {
+		return nil
+	}
+	fns, err := g.readFunctions(ctx, module)
+	if err != nil {
+		return err
+	}
+	keyToField := map[string]string{}
+	var keys []string
+	for _, fn := range fns {
+		if fn.Kind != fnKind {
+			continue
+		}
+		k := functionKey(module, fn.Name)
+		keyToField[k] = fn.Name
+		keys = append(keys, k)
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	descByKey, err := g.readFunctionAnnotations(ctx, keys)
+	if err != nil {
+		return err
+	}
+	for k, desc := range descByKey {
+		if fname, ok := keyToField[k]; ok {
+			if f := def.Fields.ForName(fname); f != nil {
+				f.Description = desc
+			}
+		}
+	}
 	return nil
 }
 
-// annotationRow is one curation row that carries text (seeds are skipped).
+// rootDirectFunctionKind reports the catalog.functions.kind a module root
+// exposes as DIRECT fields (function / mutation / subscription), with its
+// module, or ok=false when the definition is not such a root. Non-top roots
+// carry @module_root(name, type); the top-level roots are identified by name
+// (their prelude stubs carry no directive). Query/Mutation expose functions
+// only through the `function` gateway, never directly, so they return false.
+func rootDirectFunctionKind(def *ast.Definition) (module, fnKind string, ok bool) {
+	var enum string
+	if d := def.Directives.ForName(base.ModuleRootDirectiveName); d != nil {
+		module = directiveArg(d, base.ArgName)
+		enum = directiveArg(d, base.ArgType)
+	} else if k, isTop := topLevelRoots[def.Name]; isTop {
+		enum = rootKindEnum(k)
+	} else {
+		return "", "", false
+	}
+	switch enum {
+	case "FUNCTION":
+		return module, "function", true
+	case "MUT_FUNCTION":
+		return module, "mutation", true
+	case "SUBSCRIPTION":
+		return module, "subscription", true
+	}
+	return "", "", false
+}
+
+// annotationRow is one curation row carrying text (seed rows are dropped).
 type annotationRow struct {
 	kind        string
 	key         string
 	description string
 }
 
-// readAnnotations loads the type/field/argument curation rows for one type:
-// the type row (entity_key = typeName) and everything beneath it (entity_key
-// starts with "typeName."). Seed rows (NULL description) are dropped.
-func (g *genContext) readAnnotations(ctx context.Context, typeName string) ([]annotationRow, error) {
+// readAnnotationsByName loads every curated (non-seed) row anchored on
+// typeName: the type-level rows (data_object / type / gql_type with entity_key
+// = typeName) and the member rows (field / gql_field / gql_argument with
+// entity_key starting "typeName."). The dot guard keeps "shop." from matching
+// "shop_items.name". Function rows are NOT included — they key by module.name
+// and are read separately (readFunctionAnnotations).
+func (g *genContext) readAnnotationsByName(ctx context.Context, typeName string) ([]annotationRow, error) {
 	conn, err := g.s.pool.Conn(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("read annotations %s: %w", typeName, err)
@@ -77,8 +203,11 @@ func (g *genContext) readAnnotations(ctx context.Context, typeName string) ([]an
 	defer conn.Close()
 	rows, err := conn.Query(ctx, `SELECT entity_kind, entity_key, description
 		FROM core.catalog.annotations
-		WHERE entity_kind IN (`+lit(annotationType)+`, `+lit(annotationField)+`, `+lit(annotationArgument)+`)
-		  AND (entity_key = `+lit(typeName)+` OR starts_with(entity_key, `+lit(typeName+".")+`))`)
+		WHERE description IS NOT NULL AND (
+		  (entity_kind IN (`+lit(kindDataObject)+`, `+lit(kindType)+`, `+lit(kindGQLType)+`)
+		    AND entity_key = `+lit(typeName)+`)
+		  OR (entity_kind IN (`+lit(kindField)+`, `+lit(kindGQLField)+`, `+lit(kindGQLArgument)+`)
+		    AND starts_with(entity_key, `+lit(typeName+".")+`)))`)
 	if err != nil {
 		return nil, fmt.Errorf("read annotations %s: %w", typeName, err)
 	}
@@ -91,12 +220,49 @@ func (g *genContext) readAnnotations(ctx context.Context, typeName string) ([]an
 			return nil, fmt.Errorf("read annotations %s: %w", typeName, err)
 		}
 		if !desc.Valid {
-			continue // seed row — no curated text
+			continue
 		}
 		out = append(out, annotationRow{kind: kind, key: key, description: desc.String})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("read annotations %s: %w", typeName, err)
+	}
+	return out, nil
+}
+
+// readFunctionAnnotations loads the curated function descriptions for the given
+// exact entity keys (kind=function), returning key → description.
+func (g *genContext) readFunctionAnnotations(ctx context.Context, keys []string) (map[string]string, error) {
+	conn, err := g.s.pool.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read function annotations: %w", err)
+	}
+	defer conn.Close()
+	quoted := make([]string, len(keys))
+	for i, k := range keys {
+		quoted[i] = lit(k)
+	}
+	rows, err := conn.Query(ctx, `SELECT entity_key, description
+		FROM core.catalog.annotations
+		WHERE entity_kind = `+lit(kindFunction)+` AND description IS NOT NULL
+		  AND entity_key IN (`+strings.Join(quoted, ", ")+`)`)
+	if err != nil {
+		return nil, fmt.Errorf("read function annotations: %w", err)
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var key string
+		var desc sql.NullString
+		if err := rows.Scan(&key, &desc); err != nil {
+			return nil, fmt.Errorf("read function annotations: %w", err)
+		}
+		if desc.Valid {
+			out[key] = desc.String
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read function annotations: %w", err)
 	}
 	return out, nil
 }

--- a/pkg/catalog/store/annotations.go
+++ b/pkg/catalog/store/annotations.go
@@ -1,0 +1,102 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// The annotation overlay is the curation layer applied at the end of ForName,
+// AFTER the default descriptions: a row in catalog.annotations overrides the
+// description of a type, field or argument by name. Identity is
+// (entity_kind, entity_key) and the entity_key is a dot-path locating the
+// target (hugr_catalog.sql D-notes): a type is keyed by its name, a field by
+// "<type>.<field>", an argument by "<type>.<field>.<arg>". The overlay is
+// source-agnostic (never activity-gated) and orphan rows are legal; a row with
+// a NULL description is a vector seed (D24) and leaves the generated text
+// intact. This is the single key convention shared with the SchemaAnnotator
+// writer.
+
+const (
+	annotationType     = "type"
+	annotationField    = "field"
+	annotationArgument = "argument"
+)
+
+// applyAnnotations overrides def's descriptions — the type itself, its fields
+// and their arguments — from catalog.annotations. One query loads the type row
+// and every field/argument row beneath it (entity_key prefix); rows are routed
+// by entity_kind and located by their dot-path key.
+func (s *Store) applyAnnotations(ctx context.Context, g *genContext, def *ast.Definition) error {
+	rows, err := g.readAnnotations(ctx, def.Name)
+	if err != nil {
+		return err
+	}
+	prefix := def.Name + "."
+	for _, a := range rows {
+		switch a.kind {
+		case annotationType:
+			def.Description = a.description
+		case annotationField:
+			if f := def.Fields.ForName(strings.TrimPrefix(a.key, prefix)); f != nil {
+				f.Description = a.description
+			}
+		case annotationArgument:
+			fieldName, argName, ok := strings.Cut(strings.TrimPrefix(a.key, prefix), ".")
+			if !ok {
+				continue
+			}
+			if f := def.Fields.ForName(fieldName); f != nil {
+				if arg := f.Arguments.ForName(argName); arg != nil {
+					arg.Description = a.description
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// annotationRow is one curation row that carries text (seeds are skipped).
+type annotationRow struct {
+	kind        string
+	key         string
+	description string
+}
+
+// readAnnotations loads the type/field/argument curation rows for one type:
+// the type row (entity_key = typeName) and everything beneath it (entity_key
+// starts with "typeName."). Seed rows (NULL description) are dropped.
+func (g *genContext) readAnnotations(ctx context.Context, typeName string) ([]annotationRow, error) {
+	conn, err := g.s.pool.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read annotations %s: %w", typeName, err)
+	}
+	defer conn.Close()
+	rows, err := conn.Query(ctx, `SELECT entity_kind, entity_key, description
+		FROM core.catalog.annotations
+		WHERE entity_kind IN (`+lit(annotationType)+`, `+lit(annotationField)+`, `+lit(annotationArgument)+`)
+		  AND (entity_key = `+lit(typeName)+` OR starts_with(entity_key, `+lit(typeName+".")+`))`)
+	if err != nil {
+		return nil, fmt.Errorf("read annotations %s: %w", typeName, err)
+	}
+	defer rows.Close()
+	var out []annotationRow
+	for rows.Next() {
+		var kind, key string
+		var desc sql.NullString
+		if err := rows.Scan(&kind, &key, &desc); err != nil {
+			return nil, fmt.Errorf("read annotations %s: %w", typeName, err)
+		}
+		if !desc.Valid {
+			continue // seed row — no curated text
+		}
+		out = append(out, annotationRow{kind: kind, key: key, description: desc.String})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read annotations %s: %w", typeName, err)
+	}
+	return out, nil
+}

--- a/pkg/catalog/store/annotations_test.go
+++ b/pkg/catalog/store/annotations_test.go
@@ -1,0 +1,61 @@
+//go:build duckdb_arrow
+
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAnnotationOverlay pins the curation overlay applied at the end of
+// ForName: a catalog.annotations row overrides the description of a type, a
+// field or an argument by its dot-path key, over both a source-provided and a
+// default (generated) description. A NULL-text seed row leaves the generated
+// text intact.
+func TestAnnotationOverlay(t *testing.T) {
+	store, ctx := storeForSources(t, genMultiFixtures)
+
+	annotate(t, store.pool, `('type', 'shop_items', NULL, 'Curated shop item type')`)
+	annotate(t, store.pool, `('field', 'shop_items.name', 'shop_items', 'Curated name field')`)
+	// A default-described synthetic member (module-root select field) — the
+	// overlay must win over the "Query shop_items objects" default.
+	annotate(t, store.pool, `('field', '_module_shop_query.items', '_module_shop_query', 'Curated items query')`)
+	// An argument of that same root field.
+	annotate(t, store.pool, `('argument', '_module_shop_query.items.limit', '_module_shop_query.items', 'At most N items')`)
+	// A seed row (NULL text) must NOT blank the generated description.
+	annotate(t, store.pool, `('field', 'shop_items.price', 'shop_items', NULL)`)
+
+	items := store.ForName(ctx, "shop_items")
+	require.NotNil(t, items)
+	assert.Equal(t, "Curated shop item type", items.Description)
+	assert.Equal(t, "Curated name field", items.Fields.ForName("name").Description)
+	assert.Empty(t, items.Fields.ForName("price").Description, "seed row leaves the field blank")
+
+	root := store.ForName(ctx, "_module_shop_query")
+	require.NotNil(t, root)
+	itemsField := root.Fields.ForName("items")
+	require.NotNil(t, itemsField)
+	assert.Equal(t, "Curated items query", itemsField.Description, "overlay wins over the default")
+	assert.Equal(t, "At most N items", itemsField.Arguments.ForName("limit").Description)
+
+	// The pre-finalise generation carries neither the default nor the overlay.
+	rawItems := store.forNameRaw(ctx, "shop_items")
+	require.NotNil(t, rawItems)
+	assert.Empty(t, rawItems.Description, "overlay is a finalise-step concern")
+}
+
+// annotate inserts one VALUES tuple into catalog.annotations.
+func annotate(t *testing.T, pool *db.Pool, valuesTuple string) {
+	t.Helper()
+	ctx := context.Background()
+	conn, err := pool.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.Exec(ctx, `INSERT INTO core.catalog.annotations
+		(entity_kind, entity_key, parent, description) VALUES `+valuesTuple)
+	require.NoError(t, err)
+}

--- a/pkg/catalog/store/annotations_test.go
+++ b/pkg/catalog/store/annotations_test.go
@@ -11,23 +11,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAnnotationOverlay pins the curation overlay applied at the end of
-// ForName: a catalog.annotations row overrides the description of a type, a
-// field or an argument by its dot-path key, over both a source-provided and a
-// default (generated) description. A NULL-text seed row leaves the generated
-// text intact.
+// TestAnnotationOverlay pins the layered curation overlay applied at the end of
+// ForName. The LOGICAL layer keys by the source-level entity: data_object /
+// type on the definition, field on data-object fields (incl. the default-filled
+// synthetic ones), function on the module-root function fields. The GRAPHQL
+// layer keys the generated surface (gql_type / gql_field / gql_argument) and
+// runs AFTER the logical layer, so it wins. A NULL-text seed row is ignored.
 func TestAnnotationOverlay(t *testing.T) {
 	store, ctx := storeForSources(t, genMultiFixtures)
 
-	annotate(t, store.pool, `('type', 'shop_items', NULL, 'Curated shop item type')`)
+	// LOGICAL — a data object and one of its fields.
+	annotate(t, store.pool, `('data_object', 'shop_items', NULL, 'Curated shop item type')`)
 	annotate(t, store.pool, `('field', 'shop_items.name', 'shop_items', 'Curated name field')`)
-	// A default-described synthetic member (module-root select field) — the
-	// overlay must win over the "Query shop_items objects" default.
-	annotate(t, store.pool, `('field', '_module_shop_query.items', '_module_shop_query', 'Curated items query')`)
-	// An argument of that same root field.
-	annotate(t, store.pool, `('argument', '_module_shop_query.items.limit', '_module_shop_query.items', 'At most N items')`)
 	// A seed row (NULL text) must NOT blank the generated description.
 	annotate(t, store.pool, `('field', 'shop_items.price', 'shop_items', NULL)`)
+	// LOGICAL — a function keyed module.name, surfaced on the module function root.
+	annotate(t, store.pool, `('function', 'tools.slugify', 'tools', 'Slugify a string')`)
+
+	// GRAPHQL — a generated root field (overrides the "Query shop_items objects"
+	// default) and one of its arguments.
+	annotate(t, store.pool, `('gql_field', '_module_shop_query.items', '_module_shop_query', 'Curated items query')`)
+	annotate(t, store.pool, `('gql_argument', '_module_shop_query.items.limit', '_module_shop_query.items', 'At most N items')`)
 
 	items := store.ForName(ctx, "shop_items")
 	require.NotNil(t, items)
@@ -35,17 +39,36 @@ func TestAnnotationOverlay(t *testing.T) {
 	assert.Equal(t, "Curated name field", items.Fields.ForName("name").Description)
 	assert.Empty(t, items.Fields.ForName("price").Description, "seed row leaves the field blank")
 
+	tools := store.ForName(ctx, "_module_tools_function")
+	require.NotNil(t, tools)
+	assert.Equal(t, "Slugify a string", tools.Fields.ForName("slugify").Description,
+		"logical function overlay keyed module.name")
+
 	root := store.ForName(ctx, "_module_shop_query")
 	require.NotNil(t, root)
 	itemsField := root.Fields.ForName("items")
 	require.NotNil(t, itemsField)
-	assert.Equal(t, "Curated items query", itemsField.Description, "overlay wins over the default")
+	assert.Equal(t, "Curated items query", itemsField.Description, "gql overlay wins over the default")
 	assert.Equal(t, "At most N items", itemsField.Arguments.ForName("limit").Description)
 
 	// The pre-finalise generation carries neither the default nor the overlay.
 	rawItems := store.forNameRaw(ctx, "shop_items")
 	require.NotNil(t, rawItems)
 	assert.Empty(t, rawItems.Description, "overlay is a finalise-step concern")
+}
+
+// TestAnnotationGraphQLWinsLogical pins the layer precedence: a gql_type
+// curation overrides a data_object curation on the same reconstructed type.
+func TestAnnotationGraphQLWinsLogical(t *testing.T) {
+	store, ctx := storeForSources(t, genMultiFixtures)
+
+	annotate(t, store.pool, `('data_object', 'shop_items', NULL, 'Logical description')`)
+	assert.Equal(t, "Logical description", store.ForName(ctx, "shop_items").Description)
+
+	store.evictType("shop_items")
+	annotate(t, store.pool, `('gql_type', 'shop_items', NULL, 'GraphQL description')`)
+	assert.Equal(t, "GraphQL description", store.ForName(ctx, "shop_items").Description,
+		"the GraphQL layer runs last and wins")
 }
 
 // annotate inserts one VALUES tuple into catalog.annotations.

--- a/pkg/catalog/store/annotations_test.go
+++ b/pkg/catalog/store/annotations_test.go
@@ -37,7 +37,8 @@ func TestAnnotationOverlay(t *testing.T) {
 	require.NotNil(t, items)
 	assert.Equal(t, "Curated shop item type", items.Description)
 	assert.Equal(t, "Curated name field", items.Fields.ForName("name").Description)
-	assert.Empty(t, items.Fields.ForName("price").Description, "seed row leaves the field blank")
+	assert.Equal(t, "The item price", items.Fields.ForName("price").Description,
+		"seed row leaves the source-provided text intact")
 
 	tools := store.ForName(ctx, "_module_tools_function")
 	require.NotNil(t, tools)
@@ -55,6 +56,38 @@ func TestAnnotationOverlay(t *testing.T) {
 	rawItems := store.forNameRaw(ctx, "shop_items")
 	require.NotNil(t, rawItems)
 	assert.Empty(t, rawItems.Description, "overlay is a finalise-step concern")
+}
+
+// TestAnnotationDerivedInheritance pins the implicit inheritance: derived types
+// (filters / mutation inputs / aggregations) read their base through ForName —
+// already carrying the curation — so a curated base field shows on the derived
+// types' same-named fields without any per-derived-type rows. A direct
+// gql_field row on the derived type still wins.
+func TestAnnotationDerivedInheritance(t *testing.T) {
+	store, ctx := storeForSources(t, genMultiFixtures)
+
+	annotate(t, store.pool, `('field', 'shop_items.name', 'shop_items', 'Curated name field')`)
+	// A direct gql curation on the FILTER's other field must survive inheritance.
+	annotate(t, store.pool, `('gql_field', 'shop_items_filter.price', 'shop_items_filter', 'Filter by price')`)
+
+	filter := store.ForName(ctx, "shop_items_filter")
+	require.NotNil(t, filter)
+	assert.Equal(t, "Curated name field", filter.Fields.ForName("name").Description,
+		"filter field inherits the base field curation")
+	assert.Equal(t, "Filter by price", filter.Fields.ForName("price").Description,
+		"direct gql curation on the derived type wins")
+
+	agg := store.ForName(ctx, "_shop_items_aggregation")
+	require.NotNil(t, agg)
+	assert.Equal(t, "Curated name field", agg.Fields.ForName("name").Description,
+		"aggregation twin inherits the base field curation")
+	assert.Equal(t, "The item price", agg.Fields.ForName("price").Description,
+		"aggregation twin inherits the SOURCE description too — no curation needed")
+
+	mut := store.ForName(ctx, "shop_items_mut_input_data")
+	require.NotNil(t, mut)
+	assert.Equal(t, "Curated name field", mut.Fields.ForName("name").Description,
+		"mutation input inherits the base field curation")
 }
 
 // TestAnnotationGraphQLWinsLogical pins the layer precedence: a gql_type

--- a/pkg/catalog/store/cache.go
+++ b/pkg/catalog/store/cache.go
@@ -177,6 +177,21 @@ func (c *defCache) evict(name string) {
 	c.types.Remove(name)
 }
 
+// evictFamily drops a base definition plus every cached name isDerived reports
+// as derived from it — the write-side closure for a field curation, whose
+// description is INHERITED by the derived types' same-named fields.
+func (c *defCache) evictFamily(base string, isDerived func(name string) bool) {
+	if c == nil {
+		return
+	}
+	c.types.Remove(base)
+	for _, name := range c.types.Keys() {
+		if isDerived(name) {
+			c.types.Remove(name)
+		}
+	}
+}
+
 // invalidateAll purges the cache.
 func (c *defCache) invalidateAll() {
 	if c == nil {

--- a/pkg/catalog/store/cache.go
+++ b/pkg/catalog/store/cache.go
@@ -166,6 +166,17 @@ func (c *defCache) invalidate(source string, alsoEvict func(name string) bool) {
 	}
 }
 
+// evict drops a single cached definition by name — the targeted invalidation
+// for an annotation write, which changes only that one type's assembled
+// definition (its own description and its fields'/arguments' descriptions).
+// Remove fires onEvict, which strips the entry's source-index memberships.
+func (c *defCache) evict(name string) {
+	if c == nil {
+		return
+	}
+	c.types.Remove(name)
+}
+
 // invalidateAll purges the cache.
 func (c *defCache) invalidateAll() {
 	if c == nil {

--- a/pkg/catalog/store/descriptions.go
+++ b/pkg/catalog/store/descriptions.go
@@ -16,19 +16,31 @@ import (
 //      leaves blank — the module-root data-object fields and the cross-source
 //      shared-type members (_join / _spatial / _h3_data_query and their
 //      aggregation twins);
-//   2. (upcoming) the annotation overlay, which overrides any of these.
+//   2. the logical-model annotation overlay (data_object / type / field /
+//      function curation), then
+//   3. the GraphQL annotation overlay (gql_type / gql_field / gql_argument),
+//      each layer overriding the previous where a curation row exists.
 //
-// Only EMPTY descriptions are filled — a source-provided or generator-provided
-// description always wins. These defaults are store-only enrichment beyond the
+// Only EMPTY descriptions are filled by the defaults — a source- or
+// generator-provided description always wins; the overlays override
+// unconditionally. These defaults are store-only enrichment beyond the
 // (retiring) compiler; the golden parity harness compares the pre-finalise
 // generation (forNameRaw), so they do not drift the oracle.
 
 // finalizeDescriptions decorates a freshly built definition in place: the
-// default descriptions first, then the annotation overlay (which overrides
-// any of them where a curation row exists).
+// default descriptions first, then the logical overlay, then the GraphQL
+// overlay. The two overlays share one name-anchored annotation read.
 func (s *Store) finalizeDescriptions(ctx context.Context, g *genContext, def *ast.Definition) error {
 	applyDefaultDescriptions(def)
-	return s.applyAnnotations(ctx, g, def)
+	rows, err := g.readAnnotationsByName(ctx, def.Name)
+	if err != nil {
+		return err
+	}
+	if err := s.applyLogicalAnnotations(ctx, g, def, rows); err != nil {
+		return err
+	}
+	s.applyGraphQLAnnotations(def, rows)
+	return nil
 }
 
 // sharedKind labels a cross-source shared query type for its member wording.

--- a/pkg/catalog/store/descriptions.go
+++ b/pkg/catalog/store/descriptions.go
@@ -23,10 +23,12 @@ import (
 // (retiring) compiler; the golden parity harness compares the pre-finalise
 // generation (forNameRaw), so they do not drift the oracle.
 
-// finalizeDescriptions decorates a freshly built definition in place.
-func (s *Store) finalizeDescriptions(_ context.Context, _ *genContext, def *ast.Definition) error {
+// finalizeDescriptions decorates a freshly built definition in place: the
+// default descriptions first, then the annotation overlay (which overrides
+// any of them where a curation row exists).
+func (s *Store) finalizeDescriptions(ctx context.Context, g *genContext, def *ast.Definition) error {
 	applyDefaultDescriptions(def)
-	return nil
+	return s.applyAnnotations(ctx, g, def)
 }
 
 // sharedKind labels a cross-source shared query type for its member wording.

--- a/pkg/catalog/store/descriptions.go
+++ b/pkg/catalog/store/descriptions.go
@@ -1,0 +1,202 @@
+package store
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// Description finalisation runs at the END of ForName, over a freshly built
+// (non-system) definition, and is the single place the store curates human
+// descriptions:
+//
+//   1. default descriptions for synthetic query members that the source schema
+//      leaves blank — the module-root data-object fields and the cross-source
+//      shared-type members (_join / _spatial / _h3_data_query and their
+//      aggregation twins);
+//   2. (upcoming) the annotation overlay, which overrides any of these.
+//
+// Only EMPTY descriptions are filled — a source-provided or generator-provided
+// description always wins. These defaults are store-only enrichment beyond the
+// (retiring) compiler; the golden parity harness compares the pre-finalise
+// generation (forNameRaw), so they do not drift the oracle.
+
+// finalizeDescriptions decorates a freshly built definition in place.
+func (s *Store) finalizeDescriptions(_ context.Context, _ *genContext, def *ast.Definition) error {
+	applyDefaultDescriptions(def)
+	return nil
+}
+
+// sharedKind labels a cross-source shared query type for its member wording.
+type sharedKind int
+
+const (
+	sharedJoin sharedKind = iota
+	sharedSpatial
+	sharedH3
+)
+
+// sharedQueryKinds maps each shared query type to its member wording.
+var sharedQueryKinds = map[string]sharedKind{
+	"_join":                sharedJoin,
+	"_join_aggregation":    sharedJoin,
+	"_spatial":             sharedSpatial,
+	"_spatial_aggregation": sharedSpatial,
+	"_h3_data_query":       sharedH3,
+}
+
+// applyDefaultDescriptions fills empty descriptions on the synthetic query
+// members of a definition: the shared-type members by their shared kind, the
+// module-root data-object fields by their query/mutation shape.
+func applyDefaultDescriptions(def *ast.Definition) {
+	if kind, ok := sharedQueryKinds[def.Name]; ok {
+		for _, f := range def.Fields {
+			if f.Description == "" {
+				f.Description = sharedMemberDescription(kind, f)
+			}
+			enrichMemberArgs(f)
+		}
+		return
+	}
+	if !isRootTypeName(def.Name) {
+		return
+	}
+	for _, f := range def.Fields {
+		if f.Description == "" {
+			f.Description = rootShapeDescription(f)
+		}
+		enrichMemberArgs(f)
+	}
+}
+
+// isRootTypeName reports the module-root types (top-level and per-module).
+func isRootTypeName(name string) bool {
+	switch name {
+	case base.QueryBaseName, base.MutationBaseName, base.SubscriptionBaseName,
+		base.FunctionTypeName, base.FunctionMutationTypeName:
+		return true
+	}
+	return strings.HasPrefix(name, "_module_")
+}
+
+// rootShapeDescription is the default for a module-root data-object field,
+// derived from its @query / @mutation shape marker. Aggregation shapes already
+// carry a generated description, so they are not covered here (they are never
+// empty); a field without a shape marker (a child-module gateway, a function)
+// returns "" and keeps whatever it had.
+func rootShapeDescription(f *ast.FieldDefinition) string {
+	if d := f.Directives.ForName(base.QueryDirectiveName); d != nil {
+		obj := directiveArg(d, base.ArgName)
+		switch directiveArg(d, base.ArgType) {
+		case base.QueryTypeTextSelect:
+			return "Query " + obj + " objects"
+		case base.QueryTypeTextSelectOne:
+			return "Query a single " + obj + " object"
+		}
+	}
+	if d := f.Directives.ForName(base.MutationDirectiveName); d != nil {
+		obj := directiveArg(d, base.ArgName)
+		switch directiveArg(d, base.ArgType) {
+		case "INSERT":
+			return "Insert " + obj + " objects"
+		case "UPDATE":
+			return "Update " + obj + " objects"
+		case "DELETE":
+			return "Delete " + obj + " objects"
+		}
+	}
+	return ""
+}
+
+// sharedMemberSubtype classifies a shared-type member as select / aggregation /
+// bucket aggregation from its aggregation-query marker.
+type sharedMemberSubtype int
+
+const (
+	memberSelect sharedMemberSubtype = iota
+	memberAgg
+	memberBucket
+)
+
+func sharedMemberOf(f *ast.FieldDefinition) (sharedMemberSubtype, string) {
+	if d := f.Directives.ForName(base.FieldAggregationQueryDirectiveName); d != nil {
+		if directiveArg(d, base.ArgIsBucket) == "true" {
+			return memberBucket, directiveArg(d, base.ArgName)
+		}
+		return memberAgg, directiveArg(d, base.ArgName)
+	}
+	if d := f.Directives.ForName(base.QueryDirectiveName); d != nil {
+		return memberSelect, directiveArg(d, base.ArgName)
+	}
+	return memberSelect, f.Name
+}
+
+// sharedMemberDescription is the default for a per-object member of a shared
+// query type, worded by the shared kind and the member subtype.
+func sharedMemberDescription(kind sharedKind, f *ast.FieldDefinition) string {
+	sub, obj := sharedMemberOf(f)
+	switch kind {
+	case sharedJoin:
+		switch sub {
+		case memberBucket:
+			return "Bucket aggregation of " + obj + " records joined to the query"
+		case memberAgg:
+			return "Aggregation of " + obj + " records joined to the query"
+		default:
+			return "The " + obj + " records joined to the query"
+		}
+	case sharedSpatial:
+		switch sub {
+		case memberBucket:
+			return "Spatial bucket aggregation of " + obj + " records"
+		case memberAgg:
+			return "Spatial aggregation of " + obj + " records"
+		default:
+			return "The " + obj + " records for spatial queries"
+		}
+	case sharedH3:
+		switch sub {
+		case memberBucket:
+			return "H3 bucket aggregation of " + obj + " records"
+		case memberAgg:
+			return "H3 aggregation of " + obj + " records"
+		default:
+			return "The " + obj + " records for H3 spatial queries"
+		}
+	}
+	return ""
+}
+
+// enrichMemberArgs fills the empty descriptions of the structural arguments a
+// synthetic query member carries — the mutation filter/data inputs and the
+// unique-select view args the shape builders construct inline and leave bare.
+// The standard query arguments (order_by/limit/offset/distinct_on/inner/
+// nested_*/similarity/semantic) are built by the shared rules.* arg profiles
+// with base.Desc* descriptions already, so they are non-empty and untouched
+// here — this only backfills the canonical description onto the inline-built
+// ones, keyed by the same constants for a single source of truth.
+func enrichMemberArgs(f *ast.FieldDefinition) {
+	for _, a := range f.Arguments {
+		if a.Description != "" {
+			continue
+		}
+		switch a.Name {
+		case "filter":
+			a.Description = base.DescFilter
+		case "data":
+			a.Description = base.DescMutationData
+		case "args":
+			a.Description = base.DescArgs
+		}
+	}
+}
+
+// directiveArg returns a directive argument's raw value, or "" when absent.
+func directiveArg(d *ast.Directive, name string) string {
+	if a := d.Arguments.ForName(name); a != nil && a.Value != nil {
+		return a.Value.Raw
+	}
+	return ""
+}

--- a/pkg/catalog/store/descriptions_test.go
+++ b/pkg/catalog/store/descriptions_test.go
@@ -1,0 +1,76 @@
+//go:build duckdb_arrow
+
+package store
+
+import (
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// TestDefaultDescriptions pins the store-only description enrichment applied at
+// the end of ForName: synthetic query members that the source schema leaves
+// blank (module-root data-object fields, shared-type members, their structural
+// arguments) receive default descriptions, while the pre-finalise generation
+// (forNameRaw) stays blank — so the enrichment is a finalise-step concern, not
+// baked into the parity-checked generation.
+func TestDefaultDescriptions(t *testing.T) {
+	store, ctx := storeForSources(t, genMultiFixtures)
+
+	fieldDesc := func(typeName, fieldName string) string {
+		def := store.ForName(ctx, typeName)
+		require.NotNil(t, def, "type %s served", typeName)
+		f := def.Fields.ForName(fieldName)
+		require.NotNil(t, f, "%s.%s present", typeName, fieldName)
+		return f.Description
+	}
+
+	// Module-root data-object fields, worded by their query/mutation shape.
+	assert.Equal(t, "Query shop_items objects", fieldDesc("_module_shop_query", "items"))
+	assert.Equal(t, "Insert shop_items objects", fieldDesc("_module_shop_mutation", "insert_items"))
+	assert.Equal(t, "Update shop_items objects", fieldDesc("_module_shop_mutation", "update_items"))
+	assert.Equal(t, "Delete shop_items objects", fieldDesc("_module_shop_mutation", "delete_items"))
+
+	// Aggregation root fields already carry a generated description — the
+	// default must NOT overwrite it.
+	assert.Equal(t, "The aggregation for items", fieldDesc("_module_shop_query", "items_aggregation"))
+
+	// Shared-type members, worded by the shared kind and member subtype.
+	assert.Equal(t, "The shop_items records joined to the query",
+		fieldDesc("_join", "shop_items"))
+	assert.Equal(t, "Aggregation of shop_items records joined to the query",
+		fieldDesc("_join", "shop_items_aggregation"))
+	assert.Equal(t, "Bucket aggregation of shop_items records joined to the query",
+		fieldDesc("_join", "shop_items_bucket_aggregation"))
+	assert.Equal(t, "Aggregation of shop_items records joined to the query",
+		fieldDesc("_join_aggregation", "shop_items"))
+
+	// Structural arguments the generators leave bare.
+	insertItems := store.ForName(ctx, "_module_shop_mutation").Fields.ForName("insert_items")
+	require.NotNil(t, insertItems)
+	assert.Equal(t, base.DescMutationData, argDesc(t, insertItems, "data"))
+	updateItems := store.ForName(ctx, "_module_shop_mutation").Fields.ForName("update_items")
+	require.NotNil(t, updateItems)
+	assert.Equal(t, base.DescFilter, argDesc(t, updateItems, "filter"))
+
+	// The pre-finalise generation is blank on exactly these members — the
+	// enrichment is a finalise-step concern, invisible to the parity oracle.
+	rawJoin := store.forNameRaw(ctx, "_join")
+	require.NotNil(t, rawJoin)
+	assert.Empty(t, rawJoin.Fields.ForName("shop_items").Description,
+		"pre-finalise shared member carries no description")
+	rawQuery := store.forNameRaw(ctx, "_module_shop_query")
+	require.NotNil(t, rawQuery)
+	assert.Empty(t, rawQuery.Fields.ForName("items").Description,
+		"pre-finalise root field carries no description")
+}
+
+func argDesc(t *testing.T, f *ast.FieldDefinition, name string) string {
+	t.Helper()
+	a := f.Arguments.ForName(name)
+	require.NotNil(t, a, "argument %s present on %s", name, f.Name)
+	return a.Description
+}

--- a/pkg/catalog/store/embeddings.go
+++ b/pkg/catalog/store/embeddings.go
@@ -1,0 +1,41 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	qetypes "github.com/hugr-lab/query-engine/types"
+)
+
+// The store owns its own copies of the embedding-text helpers rather than
+// importing the retiring catalog/db package: the entity storage is the
+// long-term home of curation, and it must not depend on the compiled provider
+// it replaces. The wording matches catalog/db so seeds and curations produced
+// by either path embed to comparable vectors.
+
+// embeddingText returns the best available text to embed, falling back through
+// longDesc → desc → syntheticDesc (an empty result means nothing to embed).
+func embeddingText(longDesc, desc, syntheticDesc string) string {
+	if longDesc != "" {
+		return longDesc
+	}
+	if desc != "" {
+		return desc
+	}
+	return syntheticDesc
+}
+
+// embed computes an embedding vector for text, or (nil, nil) when embeddings
+// are not configured (no embedder or zero vector size) or the text is empty —
+// the caller then writes a curation row without a vector, leaving any load-time
+// seed vector untouched.
+func (s *Store) embed(ctx context.Context, text string) (qetypes.Vector, error) {
+	if s.embedder == nil || s.vecSize == 0 || text == "" {
+		return nil, nil
+	}
+	res, err := s.embedder.CreateEmbedding(ctx, text)
+	if err != nil {
+		return nil, fmt.Errorf("embed %q: %w", text, err)
+	}
+	return res.Vector, nil
+}

--- a/pkg/catalog/store/embeddings.go
+++ b/pkg/catalog/store/embeddings.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	qetypes "github.com/hugr-lab/query-engine/types"
 )
@@ -25,6 +27,27 @@ func embeddingText(longDesc, desc, syntheticDesc string) string {
 	return syntheticDesc
 }
 
+// syntheticDescription builds a fallback description from entity metadata, used
+// when no human-written description is available (mirrors catalog/db) — the
+// seed embedding text for a description-less entity.
+func syntheticDescription(hugrType, entityName, parentName, moduleName, catalog string) string {
+	var parts []string
+	if hugrType != "" {
+		parts = append(parts, hugrType)
+	}
+	parts = append(parts, entityName)
+	if parentName != "" {
+		parts = append(parts, fmt.Sprintf("on %s", parentName))
+	}
+	if moduleName != "" {
+		parts = append(parts, fmt.Sprintf("in module %s", moduleName))
+	}
+	if catalog != "" {
+		parts = append(parts, fmt.Sprintf("from catalog %s", catalog))
+	}
+	return strings.Join(parts, " ")
+}
+
 // embed computes an embedding vector for text, or (nil, nil) when embeddings
 // are not configured (no embedder or zero vector size) or the text is empty —
 // the caller then writes a curation row without a vector, leaving any load-time
@@ -38,4 +61,34 @@ func (s *Store) embed(ctx context.Context, text string) (qetypes.Vector, error) 
 		return nil, fmt.Errorf("embed %q: %w", text, err)
 	}
 	return res.Vector, nil
+}
+
+// embedBatch computes embedding vectors for many texts in one call — the seed
+// path embeds every entity of a source at once. Returns nil when embeddings are
+// not configured.
+func (s *Store) embedBatch(ctx context.Context, texts []string) ([]qetypes.Vector, error) {
+	if s.embedder == nil || s.vecSize == 0 || len(texts) == 0 {
+		return nil, nil
+	}
+	res, err := s.embedder.CreateEmbeddings(ctx, texts)
+	if err != nil {
+		return nil, fmt.Errorf("embed batch (%d): %w", len(texts), err)
+	}
+	return res.Vectors, nil
+}
+
+// vecLiteral renders a vector as a cross-engine SQL STRING literal
+// '[v1,v2,...]'. This is the ONLY vec write form that casts on BOTH CoreDB
+// backends: DuckDB casts VARCHAR→FLOAT[N], and an attached PostgreSQL casts
+// text→vector(N) through the postgres extension — pinned by the CoreDB
+// statement inventory (core-db/hugr_catalog_test.go probe E1/E2). A typed
+// DuckDB array literal (ARRAY[...]::FLOAT[N]) would NOT reach a pgvector column.
+// Fixed-notation formatting at float32 precision (the column width) keeps the
+// text free of exponents both backends would have to re-parse.
+func vecLiteral(vec qetypes.Vector) string {
+	parts := make([]string, len(vec))
+	for i, f := range vec {
+		parts[i] = strconv.FormatFloat(f, 'f', -1, 32)
+	}
+	return lit("[" + strings.Join(parts, ",") + "]")
 }

--- a/pkg/catalog/store/embeddings.go
+++ b/pkg/catalog/store/embeddings.go
@@ -63,18 +63,28 @@ func (s *Store) embed(ctx context.Context, text string) (qetypes.Vector, error) 
 	return res.Vector, nil
 }
 
-// embedBatch computes embedding vectors for many texts in one call — the seed
-// path embeds every entity of a source at once. Returns nil when embeddings are
-// not configured.
+// embedBatchSize bounds one CreateEmbeddings call — embedding backends cap
+// their batch sizes, and a large source (thousands of fields) would otherwise
+// go out in a single oversized request and fail wholesale.
+const embedBatchSize = 256
+
+// embedBatch computes embedding vectors for many texts — the seed path embeds
+// every entity of a source, chunked by embedBatchSize. Returns nil when
+// embeddings are not configured.
 func (s *Store) embedBatch(ctx context.Context, texts []string) ([]qetypes.Vector, error) {
 	if s.embedder == nil || s.vecSize == 0 || len(texts) == 0 {
 		return nil, nil
 	}
-	res, err := s.embedder.CreateEmbeddings(ctx, texts)
-	if err != nil {
-		return nil, fmt.Errorf("embed batch (%d): %w", len(texts), err)
+	out := make([]qetypes.Vector, 0, len(texts))
+	for start := 0; start < len(texts); start += embedBatchSize {
+		end := min(start+embedBatchSize, len(texts))
+		res, err := s.embedder.CreateEmbeddings(ctx, texts[start:end])
+		if err != nil {
+			return nil, fmt.Errorf("embed batch %d..%d of %d: %w", start, end, len(texts), err)
+		}
+		out = append(out, res.Vectors...)
 	}
-	return res.Vectors, nil
+	return out, nil
 }
 
 // vecLiteral renders a vector as a cross-engine SQL STRING literal

--- a/pkg/catalog/store/gen.go
+++ b/pkg/catalog/store/gen.go
@@ -36,6 +36,13 @@ import (
 type genContext struct {
 	s *Store
 
+	// derivedBase is the base entity name when THIS session resolved a derived
+	// type (filter / mutation input / aggregation) — recorded by
+	// resolveDerivedType from the matched rule, consumed by the description
+	// finalisation to inherit the base's field descriptions. Only derived rules
+	// set it, so the inheritance chain is structurally one level deep.
+	derivedBase string
+
 	// touched is the set of data sources whose ROWS the session read —
 	// exactly the sources whose rewrite can change the produced definition
 	// (row-level provenance; absence dependencies are closed on the write
@@ -165,6 +172,8 @@ var derivedRules = []derivedRule{
 }
 
 // resolveDerivedType (5) generates a derived type from its base data object.
+// The successful rule's base name is recorded on the session — the description
+// finalisation inherits the base's field descriptions from it.
 func resolveDerivedType(ctx context.Context, g *genContext, name string) (*ast.Definition, error) {
 	for i := range derivedRules {
 		r := &derivedRules[i]
@@ -177,6 +186,7 @@ func resolveDerivedType(ctx context.Context, g *genContext, name string) (*ast.D
 			return nil, err
 		}
 		if def != nil {
+			g.derivedBase = baseName
 			return def, nil
 		}
 	}

--- a/pkg/catalog/store/gen_golden_test.go
+++ b/pkg/catalog/store/gen_golden_test.go
@@ -499,6 +499,7 @@ type items @table(name: "items") {
   id: Int! @pk
   category_id: Int @field_references(references_name: "categories", field: "id", query: "category", references_query: "items")
   name: String!
+  "The item price"
   price: Float
 }
 

--- a/pkg/catalog/store/gen_golden_test.go
+++ b/pkg/catalog/store/gen_golden_test.go
@@ -625,7 +625,11 @@ func TestGenGoldenMultiSource(t *testing.T) {
 
 // assertGenParity: each covered name must be served by the store structurally
 // identical to the fully-compiled reference (member order is not part of the
-// contract — definitions are normalized before comparison).
+// contract — definitions are normalized before comparison). The comparison is
+// against the store's PRE-FINALISE generation (forNameRaw): the store enriches
+// descriptions on synthetic query members beyond the retiring compiler, and
+// that store-only enrichment is verified separately (descriptions_test.go), not
+// by the base-generation oracle.
 func assertGenParity(t *testing.T, ctx context.Context, s *Store, ref *static.Provider, names []string) {
 	t.Helper()
 	for _, name := range names {
@@ -635,7 +639,7 @@ func assertGenParity(t *testing.T, ctx context.Context, s *Store, ref *static.Pr
 		if !assert.NotNil(t, want, "reference must contain %s", name) {
 			continue
 		}
-		got := s.ForName(ctx, name)
+		got := s.forNameRaw(ctx, name)
 		if !assert.NotNil(t, got, "store must serve %s", name) {
 			continue
 		}

--- a/pkg/catalog/store/gen_live_test.go
+++ b/pkg/catalog/store/gen_live_test.go
@@ -105,17 +105,26 @@ func TestGenGoldenLiveCorpus(t *testing.T) {
 	diffs, supersets, oldPathQuirks := 0, 0, 0
 	for _, name := range names {
 		want := schema.Types[name]
-		got := store.ForName(ctx, name)
+		// Cache parity: a repeat read serves the SAME definition (cached
+		// classes by pointer identity, static classes are stable anyway).
+		cached := store.ForName(ctx, name)
+		if cached == nil {
+			diffs++
+			assert.NotNil(t, cached, "store must serve %s", name)
+			continue
+		}
+		if cached2 := store.ForName(ctx, name); cached2 != cached {
+			diffs++
+			assert.Fail(t, "cache parity", "second read of %s is a different definition", name)
+		}
+		// SDL parity is against the PRE-FINALISE generation: the store enriches
+		// synthetic-member descriptions beyond the retiring compiler, which is
+		// verified separately (descriptions_test.go), not by this oracle.
+		got := store.forNameRaw(ctx, name)
 		if got == nil {
 			diffs++
 			assert.NotNil(t, got, "store must serve %s", name)
 			continue
-		}
-		// Cache parity: a repeat read serves the SAME definition (cached
-		// classes by pointer identity, static classes are stable anyway).
-		if got2 := store.ForName(ctx, name); got2 != got {
-			diffs++
-			assert.Fail(t, "cache parity", "second read of %s is a different definition", name)
 		}
 		// Old-path quirks tolerated on the REFERENCE side (logged, never
 		// silent): @wfs* directives (intentionally dropped from the store —

--- a/pkg/catalog/store/provider.go
+++ b/pkg/catalog/store/provider.go
@@ -1,0 +1,213 @@
+package store
+
+import (
+	"context"
+	"iter"
+	"slices"
+	"sort"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// The store implements the full read-only base.Provider surface. ForName (the
+// on-demand type synthesizer) lives in reconstruct.go; this file adds the rest
+// of the interface on top of it: the schema description, the operation roots,
+// directive delegation to the static prelude, the interface/union
+// relationships, and the whole-schema enumeration used by introspection.
+var _ base.Provider = (*Store)(nil)
+
+// Description returns the schema-level description. The entity store keeps no
+// root schema description — sources describe themselves through their modules
+// and data objects — so this is empty (the db provider is likewise empty when
+// no schema description was stored).
+func (s *Store) Description(_ context.Context) string { return "" }
+
+// QueryType / MutationType / SubscriptionType synthesize the top-level roots
+// through ForName: resolveModuleRoot builds each from its module members, so a
+// root with no members resolves to nil.
+func (s *Store) QueryType(ctx context.Context) *ast.Definition {
+	return s.ForName(ctx, base.QueryBaseName)
+}
+
+func (s *Store) MutationType(ctx context.Context) *ast.Definition {
+	return s.ForName(ctx, base.MutationBaseName)
+}
+
+func (s *Store) SubscriptionType(ctx context.Context) *ast.Definition {
+	return s.ForName(ctx, base.SubscriptionBaseName)
+}
+
+// DirectiveForName / DirectiveDefinitions delegate to the static prelude: the
+// whole directive set (system + hugr) is binary-owned; sources never define
+// directives, so the entity storage holds none.
+func (s *Store) DirectiveForName(ctx context.Context, name string) *ast.DirectiveDefinition {
+	return s.static.DirectiveForName(ctx, name)
+}
+
+func (s *Store) DirectiveDefinitions(ctx context.Context) iter.Seq2[string, *ast.DirectiveDefinition] {
+	return s.static.DirectiveDefinitions(ctx)
+}
+
+// Implements yields the interfaces the named type declares.
+func (s *Store) Implements(ctx context.Context, name string) iter.Seq[*ast.Definition] {
+	return func(yield func(*ast.Definition) bool) {
+		def := s.ForName(ctx, name)
+		if def == nil {
+			return
+		}
+		for _, iface := range def.Interfaces {
+			if d := s.ForName(ctx, iface); d != nil {
+				if !yield(d) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// PossibleTypes yields the concrete members of an interface or union. Unions
+// carry their members inline; interface implementors are found by scanning the
+// enumerable object types. Interfaces and unions are source-defined and rare,
+// and this is a cold validator/introspection path, so the scan is acceptable.
+func (s *Store) PossibleTypes(ctx context.Context, name string) iter.Seq[*ast.Definition] {
+	return func(yield func(*ast.Definition) bool) {
+		def := s.ForName(ctx, name)
+		if def == nil {
+			return
+		}
+		switch def.Kind {
+		case ast.Union:
+			for _, member := range def.Types {
+				if d := s.ForName(ctx, member); d != nil {
+					if !yield(d) {
+						return
+					}
+				}
+			}
+		case ast.Interface:
+			for def := range s.Definitions(ctx) {
+				if def.Kind == ast.Object && slices.Contains(def.Interfaces, name) {
+					if !yield(def) {
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
+// Types enumerates the whole compiled schema as (name, definition) pairs.
+func (s *Store) Types(ctx context.Context) iter.Seq2[string, *ast.Definition] {
+	return func(yield func(string, *ast.Definition) bool) {
+		for def := range s.Definitions(ctx) {
+			if !yield(def.Name, def) {
+				return
+			}
+		}
+	}
+}
+
+// Definitions enumerates every compiled definition the schema serves, by name.
+// The db provider lists a stored table; the entity store synthesizes derived
+// types on demand, so there is no table to list — the set is the reachability
+// closure of the schema from its roots (schemaTypeNames), each name resolved
+// through ForName.
+func (s *Store) Definitions(ctx context.Context) iter.Seq[*ast.Definition] {
+	return func(yield func(*ast.Definition) bool) {
+		for _, name := range s.schemaTypeNames(ctx) {
+			if def := s.ForName(ctx, name); def != nil {
+				if !yield(def) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// schemaSeeds are the fixed roots of the schema reachability walk: the system
+// prelude (scalars, introspection, directives' companion types), the top-level
+// operation roots and the shared system types. Everything else — data objects,
+// their derived families, the per-module roots, structural types — is reachable
+// from these through field and argument type references.
+func (s *Store) schemaSeeds(ctx context.Context) []string {
+	seeds := []string{
+		base.QueryBaseName, base.MutationBaseName, base.SubscriptionBaseName,
+		base.FunctionTypeName, base.FunctionMutationTypeName,
+	}
+	for i := range sharedTypeRules {
+		seeds = append(seeds, sharedTypeRules[i].name)
+	}
+	for name := range s.static.Types(ctx) {
+		seeds = append(seeds, name)
+	}
+	return seeds
+}
+
+// schemaTypeNames returns every compiled type name the schema serves, sorted —
+// the reachability closure from schemaSeeds. This is the GraphQL-introspection
+// set (`__schema.types` is the types reachable from the roots and directives):
+// the entity store synthesizes derived types on demand and would serve, e.g., a
+// _X_aggregation_sub_aggregation at any depth, but only the depths the schema
+// actually references are part of the served schema. Reachability captures the
+// derived families (X_filter, _X_aggregation and its used sub-aggregation
+// depth, X_mut_*_data, the per-module roots reached through the gateway fields,
+// structural aggregations) at exactly the depth the schema uses, with no suffix
+// grammar to keep in sync with the generators.
+func (s *Store) schemaTypeNames(ctx context.Context) []string {
+	return reachableTypeNames(ctx, s, s.schemaSeeds(ctx))
+}
+
+// reachableTypeNames is the breadth-first type closure of any provider from a
+// seed set: a seed that resolves contributes its referenced types and joins the
+// result; a name that does not resolve is dropped. It works against the
+// base.Provider surface (ForName only), so the same walk measures the store and
+// the fully-compiled reference identically.
+func reachableTypeNames(ctx context.Context, p base.Provider, seeds []string) []string {
+	seen := map[string]struct{}{}
+	var queue []string
+	enqueue := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		queue = append(queue, name)
+	}
+	for _, name := range seeds {
+		enqueue(name)
+	}
+	var served []string
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		def := p.ForName(ctx, name)
+		if def == nil {
+			continue
+		}
+		served = append(served, name)
+		for _, ref := range referencedTypeNames(def) {
+			enqueue(ref)
+		}
+	}
+	sort.Strings(served)
+	return served
+}
+
+// referencedTypeNames collects the named types a definition points at: its
+// interface and union members, and every field output type with its argument
+// types (input-object fields carry no arguments, so the same walk covers them).
+func referencedTypeNames(def *ast.Definition) []string {
+	var out []string
+	out = append(out, def.Interfaces...)
+	out = append(out, def.Types...)
+	for _, f := range def.Fields {
+		out = append(out, f.Type.Name())
+		for _, a := range f.Arguments {
+			out = append(out, a.Type.Name())
+		}
+	}
+	return out
+}

--- a/pkg/catalog/store/provider_test.go
+++ b/pkg/catalog/store/provider_test.go
@@ -1,0 +1,80 @@
+//go:build duckdb_arrow
+
+package store
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/catalog/compiler/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The store satisfies the full read-only Provider contract.
+var _ base.Provider = (*Store)(nil)
+
+// TestProviderTypesParity is the drift guard for the schema enumeration: the
+// type set the store's Types() serves must equal the reference schema's
+// reachable type set, on the multi-source fixture (prefix + AsModule +
+// read-only + extension). Both sides are measured by the SAME reachability walk
+// from the SAME seeds (roots + shared + system prelude), so the comparison is
+// apples-to-apples: the reference is a flat store of every generated type
+// including orphans no query can reach, but reachability excludes those on both
+// sides. A mismatch means the two schemas expose a different reachable surface
+// — a real generation divergence, not an enumeration artifact.
+func TestProviderTypesParity(t *testing.T) {
+	store, ctx := storeForSources(t, genMultiFixtures)
+	ref := goldenRefSources(t, genMultiFixtures)
+
+	seeds := store.schemaSeeds(ctx)
+	got := toSet(reachableTypeNames(ctx, store, seeds))
+	want := toSet(reachableTypeNames(ctx, ref, seeds))
+
+	assert.Equal(t, missingFrom(want, got), []string(nil),
+		"reachable in the reference but not served by the store")
+	assert.Equal(t, missingFrom(got, want), []string(nil),
+		"served by the store but not reachable in the reference")
+}
+
+func toSet(names []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		set[name] = struct{}{}
+	}
+	return set
+}
+
+// missingFrom returns the sorted keys of want that are absent from have.
+func missingFrom(want, have map[string]struct{}) []string {
+	var out []string
+	for name := range want {
+		if _, ok := have[name]; !ok {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestProviderRootsAndDirectives covers the trivial Provider surfaces: the
+// operation roots resolve through synthesis and the directive set is delegated
+// to the static prelude.
+func TestProviderRootsAndDirectives(t *testing.T) {
+	store, ctx := storeForSources(t, genMultiFixtures)
+
+	require.NotNil(t, store.QueryType(ctx), "Query root synthesized")
+	require.NotNil(t, store.MutationType(ctx), "Mutation root synthesized")
+
+	// Directive delegation: a well-known system directive resolves.
+	require.NotNil(t, store.DirectiveForName(ctx, base.CatalogDirectiveName),
+		"catalog directive delegated to the static prelude")
+
+	var directiveCount int
+	for range store.DirectiveDefinitions(ctx) {
+		directiveCount++
+	}
+	assert.Greater(t, directiveCount, 0, "directive set delegated to the static prelude")
+
+	assert.Empty(t, store.Description(ctx), "no root schema description")
+}

--- a/pkg/catalog/store/reconstruct.go
+++ b/pkg/catalog/store/reconstruct.go
@@ -48,6 +48,11 @@ var resolvers = []resolverEntry{
 // session. The catalog.Provider surface has no error channel, so a read
 // failure is logged here and served as nil — never cached (absence is a nil
 // WITHOUT an error and is simply not cached either).
+//
+// A freshly built (non-system) definition is finalised before caching:
+// description defaults for synthetic query members, and the annotation
+// overlay. System definitions come straight from the shared static prelude
+// and are neither finalised nor cached.
 func (s *Store) ForName(ctx context.Context, name string) *ast.Definition {
 	if def := s.cache.get(name); def != nil {
 		return def
@@ -58,31 +63,63 @@ func (s *Store) ForName(ctx context.Context, name string) *ast.Definition {
 		}
 		gen := s.gen.Load()
 		g := s.genCtx()
-		for i := range resolvers {
-			e := &resolvers[i]
-			def, err := e.resolve(ctx, g, name)
-			if err != nil {
-				logReadErr("resolve "+name, err)
-				return nil, nil
-			}
-			if def == nil {
-				continue
-			}
-			if !e.system {
-				sources := []string{allSources}
-				if !e.global {
-					sources = g.sourceList()
-				}
-				s.cache.put(name, sources, def, func() bool { return s.gen.Load() == gen })
-			}
+		def, sources, system, err := s.resolveByName(ctx, g, name)
+		if err != nil {
+			logReadErr("resolve "+name, err)
+			return nil, nil
+		}
+		if def == nil || system {
 			return def, nil
 		}
-		return nil, nil
+		if err := s.finalizeDescriptions(ctx, g, def); err != nil {
+			logReadErr("finalize "+name, err)
+			return nil, nil
+		}
+		s.cache.put(name, sources, def, func() bool { return s.gen.Load() == gen })
+		return def, nil
 	})
 	if v == nil {
 		return nil
 	}
 	return v.(*ast.Definition)
+}
+
+// resolveByName runs the resolver chain and returns the built definition, the
+// cache source list to index it under, and whether it is a system definition
+// (served from the shared static prelude — never cached, never finalised). A
+// nil definition means the name is not served.
+func (s *Store) resolveByName(ctx context.Context, g *genContext, name string) (*ast.Definition, []string, bool, error) {
+	for i := range resolvers {
+		e := &resolvers[i]
+		def, err := e.resolve(ctx, g, name)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		if def == nil {
+			continue
+		}
+		if e.system {
+			return def, nil, true, nil
+		}
+		sources := []string{allSources}
+		if !e.global {
+			sources = g.sourceList()
+		}
+		return def, sources, false, nil
+	}
+	return nil, nil, false, nil
+}
+
+// forNameRaw resolves a definition through the generator chain WITHOUT the
+// description finalisation or the read cache — the pre-enrichment generation
+// the golden parity harness compares against the fully-compiled reference.
+func (s *Store) forNameRaw(ctx context.Context, name string) *ast.Definition {
+	def, _, _, err := s.resolveByName(ctx, s.genCtx(), name)
+	if err != nil {
+		logReadErr("resolve "+name, err)
+		return nil
+	}
+	return def
 }
 
 // resolveSystemType (1) serves the binary-owned system layer.

--- a/pkg/catalog/store/seed.go
+++ b/pkg/catalog/store/seed.go
@@ -1,0 +1,252 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	qetypes "github.com/hugr-lab/query-engine/types"
+)
+
+// Annotation SEEDING (D24) makes every logical entity of a source vector-
+// searchable the moment its schema loads: on writeSource the store embeds each
+// entity's description (or a synthetic fallback) and writes a vec-only
+// annotation row — text columns stay NULL, marking it a SEED. It NEVER touches a
+// curated row (description / long_description set), so curation always wins and
+// survives reloads. Two write shapes:
+//   - MODULES are INSERT-ONLY (anti-join): a module's description lives ONLY in
+//     the curation (the source SDL carries none), so an existing module row —
+//     seed or curated — is never rewritten, not even to refresh its vector.
+//   - everything else refreshes its seed vector on reload (conditional upsert),
+//     since its description comes from the SDL and can change.
+//
+// The mirror is a SWEEP on deleteSource (the unregister primitive — NOT unload,
+// which only flips flags and keeps the rows): the source's seed rows are
+// removed, curated rows are kept as tolerated orphans. Both statement shapes
+// are the ones the CoreDB inventory pins as cross-engine
+// (core-db/hugr_catalog_test.go probe E2 / F2).
+
+// seedEntity is one entity to seed: its annotation identity plus the text to
+// embed into the seed vector.
+type seedEntity struct {
+	kind   string
+	key    string
+	parent string
+	text   string
+}
+
+// collectSeedEntities enumerates the logical entities of a written source — data
+// source, modules, data objects, fields (columns + relation navigation fields),
+// functions and residual types — each with the text to embed. Keyed by
+// (kind, key) so a duplicate never reaches the multi-row upsert (which would
+// fail on a repeated conflict target).
+func collectSeedEntities(d *desired, dataSource string) []seedEntity {
+	seen := map[string]struct{}{}
+	var out []seedEntity
+	add := func(kind, key, parent, text string) {
+		id := kind + "\x1f" + key
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		out = append(out, seedEntity{kind: kind, key: key, parent: parent, text: text})
+	}
+
+	add(kindDataSource, dataSource, "", syntheticDescription("catalog", dataSource, "", "", ""))
+	for _, m := range d.modules {
+		add(kindModule, m.Name, m.Parent,
+			embeddingText("", m.Description, syntheticDescription("module", m.Name, "", "", "")))
+	}
+	for _, o := range d.dataObjects {
+		add(kindDataObject, o.Name, "",
+			embeddingText("", o.Description, syntheticDescription("", o.Name, "", o.Module, o.DataSource)))
+	}
+	for _, f := range d.fields {
+		add(kindField, fieldKey(f.TypeName, f.Name), f.TypeName,
+			embeddingText("", f.Description, syntheticDescription("", f.Name, f.TypeName, "", f.DataSource)))
+	}
+	for _, r := range d.relations {
+		if r.SourceField != "" {
+			add(kindField, fieldKey(r.Source, r.SourceField), r.Source,
+				embeddingText("", r.SourceFieldDescription,
+					syntheticDescription("", r.SourceField, r.Source, "", r.DataSource)))
+		}
+		if r.DestinationField != "" {
+			add(kindField, fieldKey(r.Destination, r.DestinationField), r.Destination,
+				embeddingText("", r.DestinationFieldDescription,
+					syntheticDescription("", r.DestinationField, r.Destination, "", r.DataSource)))
+		}
+	}
+	for _, fn := range d.functions {
+		add(kindFunction, functionKey(fn.Module, fn.Name), fn.Module,
+			embeddingText("", fn.Description, syntheticDescription("", fn.Name, "", fn.Module, fn.DataSource)))
+	}
+	for _, t := range d.types {
+		add(kindType, t.Name, "",
+			embeddingText("", t.Description, syntheticDescription("", t.Name, "", t.Module, t.DataSource)))
+	}
+	return out
+}
+
+// seedRow is one embedded entity ready to persist: its annotation identity plus
+// the computed vector.
+type seedRow struct {
+	kind   string
+	key    string
+	parent string
+	vec    qetypes.Vector
+}
+
+// computeSeeds embeds every logical entity of a written source, OUTSIDE any
+// transaction — the embedder is a network call and must not be made while a DB
+// transaction holds locks (on an attached PostgreSQL CoreDB that would pin the
+// remote transaction for the whole round-trip). Returns nil when embeddings are
+// not configured. The caller treats an error as best-effort: it logs and writes
+// the source WITHOUT seeds, so an embedder outage never blocks schema loading
+// (the entity rows still carry the descriptions the overlay COALESCEs).
+func (s *Store) computeSeeds(ctx context.Context, d *desired, state SourceState) ([]seedRow, error) {
+	if s.embedder == nil || s.vecSize == 0 {
+		return nil, nil
+	}
+	ents := collectSeedEntities(d, state.Name)
+	if len(ents) == 0 {
+		return nil, nil
+	}
+	texts := make([]string, len(ents))
+	for i, e := range ents {
+		texts[i] = e.text
+	}
+	vecs, err := s.embedBatch(ctx, texts)
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) != len(ents) {
+		return nil, fmt.Errorf("catalog seed %s: embedder returned %d vectors for %d entities",
+			state.Name, len(vecs), len(ents))
+	}
+	rows := make([]seedRow, len(ents))
+	for i, e := range ents {
+		rows[i] = seedRow{kind: e.kind, key: e.key, parent: e.parent, vec: vecs[i]}
+	}
+	return rows, nil
+}
+
+// writeSeeds persists the pre-computed seed rows INSIDE the write transaction
+// (ctx carries it — every helper takes the transaction's connection from the
+// pool), so the seeds commit atomically with the entity rows. Modules are
+// INSERT-ONLY: a module's description lives ONLY in the annotation curation (the
+// source SDL carries none), so the seed must never touch an existing module row
+// — not even to refresh a vector. The rest refresh their seed vector, since
+// their description comes from the SDL and can change. Both statement shapes are
+// the CoreDB-pinned cross-engine ones (probe E3 anti-join / E2 conditional
+// upsert).
+func (s *Store) writeSeeds(ctx context.Context, source string, rows []seedRow) error {
+	refresh := make([]seedRow, 0, len(rows))
+	for _, r := range rows {
+		if r.kind == kindModule {
+			if err := s.insertSeedIfAbsent(ctx, r); err != nil {
+				return fmt.Errorf("catalog seed %s: %w", source, err)
+			}
+			continue
+		}
+		refresh = append(refresh, r)
+	}
+	return s.refreshSeedVectors(ctx, source, refresh)
+}
+
+// insertSeedIfAbsent inserts a vec-only seed row ONLY when no row for the key
+// exists — the module write path, which must never update an existing (seed or
+// curated) row. The anti-join is the cross-engine seed shape the CoreDB
+// inventory pins (probe E3).
+func (s *Store) insertSeedIfAbsent(ctx context.Context, r seedRow) error {
+	conn, err := s.pool.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, err = conn.Exec(ctx, `INSERT INTO core.catalog.annotations (entity_kind, entity_key, parent, vec, updated_at)
+		SELECT `+lit(r.kind)+`, `+lit(r.key)+`, `+lit(nilIfEmpty(r.parent))+`, `+vecLiteral(r.vec)+`, CURRENT_TIMESTAMP
+		WHERE NOT EXISTS (SELECT 1 FROM core.catalog.annotations a
+			WHERE a.entity_kind = `+lit(r.kind)+` AND a.entity_key = `+lit(r.key)+`)`)
+	return err
+}
+
+// refreshSeedVectors upserts the SEED vectors of the non-module entities: create
+// the row (text NULL) or, when it already exists as a seed, refresh only its
+// vector — a curated row (description / long_description set) is left untouched
+// by the WHERE (probe E2).
+func (s *Store) refreshSeedVectors(ctx context.Context, source string, rows []seedRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	conn, err := s.pool.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("catalog seed %s: %w", source, err)
+	}
+	defer conn.Close()
+	tail := ` ON CONFLICT (entity_kind, entity_key) DO UPDATE SET vec = EXCLUDED.vec,
+		updated_at = EXCLUDED.updated_at
+		WHERE description IS NULL AND long_description IS NULL`
+	head := `INSERT INTO core.catalog.annotations (entity_kind, entity_key, parent, vec, updated_at) VALUES `
+	for start := 0; start < len(rows); start += insertChunk {
+		end := min(start+insertChunk, len(rows))
+		var b strings.Builder
+		b.WriteString(head)
+		for i := start; i < end; i++ {
+			if i > start {
+				b.WriteString(", ")
+			}
+			r := rows[i]
+			fmt.Fprintf(&b, "(%s, %s, %s, %s, CURRENT_TIMESTAMP)",
+				lit(r.kind), lit(r.key), lit(nilIfEmpty(r.parent)), vecLiteral(r.vec))
+		}
+		b.WriteString(tail)
+		if _, err := conn.Exec(ctx, b.String()); err != nil {
+			return fmt.Errorf("catalog seed %s: %w", source, err)
+		}
+	}
+	return nil
+}
+
+// sweepAnnotationSeeds removes the SEED annotation rows of a source's own
+// logical entities on unregister — curated rows (description / long_description
+// set) are kept. It must run BEFORE deleteSourceRows, while the entity rows are
+// still present to resolve the keys (ctx carries the transaction). Modules are
+// shared across sources and are not swept here (a truly orphaned module seed is
+// harmless — the module row is gone, so it never surfaces through
+// entity_modules).
+func (s *Store) sweepAnnotationSeeds(ctx context.Context, dataSource string) error {
+	conn, err := s.pool.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("catalog sweep %s: %w", dataSource, err)
+	}
+	defer conn.Close()
+	ds := lit(dataSource)
+	seedOnly := ` AND description IS NULL AND long_description IS NULL`
+	stmts := []string{
+		`DELETE FROM core.catalog.annotations WHERE entity_kind = ` + lit(kindDataSource) +
+			` AND entity_key = ` + ds + seedOnly,
+		`DELETE FROM core.catalog.annotations WHERE entity_kind = ` + lit(kindDataObject) +
+			` AND entity_key IN (SELECT name FROM core.catalog.data_objects WHERE data_source = ` + ds + `)` + seedOnly,
+		`DELETE FROM core.catalog.annotations WHERE entity_kind = ` + lit(kindType) +
+			` AND entity_key IN (SELECT name FROM core.catalog.types WHERE data_source = ` + ds + `)` + seedOnly,
+		`DELETE FROM core.catalog.annotations WHERE entity_kind = ` + lit(kindField) +
+			` AND entity_key IN (SELECT type_name || '.' || name FROM core.catalog.fields WHERE data_source = ` + ds + `)` + seedOnly,
+		`DELETE FROM core.catalog.annotations WHERE entity_kind = ` + lit(kindField) +
+			` AND entity_key IN (
+				SELECT source || '.' || source_field FROM core.catalog.relations
+					WHERE data_source = ` + ds + ` AND source_field IS NOT NULL AND source_field <> ''
+				UNION
+				SELECT destination || '.' || destination_field FROM core.catalog.relations
+					WHERE data_source = ` + ds + ` AND destination_field IS NOT NULL AND destination_field <> '')` + seedOnly,
+		`DELETE FROM core.catalog.annotations WHERE entity_kind = ` + lit(kindFunction) +
+			` AND entity_key IN (SELECT CASE WHEN module = '' THEN name ELSE module || '.' || name END
+				FROM core.catalog.functions WHERE data_source = ` + ds + `)` + seedOnly,
+	}
+	for _, stmt := range stmts {
+		if _, err := conn.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("catalog sweep %s: %w", dataSource, err)
+		}
+	}
+	return nil
+}

--- a/pkg/catalog/store/seed_test.go
+++ b/pkg/catalog/store/seed_test.go
@@ -68,6 +68,21 @@ func TestSeedVectorsAndSweep(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, changed)
 
+	// --- Reload with a version that DROPS entities sweeps their stale seeds ---
+	// (after the entity rows are gone their keys would be unresolvable forever).
+	d2 := collect(ctx, partialSource(t, "test", seedV2Schema), "test")
+	changed, err = store.writeSource(ctx, d2, SourceState{
+		Name: "test", Version: "v2", Engine: "duckdb", Prefix: "shop", AsModule: true, Loaded: true,
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+	assert.Empty(t, seedRow(kindFunction, "sales.order_status"), "dropped function's seed swept on reload")
+	assert.Empty(t, seedRow(kindField, "orders.amount"), "dropped object's field seed swept on reload")
+	assert.Equal(t, []string{"true|false"}, seedRow(kindDataObject, "customers"), "kept entity reseeded")
+	assert.Equal(t, []string{"Curated orders"}, rows(t, pool,
+		`SELECT description FROM core.catalog.annotations WHERE entity_kind = 'data_object' AND entity_key = 'orders'`),
+		"curation survives the reload sweep even though its object was dropped")
+
 	// --- Unregister sweeps seeds, keeps curation ---
 	require.NoError(t, store.deleteSource(ctx, "test"))
 
@@ -104,3 +119,12 @@ func TestSeedNoEmbedderNoop(t *testing.T) {
 	assert.Equal(t, []string{"0"}, rows(t, pool, `SELECT count(*) FROM core.catalog.annotations`),
 		"no embedder → no seed rows")
 }
+
+// seedV2Schema is the collectTestSchema source rewritten to a single table —
+// the reload fixture that DROPS the other objects, functions and types.
+const seedV2Schema = `
+type customers @module(name: "sales") @table(name: "customers") {
+  id: Int! @pk
+  name: String!
+}
+`

--- a/pkg/catalog/store/seed_test.go
+++ b/pkg/catalog/store/seed_test.go
@@ -1,0 +1,106 @@
+//go:build duckdb_arrow
+
+package store
+
+import (
+	"context"
+	"testing"
+
+	coredb "github.com/hugr-lab/query-engine/pkg/data-sources/sources/runtime/core-db"
+	"github.com/hugr-lab/query-engine/pkg/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSeedVectorsAndSweep pins the D24 seed/sweep lifecycle. writeSource seeds a
+// vec-only annotation row (text NULL) for every logical entity of the source
+// without clobbering a pre-existing curation; deleteSource (the unregister
+// primitive) sweeps the seeds and keeps the curated rows. Both use the
+// cross-engine statement shapes pinned by the CoreDB inventory.
+func TestSeedVectorsAndSweep(t *testing.T) {
+	ctx := context.Background()
+	pool, err := db.NewPool("")
+	require.NoError(t, err)
+	t.Cleanup(func() { pool.Close() })
+	require.NoError(t, coredb.New(coredb.Config{VectorSize: 8}).Attach(ctx, pool))
+	store, err := New(ctx, pool, Config{VecSize: 8}, fakeEmbedder{dim: 8})
+	require.NoError(t, err)
+
+	// Curate one data object AND one module BEFORE the source loads — the seed
+	// must clobber neither (modules are insert-only; the object seed is guarded).
+	require.NoError(t, store.SetDataObjectDescription(ctx, "orders", "Curated orders", ""))
+	require.NoError(t, store.SetModuleDescription(ctx, "sales", "Curated sales module", ""))
+
+	d := collect(ctx, partialSource(t, "test", collectTestSchema), "test")
+	state := SourceState{Name: "test", Version: "v1", Engine: "duckdb", Prefix: "shop", AsModule: true, Loaded: true}
+	changed, err := store.writeSource(ctx, d, state)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	seedRow := func(kind, key string) []string {
+		return rows(t, pool, `SELECT vec IS NOT NULL, description IS NOT NULL FROM core.catalog.annotations
+			WHERE entity_kind = `+lit(kind)+` AND entity_key = `+lit(key))
+	}
+
+	// Seeds landed: vector present, text NULL — for the source, an object and a function.
+	assert.Equal(t, []string{"true|false"}, seedRow(kindDataSource, "test"))
+	assert.Equal(t, []string{"true|false"}, seedRow(kindDataObject, "customers"))
+	assert.Equal(t, []string{"true|false"}, seedRow(kindFunction, "sales.order_status"))
+	// A field seed keyed owner.field.
+	assert.Equal(t, []string{"true|false"}, seedRow(kindField, "customers.id"))
+
+	// The curated object survived: text kept, vec is the curated one (not reseeded).
+	assert.Equal(t, []string{"Curated orders"}, rows(t, pool,
+		`SELECT description FROM core.catalog.annotations WHERE entity_kind = 'data_object' AND entity_key = 'orders'`))
+
+	// Modules: the curated one is untouched (insert-only), the other is a fresh
+	// vec-only seed.
+	assert.Equal(t, []string{"Curated sales module"}, rows(t, pool,
+		`SELECT description FROM core.catalog.annotations WHERE entity_kind = 'module' AND entity_key = 'sales'`))
+	assert.Equal(t, []string{"true|false"}, seedRow(kindModule, "sales.reports"))
+
+	// A curated row is NOT double-counted as a seed; there are many seeds overall.
+	seedCount := rows(t, pool, `SELECT count(*) FROM core.catalog.annotations WHERE description IS NULL AND vec IS NOT NULL`)
+	assert.NotEqual(t, []string{"0"}, seedCount)
+
+	// Reload of the same version is a no-op — seeds are not rewritten, curation stays.
+	changed, err = store.writeSource(ctx, d, state)
+	require.NoError(t, err)
+	require.False(t, changed)
+
+	// --- Unregister sweeps seeds, keeps curation ---
+	require.NoError(t, store.deleteSource(ctx, "test"))
+
+	assert.Empty(t, seedRow(kindDataSource, "test"), "data-source seed swept")
+	assert.Empty(t, seedRow(kindDataObject, "customers"), "object seed swept")
+	assert.Empty(t, seedRow(kindFunction, "sales.order_status"), "function seed swept")
+	assert.Empty(t, seedRow(kindField, "customers.id"), "field seed swept")
+
+	// The curated object survives; module seeds stay as tolerated orphans —
+	// modules are shared and not source-attributable, and a vec-only orphan is
+	// invisible through entity_modules (the module row is gone) and is revived
+	// by the seed upsert if the module is recreated.
+	assert.Equal(t, []string{"data_object|orders", "module|sales", "module|sales.reports"},
+		rows(t, pool, `SELECT entity_kind, entity_key FROM core.catalog.annotations
+			ORDER BY entity_kind, entity_key`),
+		"curated row plus tolerated module-seed orphans")
+}
+
+// TestSeedNoEmbedderNoop confirms the seed path is inert without an embedder:
+// writeSource persists entity rows but writes no annotation seed rows.
+func TestSeedNoEmbedderNoop(t *testing.T) {
+	ctx := context.Background()
+	pool, err := db.NewPool("")
+	require.NoError(t, err)
+	t.Cleanup(func() { pool.Close() })
+	require.NoError(t, coredb.New(coredb.Config{VectorSize: 8}).Attach(ctx, pool))
+	store, err := New(ctx, pool, Config{VecSize: 8}, nil) // no embedder
+	require.NoError(t, err)
+
+	d := collect(ctx, partialSource(t, "test", collectTestSchema), "test")
+	_, err = store.writeSource(ctx, d, SourceState{Name: "test", Version: "v1", Engine: "duckdb", Loaded: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"0"}, rows(t, pool, `SELECT count(*) FROM core.catalog.annotations`),
+		"no embedder → no seed rows")
+}

--- a/pkg/catalog/store/store.go
+++ b/pkg/catalog/store/store.go
@@ -133,6 +133,23 @@ func (s *Store) evictType(name string) {
 	s.cache.evict(name)
 }
 
+// evictTypeFamily drops a base type AND its cached derived types (filters,
+// mutation inputs, aggregation types) — the write-side closure for a FIELD
+// curation, whose description the derived types inherit onto their same-named
+// fields at reconstruction. Every derived rule is checked (suffixes overlap:
+// x_list_filter parses as both x+list_filter and x_list+filter).
+func (s *Store) evictTypeFamily(name string) {
+	s.gen.Add(1)
+	s.cache.evictFamily(name, func(candidate string) bool {
+		for i := range derivedRules {
+			if b, ok := derivedRules[i].match(candidate); ok && b == name {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 // System returns the in-memory system-type layer. The writer skips
 // sdl.IsSystemType(def) and the reader delegates system-type resolution here
 // (except Query/Mutation/Subscription, which are synthesized from catalog.*).

--- a/pkg/catalog/store/store.go
+++ b/pkg/catalog/store/store.go
@@ -123,6 +123,16 @@ func (s *Store) invalidateAll() {
 	s.cache.invalidateAll()
 }
 
+// evictType drops one type from the definition cache — the targeted
+// invalidation for a type/field/argument annotation write, which changes only
+// that type's assembled definition. The clock is bumped FIRST so an in-flight
+// resolution that read the pre-write annotations discards its result instead
+// of racing a stale definition back into the cache after the evict.
+func (s *Store) evictType(name string) {
+	s.gen.Add(1)
+	s.cache.evict(name)
+}
+
 // System returns the in-memory system-type layer. The writer skips
 // sdl.IsSystemType(def) and the reader delegates system-type resolution here
 // (except Query/Mutation/Subscription, which are synthesized from catalog.*).

--- a/pkg/catalog/store/writer.go
+++ b/pkg/catalog/store/writer.go
@@ -112,6 +112,18 @@ func (s *Store) writeSource(ctx context.Context, d *desired, state SourceState) 
 		return false, fmt.Errorf("catalog write %s: %w", state.Name, err)
 	}
 
+	// Refresh the seed set atomically with the entity rows: sweep the STORED
+	// entities' seeds first (this is what drops the seeds of entities the new
+	// version removes — after deleteSourceRows their keys are unresolvable, and
+	// the unregister sweep could never find them either), then writeSeeds below
+	// inserts the fresh set. Skipped when embedding produced nothing (embedder
+	// off or failed): stale seeds are better than none.
+	if len(seeds) > 0 {
+		if err := s.sweepAnnotationSeeds(txCtx, state.Name); err != nil {
+			return false, err
+		}
+	}
+
 	if err := s.deleteSourceRows(txCtx, state.Name); err != nil {
 		return false, err
 	}

--- a/pkg/catalog/store/writer.go
+++ b/pkg/catalog/store/writer.go
@@ -6,10 +6,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"strings"
 
-	"github.com/hugr-lab/query-engine/pkg/db"
 	"github.com/hugr-lab/query-engine/pkg/engines"
 )
 
@@ -73,63 +73,73 @@ func (s *Store) writeSource(ctx context.Context, d *desired, state SourceState) 
 		return false, nil // unchanged — nothing to do
 	}
 
+	// Embed the seed vectors BEFORE opening the transaction — the embedder is a
+	// network call and must not hold DB locks (on an attached PostgreSQL CoreDB
+	// it would pin the remote transaction for the whole round-trip). Best-effort:
+	// an embed failure logs and proceeds without seeds, so an embedder outage
+	// never blocks schema loading. The seed ROWS are written inside the tx below.
+	seeds, err := s.computeSeeds(ctx, d, state)
+	if err != nil {
+		slog.Error("catalog store: seed embeddings", "source", state.Name, "error", err)
+		seeds = nil
+	}
+
 	txCtx, err := s.pool.WithTx(ctx)
 	if err != nil {
 		return false, fmt.Errorf("catalog write %s: %w", state.Name, err)
 	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = s.pool.Rollback(txCtx)
-		}
-	}()
-	conn, err := s.pool.Conn(txCtx)
-	if err != nil {
-		return false, fmt.Errorf("catalog write %s: %w", state.Name, err)
-	}
-	defer conn.Close()
+	// Rollback is idempotent per WithTx scope — after a successful Commit it is a
+	// no-op, on any early return it aborts the flattened tx.
+	defer s.pool.Rollback(txCtx)
+
+	// Every writer step takes the transaction's connection from txCtx (via the
+	// pool) — no connection is threaded through.
 
 	// Virtual fields are attributed to the source their DATA comes from,
 	// resolved by the declared reference at WRITE time — the read side then
 	// takes @catalog straight from the field row and the standard activity
 	// gate hides the field with that source.
-	if err := resolveVirtualAttribution(txCtx, conn, d); err != nil {
+	if err := s.resolveVirtualAttribution(txCtx, d); err != nil {
 		return false, fmt.Errorf("catalog write %s: %w", state.Name, err)
 	}
 
 	// The cross-source invalidation closure needs the OLD rows (about to be
-	// deleted) and the incoming ones; a failure here never fails the write —
-	// the cache then invalidates wholesale.
-	affected, affectedErr := affectedObjects(txCtx, conn, state.Name, d)
-
-	if err := deleteSourceRows(txCtx, conn, state.Name); err != nil {
-		return false, err
-	}
-	if err := insertSourceRows(txCtx, conn, d); err != nil {
-		return false, err
-	}
-	if err := mergeModules(txCtx, conn, d); err != nil {
-		return false, err
-	}
-	if err := pruneOrphanModules(txCtx, conn); err != nil {
-		return false, err
-	}
-	if err := upsertMeta(txCtx, conn, state); err != nil {
-		return false, err
+	// deleted) and the incoming ones. It shares the write transaction's
+	// connection, so a failure here would fail the write anyway — abort now
+	// rather than proceed and mask it.
+	affected, err := s.affectedObjects(txCtx, state.Name, d)
+	if err != nil {
+		return false, fmt.Errorf("catalog write %s: %w", state.Name, err)
 	}
 
-	committed = true
+	if err := s.deleteSourceRows(txCtx, state.Name); err != nil {
+		return false, err
+	}
+	if err := s.insertSourceRows(txCtx, d); err != nil {
+		return false, err
+	}
+	if err := s.mergeModules(txCtx, d); err != nil {
+		return false, err
+	}
+	if err := s.pruneOrphanModules(txCtx); err != nil {
+		return false, err
+	}
+	if err := s.upsertMeta(txCtx, state); err != nil {
+		return false, err
+	}
+	// Seed rows commit atomically with the entity rows (vectors already embedded
+	// above, outside the transaction).
+	if err := s.writeSeeds(txCtx, state.Name, seeds); err != nil {
+		return false, err
+	}
+
 	if err := s.pool.Commit(txCtx); err != nil {
 		// The commit may have succeeded server-side despite the client error —
 		// invalidate conservatively.
 		s.invalidateAll()
 		return false, fmt.Errorf("catalog write %s commit: %w", state.Name, err)
 	}
-	if affectedErr != nil {
-		s.invalidateAll()
-	} else {
-		s.invalidateSource(state.Name, affected)
-	}
+	s.invalidateSource(state.Name, affected)
 	return true, nil
 }
 
@@ -140,7 +150,12 @@ func (s *Store) writeSource(ctx context.Context, d *desired, state SourceState) 
 // incoming batch resolves first, then the stored catalog. An unresolvable
 // reference keeps the declared attribution — the engine writes an extension
 // AFTER its dependencies, and a reload re-resolves.
-func resolveVirtualAttribution(ctx context.Context, conn *db.Connection, d *desired) error {
+func (s *Store) resolveVirtualAttribution(ctx context.Context, d *desired) error {
+	conn, err := s.pool.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
 	lookupFunc := func(module, name string) (string, error) {
 		if fn, ok := d.functions[pkKey(module, name)]; ok {
 			return fn.DataSource, nil
@@ -221,7 +236,12 @@ func resolveVirtualAttribution(ctx context.Context, conn *db.Connection, d *desi
 //
 // All lookups read DECLARED rows (types, references_name, function bindings) —
 // a reverse index computed at write time, no heuristics.
-func affectedObjects(ctx context.Context, conn *db.Connection, dataSource string, d *desired) (map[string]struct{}, error) {
+func (s *Store) affectedObjects(ctx context.Context, dataSource string, d *desired) (map[string]struct{}, error) {
+	conn, err := s.pool.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
 	out := map[string]struct{}{}
 	ds := lit(dataSource)
 
@@ -409,21 +429,21 @@ func (s *Store) deleteSource(ctx context.Context, dataSource string) error {
 	if err != nil {
 		return fmt.Errorf("catalog delete %s: %w", dataSource, err)
 	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = s.pool.Rollback(txCtx)
-		}
-	}()
-	conn, err := s.pool.Conn(txCtx)
+	// Idempotent per scope: no-op after Commit, aborts the flattened tx on any
+	// early return.
+	defer s.pool.Rollback(txCtx)
+
+	affected, err := s.affectedObjects(txCtx, dataSource, nil)
 	if err != nil {
 		return fmt.Errorf("catalog delete %s: %w", dataSource, err)
 	}
-	defer conn.Close()
 
-	affected, affectedErr := affectedObjects(txCtx, conn, dataSource, nil)
-
-	if err := deleteSourceRows(txCtx, conn, dataSource); err != nil {
+	// Sweep the source's SEED annotations BEFORE its entity rows go — the sweep
+	// resolves keys from the still-present rows and keeps curated rows.
+	if err := s.sweepAnnotationSeeds(txCtx, dataSource); err != nil {
+		return err
+	}
+	if err := s.deleteSourceRows(txCtx, dataSource); err != nil {
 		return err
 	}
 	ds := lit(dataSource)
@@ -431,25 +451,20 @@ func (s *Store) deleteSource(ctx context.Context, dataSource string) error {
 		`DELETE FROM core.catalog.data_source_dependencies WHERE data_source = ` + ds,
 		`DELETE FROM core.catalog.data_source_meta WHERE data_source = ` + ds,
 	} {
-		if _, err := conn.Exec(txCtx, stmt); err != nil {
+		if err := s.exec(txCtx, stmt); err != nil {
 			return fmt.Errorf("catalog delete %s: %w", dataSource, err)
 		}
 	}
-	if err := pruneOrphanModules(txCtx, conn); err != nil {
+	if err := s.pruneOrphanModules(txCtx); err != nil {
 		return err
 	}
-	committed = true
 	if err := s.pool.Commit(txCtx); err != nil {
 		// The commit may have succeeded server-side despite the client error —
 		// invalidate conservatively.
 		s.invalidateAll()
 		return fmt.Errorf("catalog delete %s: %w", dataSource, err)
 	}
-	if affectedErr != nil {
-		s.invalidateAll()
-	} else {
-		s.invalidateSource(dataSource, affected)
-	}
+	s.invalidateSource(dataSource, affected)
 	return nil
 }
 
@@ -457,25 +472,18 @@ func (s *Store) deleteSource(ctx context.Context, dataSource string) error {
 // (unload, suspend, enable — the rows stay, hidden by the flags). A missing
 // meta row (source never written) is a no-op.
 func (s *Store) setFlags(ctx context.Context, dataSource string, loaded, disabled, suspended bool) error {
-	conn, err := s.pool.Conn(ctx)
-	if err != nil {
-		return fmt.Errorf("catalog set flags %s: %w", dataSource, err)
-	}
-	defer conn.Close()
 	// Flag flips change VISIBILITY, not rows — the affected closure reads the
 	// (surviving) rows either before hiding or after unhiding.
-	affected, affectedErr := affectedObjects(ctx, conn, dataSource, nil)
-	_, err = conn.Exec(ctx, `UPDATE core.catalog.data_source_meta SET loaded = `+lit(loaded)+
-		`, disabled = `+lit(disabled)+`, suspended = `+lit(suspended)+
-		` WHERE data_source = `+lit(dataSource))
+	affected, err := s.affectedObjects(ctx, dataSource, nil)
 	if err != nil {
 		return fmt.Errorf("catalog set flags %s: %w", dataSource, err)
 	}
-	if affectedErr != nil {
-		s.invalidateAll()
-	} else {
-		s.invalidateSource(dataSource, affected)
+	if err := s.exec(ctx, `UPDATE core.catalog.data_source_meta SET loaded = `+lit(loaded)+
+		`, disabled = `+lit(disabled)+`, suspended = `+lit(suspended)+
+		` WHERE data_source = `+lit(dataSource)); err != nil {
+		return fmt.Errorf("catalog set flags %s: %w", dataSource, err)
 	}
+	s.invalidateSource(dataSource, affected)
 	return nil
 }
 
@@ -497,7 +505,7 @@ func (s *Store) sourceVersion(ctx context.Context, dataSource string) (string, b
 	return v, true, nil
 }
 
-func deleteSourceRows(ctx context.Context, conn *db.Connection, dataSource string) error {
+func (s *Store) deleteSourceRows(ctx context.Context, dataSource string) error {
 	// Strictly own attribution: a source touches only its own rows. Fields an
 	// EXTENSION source added to another source's object carry their own
 	// data_source, so reloading the base source never removes them (cross-source
@@ -511,7 +519,7 @@ func deleteSourceRows(ctx context.Context, conn *db.Connection, dataSource strin
 		`DELETE FROM core.catalog.types WHERE data_source = ` + ds,
 		`DELETE FROM core.catalog.module_data_sources WHERE data_source = ` + ds,
 	} {
-		if _, err := conn.Exec(ctx, stmt); err != nil {
+		if err := s.exec(ctx, stmt); err != nil {
 			return fmt.Errorf("catalog delete rows %s: %w", dataSource, err)
 		}
 	}
@@ -519,13 +527,13 @@ func deleteSourceRows(ctx context.Context, conn *db.Connection, dataSource strin
 }
 
 // insertSourceRows inserts every entity row collected for one source.
-func insertSourceRows(ctx context.Context, conn *db.Connection, d *desired) error {
+func (s *Store) insertSourceRows(ctx context.Context, d *desired) error {
 	objs := make([][]any, 0, len(d.dataObjects))
 	for _, k := range sortedKeys(d.dataObjects) {
 		r := d.dataObjects[k]
 		objs = append(objs, []any{r.Name, r.OriginalName, r.DataSource, r.Module, r.Kind, jsonOrNil(r.Properties), nilIfEmpty(r.Description)})
 	}
-	if err := insertRows(ctx, conn, "data_objects",
+	if err := s.insertRows(ctx, "data_objects",
 		[]string{"name", "original_name", "data_source", "module", "kind", "properties", "description"}, objs); err != nil {
 		return err
 	}
@@ -537,7 +545,7 @@ func insertSourceRows(ctx context.Context, conn *db.Connection, d *desired) erro
 			r.DataSource, nilIfEmpty(r.DependencyDataSource), r.IsPK, r.Ordinal,
 			nilIfEmpty(r.DeprecationReason), nilIfEmpty(r.Description)})
 	}
-	if err := insertRows(ctx, conn, "fields",
+	if err := s.insertRows(ctx, "fields",
 		[]string{"type_name", "name", "field_type", "properties", "args", "data_source",
 			"dependency_data_source", "is_pk", "ordinal", "deprecation_reason", "description"}, fields); err != nil {
 		return err
@@ -556,7 +564,7 @@ func insertSourceRows(ctx context.Context, conn *db.Connection, d *desired) erro
 			nilIfEmpty(r.SourceFieldDescription), r.DestinationField,
 			nilIfEmpty(r.DestinationFieldDescription), r.FieldDeclared, r.DataSource})
 	}
-	if err := insertRows(ctx, conn, "relations",
+	if err := s.insertRows(ctx, "relations",
 		[]string{"source", "name", "kind", "destination", "m2m_object", "source_keys", "destination_keys",
 			"source_field", "source_field_description", "destination_field", "destination_field_description",
 			"field_declared", "data_source"}, rels); err != nil {
@@ -569,7 +577,7 @@ func insertSourceRows(ctx context.Context, conn *db.Connection, d *desired) erro
 		fns = append(fns, []any{r.Module, r.Name, r.Kind, r.DataSource, r.Returns, r.IsTable,
 			jsonOrNil(r.Args), jsonOrNil(r.Properties), nilIfEmpty(r.DeprecationReason), nilIfEmpty(r.Description)})
 	}
-	if err := insertRows(ctx, conn, "functions",
+	if err := s.insertRows(ctx, "functions",
 		[]string{"module", "name", "kind", "data_source", "returns", "is_table", "args", "properties",
 			"deprecation_reason", "description"}, fns); err != nil {
 		return err
@@ -580,20 +588,20 @@ func insertSourceRows(ctx context.Context, conn *db.Connection, d *desired) erro
 		r := d.types[k]
 		types = append(types, []any{r.Name, r.Kind, r.DataSource, r.Module, r.Definition, nilIfEmpty(r.Description)})
 	}
-	return insertRows(ctx, conn, "types",
+	return s.insertRows(ctx, "types",
 		[]string{"name", "kind", "data_source", "module", "definition", "description"}, types)
 }
 
 // mergeModules upserts the source's module rows and inserts its module→source
 // closure (its old closure rows were removed by deleteSourceRows). Modules are
 // shared across sources, so they are upserted, never attributed.
-func mergeModules(ctx context.Context, conn *db.Connection, d *desired) error {
+func (s *Store) mergeModules(ctx context.Context, d *desired) error {
 	moduleRows := make([][]any, 0, len(d.modules))
 	for _, k := range sortedKeys(d.modules) {
 		m := d.modules[k]
 		moduleRows = append(moduleRows, []any{m.Name, nilIfEmpty(m.Parent), nilIfEmpty(m.Description)})
 	}
-	if err := upsertRows(ctx, conn, "modules",
+	if err := s.upsertRows(ctx, "modules",
 		[]string{"name", "parent", "description"}, []string{"name"},
 		[]string{"parent", "description"}, moduleRows); err != nil {
 		return err
@@ -604,24 +612,23 @@ func mergeModules(ctx context.Context, conn *db.Connection, d *desired) error {
 		links = append(links, []any{ms.Module, ms.DataSource,
 			ms.HasDataObjects, ms.HasTables, ms.HasFunctions, ms.HasMutFunctions, ms.HasSubscriptions})
 	}
-	return insertRows(ctx, conn, "module_data_sources",
+	return s.insertRows(ctx, "module_data_sources",
 		[]string{"module", "data_source", "has_data_objects", "has_tables",
 			"has_functions", "has_mut_functions", "has_subscriptions"}, links)
 }
 
 // pruneOrphanModules removes modules no source backs anymore — with the closure,
 // a live module always has at least one module_data_sources row.
-func pruneOrphanModules(ctx context.Context, conn *db.Connection) error {
-	_, err := conn.Exec(ctx, `DELETE FROM core.catalog.modules
-		WHERE name NOT IN (SELECT DISTINCT module FROM core.catalog.module_data_sources)`)
-	if err != nil {
+func (s *Store) pruneOrphanModules(ctx context.Context) error {
+	if err := s.exec(ctx, `DELETE FROM core.catalog.modules
+		WHERE name NOT IN (SELECT DISTINCT module FROM core.catalog.module_data_sources)`); err != nil {
 		return fmt.Errorf("catalog prune modules: %w", err)
 	}
 	return nil
 }
 
 // upsertMeta stamps the source's version, capabilities and flags.
-func upsertMeta(ctx context.Context, conn *db.Connection, state SourceState) error {
+func (s *Store) upsertMeta(ctx context.Context, state SourceState) error {
 	stmt := `INSERT INTO core.catalog.data_source_meta
 		(data_source, version, capabilities, engine, read_only, prefix, as_module, is_extension, loaded, disabled, suspended, loaded_at)
 		VALUES (` + lit(state.Name) + `, ` + lit(state.storedVersion()) + `, ` + lit(capabilitiesText(state.Capabilities)) + `, ` +
@@ -632,7 +639,7 @@ func upsertMeta(ctx context.Context, conn *db.Connection, state SourceState) err
 		capabilities = EXCLUDED.capabilities, engine = EXCLUDED.engine, read_only = EXCLUDED.read_only,
 		prefix = EXCLUDED.prefix, as_module = EXCLUDED.as_module, is_extension = EXCLUDED.is_extension,
 		loaded = EXCLUDED.loaded, disabled = EXCLUDED.disabled, suspended = EXCLUDED.suspended, loaded_at = EXCLUDED.loaded_at`
-	if _, err := conn.Exec(ctx, stmt); err != nil {
+	if err := s.exec(ctx, stmt); err != nil {
 		return fmt.Errorf("catalog meta upsert %s: %w", state.Name, err)
 	}
 	return nil
@@ -640,10 +647,29 @@ func upsertMeta(ctx context.Context, conn *db.Connection, state SourceState) err
 
 // --- SQL building ---
 
-func insertRows(ctx context.Context, conn *db.Connection, table string, columns []string, rows [][]any) error {
+// exec runs one statement on the connection carried by ctx — the transaction's
+// connection inside a write tx (Close is then a no-op), or a fresh pooled one
+// otherwise. The seed/sweep and writer helpers all resolve the connection this
+// way instead of threading it through.
+func (s *Store) exec(ctx context.Context, query string) error {
+	conn, err := s.pool.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, err = conn.Exec(ctx, query)
+	return err
+}
+
+func (s *Store) insertRows(ctx context.Context, table string, columns []string, rows [][]any) error {
 	if len(rows) == 0 {
 		return nil
 	}
+	conn, err := s.pool.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
 	head := `INSERT INTO core.catalog.` + table + ` (` + strings.Join(columns, ", ") + `) VALUES `
 	for start := 0; start < len(rows); start += insertChunk {
 		end := min(start+insertChunk, len(rows))
@@ -663,10 +689,15 @@ func insertRows(ctx context.Context, conn *db.Connection, table string, columns 
 }
 
 // upsertRows inserts with ON CONFLICT DO UPDATE of the given columns.
-func upsertRows(ctx context.Context, conn *db.Connection, table string, columns, pkCols, updateCols []string, rows [][]any) error {
+func (s *Store) upsertRows(ctx context.Context, table string, columns, pkCols, updateCols []string, rows [][]any) error {
 	if len(rows) == 0 {
 		return nil
 	}
+	conn, err := s.pool.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
 	sets := make([]string, len(updateCols))
 	for i, c := range updateCols {
 		sets[i] = c + " = EXCLUDED." + c

--- a/pkg/data-sources/sources/runtime/core-db/schema_catalog_tmpl.graphql
+++ b/pkg/data-sources/sources/runtime/core-db/schema_catalog_tmpl.graphql
@@ -817,6 +817,41 @@ type entity_types
   vec: Vector {{ if .EmbeddingsEnabled }} @dim(len: {{ .VectorSize }}){{ end }}
 }
 
+"Logical-model data sources (active runtime state; config joined when present)"
+type entity_data_sources
+  @view(name: "entity_data_sources", sql: """
+    SELECT m.data_source AS name, m.engine,
+      COALESCE(ds.type, m.engine) AS type,
+      COALESCE(NULLIF(m.prefix, ''), ds.prefix) AS prefix,
+      m.as_module, m.read_only, m.is_extension,
+      COALESCE(ds.self_defined, false) AS self_defined,
+      ds.path,
+      COALESCE(a.description, ds.description) AS description,
+      a.long_description,
+      a.vec
+    FROM [catalog.data_source_meta] m
+      LEFT JOIN [data_sources] ds ON ds.name = m.data_source
+      LEFT JOIN [catalog.annotations] a
+        ON a.entity_kind = 'data_source' AND a.entity_key = m.data_source
+    WHERE m.loaded AND NOT m.disabled AND NOT m.suspended
+  """)
+  {{ if .EmbeddingsEnabled }}@embeddings(model: "_system_embedder", vector: "vec", distance: Cosine){{ end }} {
+  "The data source name (@catalog name)"
+  name: String! @pk
+  "The source's engine type string"
+  engine: String
+  type: String
+  prefix: String
+  as_module: Boolean
+  read_only: Boolean
+  is_extension: Boolean
+  self_defined: Boolean
+  path: String
+  description: String
+  long_description: String
+  vec: Vector {{ if .EmbeddingsEnabled }} @dim(len: {{ .VectorSize }}){{ end }}
+}
+
 "Curation overlay incl. orphans and vec-only seed rows (entity storage)"
 type entity_annotations
   @view(name: "entity_annotations", sql: """

--- a/pkg/db/context.go
+++ b/pkg/db/context.go
@@ -25,10 +25,39 @@ func TimezoneFromCtx(ctx context.Context) string {
 	return ""
 }
 
+// txContext is the ONE physical transaction shared by a WithTx scope and every
+// nested WithTx joined to it — DuckDB has no nested transactions, so nesting is
+// FLATTENED onto a single *sql.Tx. level counts the live holders; a COMMIT is
+// physical only when the last holder commits, while a ROLLBACK at ANY level
+// aborts the whole flattened tx (there are no savepoints to undo just part of
+// it). settled records that the physical tx has terminated, so once a rollback
+// poisons it every later Commit/Rollback — here or in an enclosing frame —
+// no-ops instead of acting on a finished tx.
 type txContext struct {
 	*Connection
-	tx    *sql.Tx
-	level atomic.Int32
+	tx      *sql.Tx
+	level   atomic.Int32
+	settled atomic.Bool
+}
+
+// txFrame is one WithTx scope. done makes that scope's terminal call
+// idempotent: the FIRST Commit or Rollback on the frame runs, any later one is
+// a no-op. This makes the idiomatic `defer Rollback(); …; Commit()` safe even
+// when nested — the deferred Rollback that fires after a successful Commit does
+// NOTHING, instead of decrementing the shared counter a second time and (since
+// the counter would then read 1) physically rolling back the PARENT's flattened
+// transaction. Each WithTx call gets its own frame in a distinct child context;
+// all frames of a scope share the one txContext.
+type txFrame struct {
+	txc  *txContext
+	done atomic.Bool
+}
+
+func txFrameFrom(ctx context.Context) *txFrame {
+	if v := ctx.Value(txKey); v != nil {
+		return v.(*txFrame)
+	}
+	return nil
 }
 
 func ClearTxContext(ctx context.Context) context.Context {
@@ -36,11 +65,9 @@ func ClearTxContext(ctx context.Context) context.Context {
 }
 
 func (p *Pool) WithTx(parent context.Context) (context.Context, error) {
-	tx := parent.Value(txKey)
-	if tx != nil {
-		txc := tx.(*txContext)
-		txc.level.Add(1)
-		return parent, nil
+	if f := txFrameFrom(parent); f != nil {
+		f.txc.level.Add(1)
+		return context.WithValue(parent, txKey, &txFrame{txc: f.txc}), nil
 	}
 	c, err := p.Conn(parent)
 	if err != nil {
@@ -57,18 +84,21 @@ func (p *Pool) WithTx(parent context.Context) (context.Context, error) {
 		tx:         dbTx,
 	}
 	txc.level.Store(1)
-	ctx := context.WithValue(parent, txKey, txc)
-	return ctx, nil
+	return context.WithValue(parent, txKey, &txFrame{txc: txc}), nil
 }
 
 func (p *Pool) Commit(ctx context.Context) error {
-	tx := ctx.Value(txKey)
-	if tx == nil {
+	f := txFrameFrom(ctx)
+	if f == nil || f.done.Swap(true) {
 		return nil
 	}
-	txc := tx.(*txContext)
-	if !txc.level.CompareAndSwap(1, 0) {
-		txc.level.Add(-1)
+	txc := f.txc
+	// A nested commit is only a vote — the physical commit happens when the LAST
+	// holder commits, and only if no rollback has poisoned the flattened tx.
+	if txc.level.Add(-1) > 0 {
+		return nil
+	}
+	if txc.settled.Swap(true) {
 		return nil
 	}
 	err := txc.tx.Commit()
@@ -78,19 +108,15 @@ func (p *Pool) Commit(ctx context.Context) error {
 }
 
 func (p *Pool) Rollback(ctx context.Context) error {
-	tx := ctx.Value(txKey)
-	if tx == nil {
+	f := txFrameFrom(ctx)
+	if f == nil || f.done.Swap(true) {
 		return nil
 	}
-	txc := tx.(*txContext)
-	if txc.level.CompareAndSwap(0, 0) {
-		return nil
-	}
-	if !txc.level.CompareAndSwap(1, 0) {
-		txc.level.Add(-1)
-		return nil
-	}
-	if txc.tx == nil {
+	txc := f.txc
+	txc.level.Add(-1)
+	// A rollback at ANY level aborts the whole flattened tx — roll back once and
+	// poison it; every later terminal (here or in an enclosing frame) no-ops.
+	if txc.settled.Swap(true) || txc.tx == nil {
 		return nil
 	}
 	err := txc.tx.Rollback()
@@ -100,10 +126,6 @@ func (p *Pool) Rollback(ctx context.Context) error {
 }
 
 func (p *Pool) IsTxContext(ctx context.Context) bool {
-	tx := ctx.Value(txKey)
-	if tx == nil {
-		return false
-	}
-	txc := tx.(*txContext)
-	return txc.Connection.tx != nil
+	f := txFrameFrom(ctx)
+	return f != nil && f.txc.Connection.tx != nil
 }

--- a/pkg/db/context.go
+++ b/pkg/db/context.go
@@ -95,11 +95,16 @@ func (p *Pool) Commit(ctx context.Context) error {
 	txc := f.txc
 	// A nested commit is only a vote — the physical commit happens when the LAST
 	// holder commits, and only if no rollback has poisoned the flattened tx.
+	// Committing work a rollback has already thrown away must NOT look like
+	// success — report ErrTxDone so the caller knows nothing was persisted.
 	if txc.level.Add(-1) > 0 {
+		if txc.settled.Load() {
+			return sql.ErrTxDone
+		}
 		return nil
 	}
 	if txc.settled.Swap(true) {
-		return nil
+		return sql.ErrTxDone
 	}
 	err := txc.tx.Commit()
 	txc.Connection.tx = nil

--- a/pkg/db/context_test.go
+++ b/pkg/db/context_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 )
@@ -239,5 +240,25 @@ func TestPool_NestedTxSemantics(t *testing.T) {
 	}()
 	if got := count(); got != 0 {
 		t.Fatalf("inner rollback must abort the whole tx: want 0 rows, got %d", got)
+	}
+
+	// (c) Committing AFTER an inner rollback poisoned the tx must not look like
+	// success — the work is gone, the owner gets ErrTxDone.
+	func() {
+		owner, _ := pool.WithTx(ctx)
+		defer pool.Rollback(owner)
+		exec(owner, "INSERT INTO t VALUES (1)")
+		func() {
+			inner, _ := pool.WithTx(owner)
+			defer pool.Rollback(inner) // rolls back and poisons
+			exec(inner, "INSERT INTO t VALUES (2)")
+		}()
+		// The owner IGNORES the inner failure and commits anyway.
+		if err := pool.Commit(owner); err != sql.ErrTxDone {
+			t.Errorf("commit after poison: want sql.ErrTxDone, got %v", err)
+		}
+	}()
+	if got := count(); got != 0 {
+		t.Fatalf("poisoned commit persisted rows: want 0, got %d", got)
 	}
 }

--- a/pkg/db/context_test.go
+++ b/pkg/db/context_test.go
@@ -24,27 +24,28 @@ func TestPool_WithTx(t *testing.T) {
 		t.Fatalf("expected false, got true")
 	}
 
-	// Test nested transaction
+	// A nested WithTx joins the same physical tx via its OWN frame.
 	ctx2, err := pool.WithTx(ctx)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if ctx != ctx2 {
-		t.Fatalf("expected contexts to be equal")
+	if !pool.IsTxContext(ctx2) {
+		t.Fatalf("expected nested context to be a tx context")
 	}
-	err = pool.Commit(ctx2)
-	if err != nil {
+	// The inner commit is only a vote — the physical tx stays open until the
+	// owner terminates.
+	if err = pool.Commit(ctx2); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if !pool.IsTxContext(ctx) {
-		t.Fatalf("expected false, got true")
+		t.Fatalf("tx must stay open after an inner commit")
 	}
-	err = pool.Commit(ctx2)
-	if err != nil {
+	// The owner commit finalizes the physical tx.
+	if err = pool.Commit(ctx); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if pool.IsTxContext(ctx) {
-		t.Fatalf("expected true, got false")
+		t.Fatalf("tx must be closed after the owner commit")
 	}
 }
 
@@ -151,7 +152,7 @@ func TestPool_ChainContext(t *testing.T) {
 		t.Fatalf("expected true, got false")
 	}
 
-	// Commit the nested transaction
+	// Commit the nested transaction — a vote; the physical tx stays open.
 	err = pool.Commit(nestedTxCtx)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -160,12 +161,83 @@ func TestPool_ChainContext(t *testing.T) {
 		t.Fatalf("expected true, got false")
 	}
 
-	// Rollback the transaction
-	err = pool.Rollback(nestedTxCtx)
+	// The owner terminates the physical tx (through the WithValue chain).
+	err = pool.Rollback(txCtx)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if pool.IsTxContext(nestedTxCtx) {
 		t.Fatalf("expected false, got true")
+	}
+}
+
+// TestPool_NestedTxSemantics pins the two guarantees the frame model provides
+// on the flattened (DuckDB has no nested tx) transaction: the idiomatic
+// `defer Rollback(); …; Commit()` is safe when nested (the deferred Rollback
+// no-ops after the commit), and a rollback at ANY level aborts the WHOLE tx.
+func TestPool_NestedTxSemantics(t *testing.T) {
+	ctx := context.Background()
+	pool, err := NewPool("")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	c0, _ := pool.Conn(ctx)
+	if _, err := c0.Exec(ctx, "CREATE TABLE t(x INT)"); err != nil {
+		t.Fatal(err)
+	}
+	c0.Close()
+
+	count := func() int {
+		c, _ := pool.Conn(ctx)
+		defer c.Close()
+		var n int
+		_ = c.QueryRow(ctx, "SELECT count(*) FROM t").Scan(&n)
+		return n
+	}
+	exec := func(c context.Context, q string) {
+		conn, _ := pool.Conn(c)
+		defer conn.Close()
+		if _, err := conn.Exec(c, q); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// (a) Nested `defer Rollback + Commit` on success commits everything.
+	func() {
+		owner, _ := pool.WithTx(ctx)
+		defer pool.Rollback(owner)
+		exec(owner, "INSERT INTO t VALUES (1)")
+		func() {
+			inner, _ := pool.WithTx(owner)
+			defer pool.Rollback(inner)
+			exec(inner, "INSERT INTO t VALUES (2)")
+			_ = pool.Commit(inner) // deferred Rollback below must no-op
+		}()
+		_ = pool.Commit(owner)
+	}()
+	if got := count(); got != 2 {
+		t.Fatalf("nested commit idiom: want 2 rows, got %d", got)
+	}
+	exec(ctx, "DELETE FROM t")
+
+	// (b) A rollback at the inner level aborts the whole flattened tx.
+	func() {
+		owner, _ := pool.WithTx(ctx)
+		defer pool.Rollback(owner)
+		exec(owner, "INSERT INTO t VALUES (1)")
+		abort := func() error {
+			inner, _ := pool.WithTx(owner)
+			defer pool.Rollback(inner) // no Commit → rolls back
+			exec(inner, "INSERT INTO t VALUES (2)")
+			return context.Canceled
+		}()
+		if abort != nil {
+			return // owner aborts; its deferred Rollback no-ops (already poisoned)
+		}
+		_ = pool.Commit(owner)
+	}()
+	if got := count(); got != 0 {
+		t.Fatalf("inner rollback must abort the whole tx: want 0 rows, got %d", got)
 	}
 }

--- a/pkg/db/pool.go
+++ b/pkg/db/pool.go
@@ -165,8 +165,8 @@ func (p *Pool) Exec(ctx context.Context, query string, args ...any) (sql.Result,
 }
 
 func (p *Pool) Conn(ctx context.Context) (*Connection, error) {
-	if tx := ctx.Value(txKey); tx != nil {
-		return tx.(*txContext).Connection, nil
+	if f := txFrameFrom(ctx); f != nil {
+		return f.txc.Connection, nil
 	}
 	// wait for available connection
 	p.acquire(ctx)


### PR DESCRIPTION
Advances the design-034 entity-storage catalog provider (`pkg/catalog/store`)
toward being a drop-in read provider, and hardens the transaction primitive it
relies on.

## Read Provider
- Store now implements the full `base.Provider` read surface — `Types` /
  `Definitions` / `PossibleTypes` / `Implements` / root types / directive
  delegation. `Types()`/`Definitions()` are a **reachability closure** from the
  roots (spec-correct `__schema.types`), not a suffix grammar, so they don't
  drift from what `ForName` actually serves.
- Default descriptions for synthetic query members (shared-type members
  `_join`/`_spatial`/`_h3`, module-root data-object fields, their args), applied
  in a single `finalizeDescriptions` at the end of `ForName`; the golden parity
  harness compares the pre-finalise generation so the oracle is unaffected.

## Annotation overlay (synced to the core-db `entity_*` views)
- `SchemaAnnotator` split into **`LogicalAnnotator`** (module / data_object /
  type / field incl. relation nav / function keyed `module.name` / data_source)
  and **`GraphQLAnnotator`** (`gql_type` / `gql_field` / `gql_argument`), keyed
  exactly the way the CoreDB `entity_*` views select their overlay from
  `catalog.annotations`.
- Layered read overlay: `default → logical → graphql` (GraphQL wins).
- New `entity_data_sources` view (base `catalog.data_source_meta` + `data_sources`
  + `annotations`).

## Vector seeding (D24)
- On source load, every logical entity is embedded and a vec-only **seed** row is
  written so MCP vector search works immediately. Embedding runs BEFORE the
  transaction (a network call must not hold DB locks) and is best-effort; the
  seed rows commit INSIDE the tx, atomic with the entity rows. Curated rows are
  never touched. Modules are INSERT-only (their description lives only in
  curation). Unregister sweeps the source's seed rows, keeps curated ones.
- Cross-engine: CoreDB is always attached into DuckDB (Postgres via `ATTACH TYPE
  POSTGRES`), so the vec is written as a **text literal `'[…]'`** (casts to
  `FLOAT[]` on DuckDB and `vector(N)` on pgvector); every statement matches a
  shape the CoreDB inventory pins on both backends.

## `pkg/db` transaction fix
DuckDB has no nested transactions, so `WithTx` flattens nesting onto one
`*sql.Tx` via a counter. Two bugs fixed:
- `defer Rollback(); … ; Commit()` was unsafe nested — the deferred Rollback
  after a nested Commit physically rolled back the **parent** tx.
- A nested Rollback only decremented, so a failed inner scope could still be
  committed by the owner.

Each `WithTx` now gets its own frame with an idempotent terminal, and a
Rollback at any level rolls the whole flattened tx back once and poisons it.
The `committed`-flag dance in the store writer is gone as a result.

## Notes
- The store is **not yet wired** to the engine — that is the CatalogManager
  flag-switch step (Ш6), which will also introduce the real nested-transaction
  usage this db fix enables.
- Unit + golden + store/db suites green. Both e2e suites to run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)