### PR TITLE
Enforce the cross-source contract on the extend-type path

### DIFF
--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/01_register_plain.graphql
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/01_register_plain.graphql
@@ -1,0 +1,18 @@
+# The registration is only a row — nothing is compiled until the load, which is
+# why it is a step of its own: a mutation cannot both insert a source and load it.
+#
+# An HTTP source, because the point is the SDL and nothing else: it attaches
+# without touching a file, so the load reaches the compile step cleanly on every
+# engine variant (a DuckDB file would still be locked from the previous run).
+mutation {
+  core {
+    insert_data_sources(data: {
+      name: "cross_plain"
+      prefix: "cross_plain"
+      type: "http"
+      path: "http://http-service:17000"
+      as_module: false
+      catalogs: [{ name: "cross_contract_plain", type: "localFS", path: "/workspace/schemas/cross_contract" }]
+    }) { name }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/01_register_plain.json
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/01_register_plain.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "core": {
+      "insert_data_sources": {
+        "name": "cross_plain"
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/02_plain_load_refused.graphql
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/02_plain_load_refused.graphql
@@ -1,0 +1,10 @@
+# A regular source describes only its own data. Reaching into another source's
+# type through `extend type` is the same act as an @join to a foreign target,
+# and is refused with the same reasoning.
+mutation {
+  function {
+    core {
+      load_data_source(name: "cross_plain") { success message }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/02_plain_load_refused.json
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/02_plain_load_refused.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "function": {
+      "core": {
+        "load_data_source": {
+          "message": "compile catalog \"cross_plain\": catalog schema is invalid: schema.graphql:8:13: [VALIDATE/ExtensionValidator] extend type local_db_items: data source local_db — a regular source describes only its own data; cross-source extensions belong to an extension source (IsExtension)",
+          "success": false
+        }
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/02_plain_load_refused.json
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/02_plain_load_refused.json
@@ -3,7 +3,7 @@
     "function": {
       "core": {
         "load_data_source": {
-          "message": "compile catalog \"cross_plain\": catalog schema is invalid: schema.graphql:8:13: [VALIDATE/ExtensionValidator] extend type local_db_items: data source local_db — a regular source describes only its own data; cross-source extensions belong to an extension source (IsExtension)",
+          "message": "compile catalog \"cross_plain\": catalog schema is invalid: schema.graphql:8:13: [VALIDATE/ExtensionValidator] extend type local_db_items: it belongs to data source \"local_db\" \u2014 a regular source describes only its own data, and cross-source extensions belong to an extension source",
           "success": false
         }
       }

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/03_drop_plain.graphql
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/03_drop_plain.graphql
@@ -1,0 +1,15 @@
+# Unload BEFORE deleting: deleting the row does not detach the source, and a
+# still-attached database is visible to every later test that enumerates them.
+# catalog_sources also outlives its data source, so it goes explicitly — the
+# next registration points at the same directory under its own name.
+mutation {
+  function {
+    core {
+      unload_data_source(name: "cross_plain") { success }
+    }
+  }
+  core {
+    delete_data_sources(filter: { name: { eq: "cross_plain" } }) { success }
+    delete_catalog_sources(filter: { name: { eq: "cross_contract_plain" } }) { success }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/03_drop_plain.json
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/03_drop_plain.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "core": {
+      "delete_catalog_sources": {
+        "success": true
+      },
+      "delete_data_sources": {
+        "success": true
+      }
+    },
+    "function": {
+      "core": {
+        "unload_data_source": {
+          "success": true
+        }
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/04_register_extension.graphql
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/04_register_extension.graphql
@@ -1,0 +1,13 @@
+# The SAME schema directory, registered as an extension source.
+mutation {
+  core {
+    insert_data_sources(data: {
+      name: "cross_ext"
+      prefix: "cross_ext"
+      type: "extension"
+      path: ""
+      as_module: false
+      catalogs: [{ name: "cross_contract_ext", type: "localFS", path: "/workspace/schemas/cross_contract" }]
+    }) { name }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/04_register_extension.json
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/04_register_extension.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "core": {
+      "insert_data_sources": {
+        "name": "cross_ext"
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/05_extension_load_accepted.graphql
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/05_extension_load_accepted.graphql
@@ -1,0 +1,7 @@
+mutation {
+  function {
+    core {
+      load_data_source(name: "cross_ext") { success message }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/05_extension_load_accepted.json
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/05_extension_load_accepted.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "function": {
+      "core": {
+        "load_data_source": {
+          "message": "Datasource was loaded",
+          "success": true
+        }
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/06_contributed_field_serves.graphql
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/06_contributed_field_serves.graphql
@@ -1,0 +1,9 @@
+# The contributed field is in the schema and returns the joined rows.
+{
+  local_db {
+    items(order_by: [{ field: "id", direction: ASC }], limit: 2) {
+      id
+      contract_probe { id }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/06_contributed_field_serves.json
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/06_contributed_field_serves.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "local_db": {
+      "items": [
+        {
+          "contract_probe": [
+            {
+              "id": 1
+            }
+          ],
+          "id": 1
+        },
+        {
+          "contract_probe": [
+            {
+              "id": 2
+            }
+          ],
+          "id": 2
+        }
+      ]
+    }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/07_cleanup.graphql
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/07_cleanup.graphql
@@ -1,0 +1,11 @@
+mutation {
+  function {
+    core {
+      unload_data_source(name: "cross_ext") { success }
+    }
+  }
+  core {
+    delete_data_sources(filter: { name: { eq: "cross_ext" } }) { success }
+    delete_catalog_sources(filter: { name: { eq: "cross_contract_ext" } }) { success }
+  }
+}

--- a/integration-test/e2e/testdata/queries/extensions/cross_source_contract/07_cleanup.json
+++ b/integration-test/e2e/testdata/queries/extensions/cross_source_contract/07_cleanup.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "core": {
+      "delete_catalog_sources": {
+        "success": true
+      },
+      "delete_data_sources": {
+        "success": true
+      }
+    },
+    "function": {
+      "core": {
+        "unload_data_source": {
+          "success": true
+        }
+      }
+    }
+  }
+}

--- a/integration-test/e2e/testdata/schemas/cross_contract/schema.graphql
+++ b/integration-test/e2e/testdata/schemas/cross_contract/schema.graphql
@@ -1,0 +1,15 @@
+# One SDL, two verdicts — the point of the cross-source contract.
+#
+# It contributes a field to local_db's object. Registered as a PLAIN source it is
+# refused: a regular source describes only its own data, and reaching into
+# another source's type through `extend type` is the same act as an @join to a
+# foreign target, which has always been refused on the object path. Registered as
+# an EXTENSION source the identical file loads and serves.
+extend type local_db_items
+  @dependency(name: "local_db") {
+  contract_probe: [local_db_events] @join(
+    references_name: "local_db_events"
+    source_fields: ["id"]
+    references_fields: ["id"]
+  )
+}

--- a/pkg/catalog/ingest/validate_extension.go
+++ b/pkg/catalog/ingest/validate_extension.go
@@ -22,7 +22,7 @@ func (r *ExtensionValidator) Phase() base.Phase { return base.PhaseValidate }
 
 func (r *ExtensionValidator) ProcessAll(ctx base.CompilationContext) error {
 	if !ctx.CompileOptions().IsExtension {
-		return nil
+		return validateNoCrossSourceExtends(ctx)
 	}
 
 	for def := range ctx.Source().Definitions(ctx.Context()) {
@@ -38,6 +38,63 @@ func (r *ExtensionValidator) ProcessAll(ctx base.CompilationContext) error {
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+// validateNoCrossSourceExtends enforces, for a source that is NOT an extension,
+// the contract the whole catalog rests on: a regular source describes ONLY its
+// own data.
+//
+// `extend type X` where X belongs to another source is how a source reaches
+// across the seam — it is the same act as an `@join` or `@function_call` to a
+// foreign target, which JoinValidator and FunctionCallValidator already refuse
+// outside an extension source (rules 2b / 1b). Reached through an `extend type`
+// it was refused nowhere: InternalExtensionMerger asks only whether the target
+// resolves in the provider, never who is asking. So a plain source could
+// contribute fields to another source's objects, which then outlive their
+// declarer in ways nothing accounts for — the storage attributes them to the
+// source the DATA comes from, and the dependency gating that makes extensions
+// safe is only wired for extension sources.
+//
+// The module ROOTS are not cross-source: every source declares its functions
+// and subscriptions by extending them, and they are engine-owned, not another
+// source's property.
+func validateNoCrossSourceExtends(ctx base.CompilationContext) error {
+	extSrc, ok := ctx.Source().(base.ExtensionsSource)
+	if !ok {
+		return nil
+	}
+	for ext := range extSrc.Extensions(ctx.Context()) {
+		switch ext.Name {
+		case base.QueryBaseName, base.MutationBaseName, base.SubscriptionBaseName,
+			base.FunctionTypeName, base.FunctionMutationTypeName:
+			continue
+		}
+		if base.ModuleRootInfo(ext) != nil {
+			continue
+		}
+		// The source's own type: `extend type Foo` next to `type Foo` is a
+		// same-source merge, which PREPARE does in place.
+		if ctx.Source().ForName(ctx.Context(), ext.Name) != nil {
+			continue
+		}
+		// Anything else is either another source's type or a type that does not
+		// exist. Both are refused here: the first breaks the contract, and the
+		// second is a typo that would otherwise vanish without a trace —
+		// InternalExtensionMerger skips an unresolvable target silently.
+		owner := "another data source"
+		if def := ctx.LookupType(ext.Name); def != nil {
+			if c := base.DefinitionCatalog(def); c != "" {
+				owner = "data source " + c
+			}
+		} else {
+			owner = "no known type"
+		}
+		return gqlerror.ErrorPosf(ext.Position,
+			"extend type %s: %s — a regular source describes only its own data; "+
+				"cross-source extensions belong to an extension source (IsExtension)",
+			ext.Name, owner)
 	}
 	return nil
 }

--- a/pkg/catalog/ingest/validate_extension.go
+++ b/pkg/catalog/ingest/validate_extension.go
@@ -79,22 +79,25 @@ func validateNoCrossSourceExtends(ctx base.CompilationContext) error {
 		if ctx.Source().ForName(ctx.Context(), ext.Name) != nil {
 			continue
 		}
-		// Anything else is either another source's type or a type that does not
-		// exist. Both are refused here: the first breaks the contract, and the
-		// second is a typo that would otherwise vanish without a trace —
-		// InternalExtensionMerger skips an unresolvable target silently.
-		owner := "another data source"
-		if def := ctx.LookupType(ext.Name); def != nil {
-			if c := base.DefinitionCatalog(def); c != "" {
-				owner = "data source " + c
-			}
-		} else {
-			owner = "no known type"
+		// Three ways to get here, and they want different advice.
+		target := ctx.LookupType(ext.Name)
+		switch {
+		case target == nil:
+			// A typo. It used to vanish without a trace: InternalExtensionMerger
+			// skips an unresolvable target silently, so the fields were simply
+			// never contributed and nothing said why.
+			return gqlerror.ErrorPosf(ext.Position,
+				"extend type %s: no such type", ext.Name)
+		case base.DefinitionCatalog(target) == "":
+			// A system type — the engine's, not a data source's.
+			return gqlerror.ErrorPosf(ext.Position,
+				"extend type %s: system types cannot be extended", ext.Name)
+		default:
+			return gqlerror.ErrorPosf(ext.Position,
+				"extend type %s: it belongs to data source %q — a regular source describes "+
+					"only its own data, and cross-source extensions belong to an extension source",
+				ext.Name, base.DefinitionCatalog(target))
 		}
-		return gqlerror.ErrorPosf(ext.Position,
-			"extend type %s: %s — a regular source describes only its own data; "+
-				"cross-source extensions belong to an extension source (IsExtension)",
-			ext.Name, owner)
 	}
 	return nil
 }

--- a/pkg/catalog/ingest/validate_join.go
+++ b/pkg/catalog/ingest/validate_join.go
@@ -38,14 +38,55 @@ func (r *JoinValidator) ProcessAll(ctx base.CompilationContext) error {
 		if def == nil {
 			continue
 		}
-		for _, f := range def.Fields {
-			joinDir := f.Directives.ForName(base.JoinDirectiveName)
-			if joinDir == nil {
+		if err := validateJoinFields(ctx, def, def.Fields, false); err != nil {
+			return err
+		}
+	}
+
+	// The fields an EXTENSION source contributes to another source's objects
+	// live in the output extensions, not in ctx.Objects() — which holds only a
+	// source's own data objects. They were validated nowhere, and they are
+	// exactly where the cross-source joins are: the contract sends every
+	// cross-source artifact to an extension source, so this is the path that
+	// carries them.
+	for ext := range ctx.OutputExtensions() {
+		target := inFlightType(ctx, ext.Name)
+		if target == nil {
+			// The object being extended is not resolvable — its source is not
+			// loaded yet. The dependency gate handles that (the source is
+			// stored suspended and retried); it is not this rule's error to
+			// raise.
+			continue
+		}
+		if err := validateJoinFields(ctx, target, ext.Fields, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateJoinFields checks every @join among fields, declared on def.
+//
+// tolerateMissingTarget applies to the extension path: a @join whose TARGET
+// does not resolve is skipped rather than refused, because "not resolvable" and
+// "belongs to a source that is not active yet" are the same answer through the
+// Provider, and the second is a legitimate ordering state that the dependency
+// gate suspends and retries. Everything else about the field is still checked
+// the moment the target does resolve.
+func validateJoinFields(ctx base.CompilationContext, def *ast.Definition, fields ast.FieldList, tolerateMissingTarget bool) error {
+	for _, f := range fields {
+		joinDir := f.Directives.ForName(base.JoinDirectiveName)
+		if joinDir == nil {
+			continue
+		}
+		if tolerateMissingTarget {
+			refName := base.DirectiveArgString(joinDir, base.ArgReferencesName)
+			if inFlightType(ctx, refName) == nil {
 				continue
 			}
-			if err := validateJoinField(ctx, def, f, joinDir); err != nil {
-				return err
-			}
+		}
+		if err := validateJoinField(ctx, def, f, joinDir); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -119,10 +160,10 @@ func validateJoinField(ctx base.CompilationContext, def *ast.Definition, field *
 				"@join on %s.%s: references field %q not found in %s",
 				def.Name, field.Name, rfn, refName)
 		}
-		if !equalTypesIgnoreNull(sf.Type, rf.Type) {
+		if !joinKeyCompatible(sf.Type, rf.Type) {
 			return gqlerror.ErrorPosf(field.Position,
-				"@join on %s.%s: field %q and references field %q must have the same type",
-				def.Name, field.Name, sfn, rfn)
+				"@join on %s.%s: key %q is %s and references field %q is %s — join keys must be the same type (Int and BigInt are interchangeable)",
+				def.Name, field.Name, sfn, sf.Type.String(), rfn, rf.Type.String())
 		}
 	}
 
@@ -283,4 +324,32 @@ func equalTypesIgnoreNull(a, b *ast.Type) bool {
 		return false
 	}
 	return equalTypesIgnoreNull(a.Elem, b.Elem)
+}
+
+// joinKeyCompatible is equalTypesIgnoreNull widened by ONE rule: Int and BigInt
+// join each other.
+//
+// A join key is compared, not assigned, and every engine compares integers of
+// different widths without complaint. Requiring the exact type name is a
+// sensible default within one source, where a modeller controls both sides; it
+// is the wrong test ACROSS sources, where the width comes from the backend —
+// PostgreSQL's int4 arrives as Int and DuckDB's BIGINT as BigInt, so joining
+// two id columns that hold the same numbers is refused for naming a different
+// scalar. That is not a hypothetical: it is what the e2e bridge does.
+//
+// Deliberately only integers. Float↔Int would silently change what "equal"
+// means, and the rest of the scalar set has no pair whose values are
+// interchangeable.
+func joinKeyCompatible(a, b *ast.Type) bool {
+	if equalTypesIgnoreNull(a, b) {
+		return true
+	}
+	if a == nil || b == nil || a.Elem != nil || b.Elem != nil {
+		return false
+	}
+	return isIntegerScalar(a.NamedType) && isIntegerScalar(b.NamedType)
+}
+
+func isIntegerScalar(name string) bool {
+	return name == "Int" || name == "BigInt"
 }

--- a/pkg/catalog/ingest/validate_join_keys_test.go
+++ b/pkg/catalog/ingest/validate_join_keys_test.go
@@ -1,0 +1,46 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func namedType(name string, nonNull bool) *ast.Type {
+	return &ast.Type{NamedType: name, NonNull: nonNull}
+}
+
+// TestJoinKeyCompatible pins the one widening the cross-source path forced:
+// Int and BigInt are the same join key, because the width comes from the
+// backend (PostgreSQL int4 → Int, DuckDB BIGINT → BigInt) and a key is compared,
+// not assigned. Nothing else is interchangeable.
+func TestJoinKeyCompatible(t *testing.T) {
+	list := func(t *ast.Type) *ast.Type { return &ast.Type{Elem: t} }
+
+	cases := []struct {
+		name string
+		a, b *ast.Type
+		want bool
+	}{
+		{"identical", namedType("Int", false), namedType("Int", false), true},
+		{"nullability ignored", namedType("Int", true), namedType("Int", false), true},
+		{"Int joins BigInt", namedType("Int", false), namedType("BigInt", false), true},
+		{"BigInt joins Int", namedType("BigInt", true), namedType("Int", false), true},
+		{"Int does not join String", namedType("Int", false), namedType("String", false), false},
+		{"Int does not join Float", namedType("Int", false), namedType("Float", false), false},
+		{"BigInt does not join Timestamp", namedType("BigInt", false), namedType("Timestamp", false), false},
+		// A list key is not widened: [Int] and [BigInt] are different shapes,
+		// and the pairwise rule says nothing about element-wise comparison.
+		{"lists are not widened", list(namedType("Int", false)), list(namedType("BigInt", false)), false},
+		{"identical lists", list(namedType("Int", false)), list(namedType("Int", false)), true},
+		{"nil pair", nil, nil, true},
+		{"one nil", namedType("Int", false), nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := joinKeyCompatible(c.a, c.b); got != c.want {
+				t.Errorf("joinKeyCompatible = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/catalog/store/cache_test.go
+++ b/pkg/catalog/store/cache_test.go
@@ -151,17 +151,25 @@ type b_obj @module(name: "app") @table(name: "b_obj")
 	assert.Nil(t, dropped.Fields.ForName("b_items"), "back navigation dropped with B")
 }
 
-// TestCacheJoinTargetClosure pins the cross-source @join semantics the
-// multi-source golden established: an extension source's @join to a FOREIGN
-// object serves a BARE declared field (no subquery args, no aggregation twins)
-// — and stays bare through the target source's whole lifecycle; the target
-// lookup still records provenance, so the definition re-resolves cleanly on
-// every flip instead of serving stale machinery.
+// TestCacheJoinTargetClosure pins the cross-source @join lifecycle: a field an
+// EXTENSION source contributes to one source's object, joining to ANOTHER
+// source's object, is served exactly while the source its DATA comes from is
+// active — and the definition cache re-resolves on every flip instead of
+// serving a stale shape.
 //
-// The join lives in an EXTENSION source, the only place the contract allows a
-// cross-source artifact — the same shape genMultiFixtures pins (audit_events →
-// ro's logs). A cross-source @join declared inline in a plain source is refused
-// on the write path (JoinValidator rule 2b).
+// The join lives in an extension source, the only place the contract allows a
+// cross-source artifact; the same shape genMultiFixtures pins (audit_events →
+// ro's logs). A cross-source @join declared inline in a plain source, or a
+// plain source extending another source's type at all, is refused on the write
+// path.
+//
+// The field used to be served BARE when the target was missing — declared, but
+// with no subquery machinery. That was an artifact of the write path not
+// recording who the field belongs to: JoinValidator did not walk extension
+// fields, so nothing propagated the target's @catalog and the row was
+// attributed to the extension. The read side computed the right owner anyway,
+// which is why the flag-play contract already said "hidden with its data
+// source" while this test said "bare". Both sides agree now.
 func TestCacheJoinTargetClosure(t *testing.T) {
 	const schemaB = `
 type b_stats @module(name: "app") @table(name: "b_stats") {
@@ -197,19 +205,14 @@ extend type a_orders {
 		SourceState{Name: "ext", Version: "v1", Engine: "duckdb", IsExtension: true, Loaded: true})
 	require.NoError(t, err)
 
-	// Bare: the field is declared and served, but with no subquery machinery —
-	// the target is not resolvable, so there is nothing to build it from.
-	assertBare := func(when string) {
+	// The base object is always served — only the contributed field follows the
+	// target's source.
+	assertHidden := func(when string) {
 		def := store.ForName(ctx, "a_orders")
 		require.NotNilf(t, def, "a_orders served (%s)", when)
-		fd := def.Fields.ForName("stats")
-		require.NotNilf(t, fd, "declared join field present (%s)", when)
-		assert.Emptyf(t, fd.Arguments, "join field stays bare (%s)", when)
-		assert.Nilf(t, def.Fields.ForName("stats_aggregation"), "no twins without a target (%s)", when)
+		assert.Nilf(t, def.Fields.ForName("stats"), "join field hidden with its data source (%s)", when)
+		assert.Nilf(t, def.Fields.ForName("stats_aggregation"), "no twin either (%s)", when)
 	}
-	// Wired: the target resolves, so the field carries the full subquery
-	// surface and its aggregation twin — compiled parity (golden multi.graphql,
-	// audit_events.logs).
 	assertWired := func(when string) {
 		def := store.ForName(ctx, "a_orders")
 		require.NotNilf(t, def, "a_orders served (%s)", when)
@@ -219,18 +222,18 @@ extend type a_orders {
 		assert.NotNilf(t, def.Fields.ForName("stats_aggregation"), "aggregation twin generated (%s)", when)
 	}
 
-	assertBare("target absent")
+	assertHidden("target absent")
 
-	// Register the target source — the field gains its machinery.
+	// Register the target source — the field appears, fully wired.
 	dB := collect(ctx, srcB, "b")
 	_, err = store.writeSource(ctx, dB, SourceState{Name: "b", Version: "v1", Engine: "duckdb", Loaded: true})
 	require.NoError(t, err)
 	assertWired("target active")
 
-	// ...and loses it again when the target goes away: the cached definition
-	// is invalidated by the flip, not served stale.
+	// ...and goes again when the target does: the cached definition is
+	// invalidated by the flip, not served stale.
 	require.NoError(t, store.setFlags(ctx, "b", true, true, false))
-	assertBare("target disabled")
+	assertHidden("target disabled")
 }
 
 // TestMultiSourceFlagPlay drives the 5-source golden fixture set through

--- a/pkg/catalog/store/collect_test.go
+++ b/pkg/catalog/store/collect_test.go
@@ -353,3 +353,73 @@ type shipments @table(name: "shipments") {
 	assert.Equal(t, []string{"vendor_id"},
 		d.relations[pkKey("shipments", "parts_vendor_ref")].DestinationKeys)
 }
+
+// compileErr runs the pipeline over a schema and returns the error, if any —
+// the negative counterpart of partialSource, which requires success.
+func compileErr(t *testing.T, name, schema string, isExtension bool, seeds ...base.DefinitionsSource) error {
+	t.Helper()
+	ctx := context.Background()
+	prelude, err := static.New()
+	require.NoError(t, err)
+	target := seedProvider{Provider: prelude, seeded: map[string]*ast.Definition{}}
+	for _, seed := range seeds {
+		for def := range seed.Definitions(ctx) {
+			target.seeded[def.Name] = def
+		}
+	}
+	e := &engines.DuckDB{}
+	src, err := sources.NewStringSource(name, e, base.Options{
+		Name:         name,
+		EngineType:   string(e.Type()),
+		Capabilities: e.Capabilities(),
+		IsExtension:  isExtension,
+	}, schema)
+	require.NoError(t, err)
+	_, err = ingest.New(ingest.Default()...).Compile(ctx, target, src, src.CompileOptions())
+	return err
+}
+
+// TestCrossSourceExtendContract pins the rule that a REGULAR source describes
+// only its own data. Reaching into another source's type through `extend type`
+// was accepted by nobody's decision — the merger only asked whether the target
+// resolved — while the same reach through @join or @function_call had always
+// been refused.
+func TestCrossSourceExtendContract(t *testing.T) {
+	const baseSchema = `type customers @module(name: "sales") @table(name: "customers") {
+  id: Int! @pk
+  name: String!
+}`
+	srcA := partialSource(t, "A", baseSchema)
+
+	t.Run("plain source may not extend another source's type", func(t *testing.T) {
+		err := compileErr(t, "B", `extend type customers { note: String }`, false, definitionsOnly{srcA})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `belongs to data source "A"`)
+	})
+
+	t.Run("an extension source may", func(t *testing.T) {
+		assert.NoError(t, compileErr(t, "B", `extend type customers { note: String }`, true, definitionsOnly{srcA}))
+	})
+
+	t.Run("a typo is refused rather than silently dropped", func(t *testing.T) {
+		err := compileErr(t, "B", `extend type custmoers { note: String }`, false, definitionsOnly{srcA})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no such type")
+	})
+
+	t.Run("system types cannot be extended", func(t *testing.T) {
+		err := compileErr(t, "B", `extend type _join { note: String }`, false, definitionsOnly{srcA})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "system types cannot be extended")
+	})
+
+	t.Run("a source may extend its OWN type", func(t *testing.T) {
+		assert.NoError(t, compileErr(t, "B", baseSchema+"\nextend type customers { note: String }", false))
+	})
+
+	t.Run("module roots stay open to every source", func(t *testing.T) {
+		assert.NoError(t, compileErr(t, "B", `extend type Function {
+  b_fn(id: Int!): String @function(name: "b_fn")
+}`, false))
+	})
+}

--- a/pkg/catalog/store/collect_test.go
+++ b/pkg/catalog/store/collect_test.go
@@ -309,7 +309,7 @@ func TestCollectExtensionFields(t *testing.T) {
   note: String
 }`
 	srcA := partialSource(t, "A", baseSchema)
-	srcB := partialSource(t, "B", extSchema, srcA) // B compiled with A's customers seeded
+	srcB := partialExtensionSource(t, "B", extSchema, srcA) // B extends A's customers
 
 	dA := collect(ctx, srcA, "A")
 	require.Contains(t, dA.dataObjects, "customers")

--- a/pkg/catalog/store/writer_test.go
+++ b/pkg/catalog/store/writer_test.go
@@ -150,7 +150,7 @@ func TestWriteExtensionComposition(t *testing.T) {
 }`
 	const extSchema = `extend type customers { note: String }`
 	srcA := partialSource(t, "A", baseSchema)
-	srcB := partialSource(t, "B", extSchema, srcA)
+	srcB := partialExtensionSource(t, "B", extSchema, srcA)
 
 	dA := collect(ctx, srcA, "A")
 	dB := collect(ctx, srcB, "B")


### PR DESCRIPTION
The follow-up design-036 carried out of #149.

The contract the catalog rests on is that a regular source describes ONLY its
own data, and every cross-source artifact lives in an extension source.
`JoinValidator` and `FunctionCallValidator` enforce it for a source's own
objects. Reached through `extend type <another source's object>` it was enforced
**nowhere**: `InternalExtensionMerger` asks only whether the target resolves in
the provider, never who is asking. A plain source could contribute fields to
another source's objects — attributed to the source the DATA comes from, and
outside the dependency gating that makes extensions safe.

## What this does

- **`ExtensionValidator` refuses cross-source `extend type` from a non-extension
  source.** Module roots stay exempt: extending `Function` is how every source
  declares its functions, and those are engine-owned. A target that resolves
  nowhere is refused too — the merger used to skip it silently, so a typo
  vanished without a trace.
- **`JoinValidator` walks `ctx.OutputExtensions()`**, so the fields an extension
  contributes to another source's objects are validated at all, and their
  `@catalog` is propagated — which records the field's owner at WRITE time
  rather than leaving the read side to recompute it.
- **e2e `extensions/cross_source_contract`** — one schema directory, registered
  as a plain source and refused with the contract's own message, then registered
  as an extension and accepted, with the contributed field serving joined rows.

## Two things the rehearsal found

**`Int` and `BigInt` must join.** The type check required identical type names.
That is right within one source and wrong across sources, where the width comes
from the backend: PostgreSQL's `int4` arrives as `Int`, DuckDB's `BIGINT` as
`BigInt`. The e2e bridge joins exactly such a pair, and turning the extension
walk on refused it. `joinKeyCompatible` widens the rule by that one pair and
nothing else — `Float`↔`Int` would change what "equal" means.

**A contributed field now disappears with the source its data comes from.** It
used to be served BARE when the target was absent, which was an artifact of the
write path not knowing the owner. The read side already computed it — which is
why `TestMultiSourceFlagPlay` said "hidden with its data source" while
`TestCacheJoinTargetClosure` said "bare". Both sides agree now.

Two store fixtures modelled a plain source extending another source's object —
the case this refuses — and are extension sources now.

## Not included, deliberately

Making a **dangling `@join` target an error**. Through the `Provider`, "the
target does not exist" and "the target's source is not active yet" are the same
answer, and the second is a legitimate ordering state that the dependency gate
suspends and retries. `compileAndWrite` also compiles BEFORE it checks
dependencies, so a suspended source's rows would have nowhere to come from.
Closing it properly means deciding where a suspended source's rows live. Until
then the extension path tolerates a missing target and validates everything else
the moment it resolves. Recorded in the design.

## Upgrade note

This is a **new rejection class**: an SDL that loads today can stop loading. It
lands after #149 on purpose, so the suspend-instead-of-remove path is already in
place to catch it on a boot. Worth a release note.

Full suite green; e2e 241/0, e2e-hugrapp 39/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016k9uaQHqunF6isM3XhS5PN
