### PR TITLE
A field resolved to null must reach the response

### DIFF
--- a/integration-test/e2e/testdata/queries/jq/transform/expected.json
+++ b/integration-test/e2e/testdata/queries/jq/transform/expected.json
@@ -1,4 +1,7 @@
 {
+  "data": {
+    "jq": null
+  },
   "extensions": {
     "jq": {
       "jq": [

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -334,23 +333,18 @@ func (s *Server) queryScan(ctx context.Context, gql string, vars map[string]any,
 // queryScanLookup executes a SINGLE-lookup query — one aliased root field that
 // the engine may resolve to null — and reports whether it was served at all.
 //
-// A null does not arrive as a JSON null. The engine drops a nil result before
-// it reaches the response (query.go, processQuerySequential: "res == nil &&
-// ext == nil → continue"), and on the parallel path the key is set but a
-// single-key null response collapses the whole data map to nil (query.go, the
-// len(data) == 1 check). So a path scan answers "wrong data path" or "no data"
-// depending on AllowParallel, and a tool that scanned by path would hand the
-// agent that engine error instead of saying which name it could not resolve.
+// The alias is read off the ROOT rather than scanned by path, because a null
+// AT a path is not something ScanData can report: it walks into the value and
+// answers ErrNoData, the same error a broken response gives. Here the two must
+// stay apart — "no such name, or not yours" is an answer the agent can act on,
+// and an engine failure is not.
 //
-// Scanning the ROOT sidesteps both: an unserved alias is simply missing, and
-// the two errors mean the same thing here. Absent is NOT distinguishable from
-// "hidden from this caller" — by design, that is what the tools report.
+// (Until the null-response fix this also had to tolerate the path scan failing
+// outright, because a resolved-to-null field never reached the response at
+// all. It does now, so a scan error is once again just an error.)
 func (s *Server) queryScanLookup(ctx context.Context, gql string, vars map[string]any, alias string, target any) (bool, error) {
 	root := map[string]json.RawMessage{}
-	switch err := s.queryScan(ctx, gql, vars, "", &root); {
-	case errors.Is(err, types.ErrNoData), errors.Is(err, types.ErrWrongDataPath):
-		return false, nil
-	case err != nil:
+	if err := s.queryScan(ctx, gql, vars, "", &root); err != nil {
 		return false, err
 	}
 	raw, ok := root[alias]

--- a/query.go
+++ b/query.go
@@ -105,13 +105,6 @@ func (s *Service) processQuery(ctx context.Context, provider catalog.Provider, o
 		types.DataClose(data)
 		return nil, nil, err
 	}
-	if len(data) == 1 {
-		for _, v := range data {
-			if v == nil {
-				data = nil
-			}
-		}
-	}
 	if len(extensions) == 0 && op.Definition.Directives.ForName(base.StatsDirectiveName) == nil {
 		return data, nil, nil
 	}
@@ -223,7 +216,12 @@ func (s *Service) processQuerySequential(ctx context.Context,
 		if err != nil {
 			return err
 		}
-		if res == nil && ext == nil {
+		// A resolved-to-null field must still reach the response as an explicit
+		// null — the client asked for it, so the spec says it appears. Only a
+		// query that produced NEITHER data nor extensions is skipped, and
+		// QueryTypeNone is exactly that: a grouping node whose children were
+		// already sent with a deeper path.
+		if res == nil && ext == nil && query.QueryType == base.QueryTypeNone {
 			continue
 		}
 		select {

--- a/response_null_test.go
+++ b/response_null_test.go
@@ -4,6 +4,7 @@ package hugr
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/hugr-lab/query-engine/pkg/auth"
@@ -65,20 +66,41 @@ func TestNullFieldReachesTheResponse(t *testing.T) {
 			}
 
 			// Scanning INTO the null still reports no data — that is what
-			// ScanData means by a nil value, and callers that need to tell
-			// "served null" from "no answer" read the parent instead.
+			// ScanData documents a nil leaf to mean, and callers that need to
+			// tell "served null" from "no answer" read the parent instead.
 			var node struct {
 				Name string `json:"name"`
 			}
-			if err := res.ScanData("_dataObject", &node); err == nil {
-				t.Fatal("scanning into a null must not succeed")
-			} else if !isNoData(err) {
+			if err := res.ScanData("_dataObject", &node); !errors.Is(err, types.ErrNoData) {
 				t.Fatalf("scanning into a null: got %v, want ErrNoData", err)
+			}
+
+			// The same for a DATA query that matched nothing. This is not the
+			// path the bug was found on, but it is the same defect:
+			// processDataQuery returns nil on sql.ErrNoRows, so a by-pk lookup
+			// that found no row was losing its key too, and a client could not
+			// tell "no such row" from "something went wrong".
+			res2, err := service.Query(ctx,
+				`{ core { data_sources_by_pk(name: "no_such_source") { name } } }`, nil)
+			if err != nil {
+				t.Fatalf("by-pk query: %v", err)
+			}
+			if rerr := res2.Err(); rerr != nil {
+				t.Fatalf("by-pk response error: %v", rerr)
+			}
+			defer res2.Close()
+
+			core, ok := res2.Data["core"].(map[string]any)
+			if !ok {
+				t.Fatalf("core is missing from the response: %v", res2.Data)
+			}
+			v, ok = core["data_sources_by_pk"]
+			if !ok {
+				t.Fatalf("a by-pk lookup that matched nothing lost its key: %v", core)
+			}
+			if v != nil {
+				t.Fatalf("data_sources_by_pk = %v, want null", v)
 			}
 		})
 	}
-}
-
-func isNoData(err error) bool {
-	return err == types.ErrNoData
 }

--- a/response_null_test.go
+++ b/response_null_test.go
@@ -1,0 +1,84 @@
+//go:build duckdb_arrow
+
+package hugr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hugr-lab/query-engine/pkg/auth"
+	coredb "github.com/hugr-lab/query-engine/pkg/data-sources/sources/runtime/core-db"
+	"github.com/hugr-lab/query-engine/pkg/db"
+	"github.com/hugr-lab/query-engine/types"
+)
+
+// A field the engine resolves to NULL must appear in the response as an
+// explicit null. It used to vanish: the sequential path dropped a nil result
+// before it reached the response, and the collector then collapsed a
+// single-key null response to a nil data map — so the same query answered
+// "wrong data path" or "no data" depending on AllowParallel, and neither said
+// anything about the field that was asked for.
+//
+// Both paths are covered here, because they failed differently.
+func TestNullFieldReachesTheResponse(t *testing.T) {
+	for _, parallel := range []bool{false, true} {
+		name := "sequential"
+		if parallel {
+			name = "parallel"
+		}
+		t.Run(name, func(t *testing.T) {
+			service, err := New(Config{
+				DB:            db.Config{Path: ""},
+				CoreDB:        coredb.New(coredb.Config{}),
+				Auth:          &auth.Config{},
+				AllowParallel: parallel,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := auth.ContextWithFullAccess(context.Background())
+			if err := service.Init(ctx); err != nil {
+				t.Fatal(err)
+			}
+			defer service.Close()
+
+			// One root field, resolved to null: the shape that used to lose it
+			// entirely. A meta lookup is the cheapest way to produce one.
+			res, err := service.Query(ctx, `{ _dataObject(name: "no_such_object") { name } }`, nil)
+			if err != nil {
+				t.Fatalf("query: %v", err)
+			}
+			if rerr := res.Err(); rerr != nil {
+				t.Fatalf("response error: %v", rerr)
+			}
+			defer res.Close()
+
+			if res.Data == nil {
+				t.Fatal("data is nil — a null field collapsed the whole response")
+			}
+			v, ok := res.Data["_dataObject"]
+			if !ok {
+				t.Fatalf("the field is missing from the response entirely: %v", res.Data)
+			}
+			if v != nil {
+				t.Fatalf("_dataObject = %v, want null", v)
+			}
+
+			// Scanning INTO the null still reports no data — that is what
+			// ScanData means by a nil value, and callers that need to tell
+			// "served null" from "no answer" read the parent instead.
+			var node struct {
+				Name string `json:"name"`
+			}
+			if err := res.ScanData("_dataObject", &node); err == nil {
+				t.Fatal("scanning into a null must not succeed")
+			} else if !isNoData(err) {
+				t.Fatalf("scanning into a null: got %v, want ErrNoData", err)
+			}
+		})
+	}
+}
+
+func isNoData(err error) bool {
+	return err == types.ErrNoData
+}


### PR DESCRIPTION
A field the engine resolves to `null` did not appear in the response at all — the key was simply absent. Found while reviewing #146: four MCP tools were handing agents `wrong data path` where they meant "no such name, or not visible to you", and the guard they had for it was unreachable.

## Two places, two different symptoms

- `processQuerySequential` dropped a nil result before sending it, so the key never entered the data map → `ScanData` answers `ErrWrongDataPath`.
- On the parallel path the key *was* set, but the collector then collapsed any single-key null response to a nil data map → `ScanData` answers `ErrNoData`.

So which error a caller saw depended on `AllowParallel`, and per the GraphQL spec both are wrong: the client selected the field, so it appears, as `null`.

The skip now applies only to `QueryTypeNone` — a grouping node whose children were already sent under a deeper path, and the one query kind that legitimately produces neither data nor extensions.

## Scope

Deliberately **not** narrowed to meta queries, which is only where it was noticed. `processDataQuery` returns nil on `sql.ErrNoRows`, so a `_by_pk` lookup that matched nothing was losing its key too — a client could not tell "no such row" from "something went wrong". Both scopes were measured against the full suite and the blast radius is identical, so the general fix is the one worth having.

## What moves

One expectation: `jq/transform` now carries `"data": {"jq": null}`. A JQ transform's payload lives in `extensions` and its `data` field really is null — it was being hidden by the collapse. `go test ./...` is clean and e2e is 235/235.

`h3/basic` also rewrote itself under `UPDATE_EXPECTED=1` (the two H3 cells swapped order) and was reverted — that golden is order-unstable on its own, unrelated to this change, and worth a separate look.

## Test

`response_null_test.go` covers both paths, because they failed differently. Without the fix:

```
sequential: the field is missing from the response entirely: map[]
parallel:   data is nil — a null field collapsed the whole response
```

## MCP

`queryScanLookup` no longer swallows `ErrNoData` / `ErrWrongDataPath`. That tolerance existed only because a null never arrived; keeping it would turn a genuine engine failure into "name not found". It still reads the alias off the **root**: `ScanData` walks *into* the value, so a null at a path stays indistinguishable from no answer at all, and the tools have to tell those two apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016k9uaQHqunF6isM3XhS5PN