### PR TITLE
Deprecate hugr-tools: it is moving to the hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ See the [Hugr documentation](https://hugr-lab.github.io) for more details.
 
 ```
 cmd/dev-server/       Dev server with env-based configuration
-cmd/hugr-tools/       CLI utilities (summarize, reindex, schema-info)
-pkg/catalog/          Schema catalog: compiler, static/db providers
+cmd/hugr-tools/       CLI utilities (summarize, reindex, schema-info) — DEPRECATED, moving to the hub
+pkg/catalog/          Schema catalog: base model, ingest (write), store (read-time generation)
 pkg/cluster/          Cluster mode (management/worker nodes, heartbeat, secret sync)
 pkg/data-sources/     Runtime data source management
 pkg/planner/          Query planner and SQL generation
 pkg/cache/            Two-level caching (L1 + L2)
 pkg/auth/             Authentication middleware
 pkg/mcp/              MCP server integration
-integration-test/     Integration & E2E tests (compiler, DB provider, cluster, MCP, E2E)
+integration-test/     Integration & E2E tests (catalog, cluster, MCP, E2E)
 docs/                 Internal documentation
 ```
 
@@ -43,7 +43,7 @@ docs/                 Internal documentation
 # Dev server
 CGO_CFLAGS="-O1 -g" go build -tags=duckdb_arrow -o hugr ./cmd/dev-server
 
-# CLI tools (summarize, reindex, schema-info)
+# CLI tools (summarize, reindex, schema-info) — deprecated, see docs/hugr-tools.md
 CGO_CFLAGS="-O1 -g" go build -tags=duckdb_arrow -o hugr-tools ./cmd/hugr-tools
 ```
 
@@ -68,7 +68,10 @@ CORE_DB_PATH=./core.db MCP_ENABLED=true \
   ./hugr
 ```
 
-### Summarize schema with AI
+### Summarize schema with AI (deprecated)
+
+`hugr-tools` is deprecated and is moving to the hub; its commands no longer work
+against CoreDB 0.0.20 — see [docs/hugr-tools.md](docs/hugr-tools.md).
 
 ```bash
 # Generate descriptions for all schema entities using an LLM
@@ -87,8 +90,8 @@ See [docs/configuration.md](docs/configuration.md) for the full reference.
 |----------|-------------|
 | [docs/known-issues.md](docs/known-issues.md) | Known issues and workarounds |
 | [docs/configuration.md](docs/configuration.md) | Dev server configuration reference |
-| [docs/hugr-tools.md](docs/hugr-tools.md) | CLI utilities (summarize, reindex, schema-info) |
-| [docs/compiler/01-overview.md](docs/compiler/01-overview.md) | Compiler architecture |
+| [docs/hugr-tools.md](docs/hugr-tools.md) | CLI utilities (summarize, reindex, schema-info) — **deprecated** |
+| [docs/compiler/01-overview.md](docs/compiler/01-overview.md) | Schema architecture (write pipeline, read-time generation) |
 | [docs/compiler/02-ddl-operations.md](docs/compiler/02-ddl-operations.md) | DDL operations |
 | [docs/compiler/03-directives.md](docs/compiler/03-directives.md) | Directive reference |
 | [docs/compiler/04-tables-views.md](docs/compiler/04-tables-views.md) | Tables and views |

--- a/cmd/dev-server/README.md
+++ b/cmd/dev-server/README.md
@@ -21,9 +21,13 @@ CGO_CFLAGS="-O1 -g" go build -tags=duckdb_arrow -o hugr ./cmd/dev-server
 ./hugr -install
 ```
 
-## hugr-tools CLI
+## hugr-tools CLI (deprecated)
 
 A companion CLI for schema management and AI-powered summarization.
+
+**Deprecated — moving to the hub.** Its commands read the compiled-schema views
+that CoreDB 0.0.20 removed, so they fail against a current engine; see
+[docs/hugr-tools.md](../../docs/hugr-tools.md).
 
 ```bash
 CGO_CFLAGS="-O1 -g" go build -tags=duckdb_arrow -o hugr-tools ./cmd/hugr-tools

--- a/cmd/hugr-tools/main.go
+++ b/cmd/hugr-tools/main.go
@@ -1,3 +1,13 @@
+// Command hugr-tools is DEPRECATED and is moving to the hub; it is no longer
+// developed here.
+//
+// It has not been ported to the catalog storage introduced in CoreDB 0.0.20:
+// every command still reads the compiled-schema views (core.catalog.types,
+// core.catalog.modules, core.catalog.module_intro) and calls the _schema_*
+// mutation functions, none of which exist any more. The code compiles, but the
+// commands fail at run time against a current engine. The engine-side
+// replacements are the core.catalog.annotate_* functions, the core.entity_*
+// views and the MCP catalog-* tools.
 package main
 
 import (
@@ -5,6 +15,16 @@ import (
 	"os"
 	"time"
 )
+
+// deprecationNotice is printed before every command: the binary still builds
+// and ships, so a user has no other way to learn that it is retired.
+const deprecationNotice = `hugr-tools is DEPRECATED and is moving to the hub.
+
+It has not been ported to the catalog storage of CoreDB 0.0.20 — it reads the
+compiled-schema views and _schema_* functions that version removed, so the
+commands below fail against a current engine. Use core.catalog.annotate_*, the
+core.entity_* views or the MCP catalog-* tools instead.
+`
 
 // Global flags shared by all subcommands.
 type globalFlags struct {
@@ -15,6 +35,8 @@ type globalFlags struct {
 }
 
 func main() {
+	fmt.Fprintln(os.Stderr, deprecationNotice)
+
 	if len(os.Args) < 2 {
 		printUsage()
 		os.Exit(1)
@@ -49,11 +71,11 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Fprintln(os.Stderr, `hugr-tools — Hugr schema management utilities
+	fmt.Fprintln(os.Stderr, `hugr-tools — Hugr schema management utilities (DEPRECATED)
 
 Usage: hugr-tools <command> [flags]
 
-Commands:
+Commands (all currently broken against CoreDB 0.0.20):
   summarize    AI-powered schema summarization using LLM
   reindex      Recompute vector embeddings for schema entities
   schema-info  Display human-readable schema overview

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,8 +48,11 @@ The embedder URL format: `http://host:port/path?model=<model>&api_key=<key>&time
 MCP tool logging is controlled by the `DEBUG` flag. When `DEBUG=true`, MCP tool
 invocations are logged to stdout; otherwise tool logging is suppressed.
 
-Use `hugr-tools summarize` to generate LLM-powered descriptions for schema entities,
-and `hugr-tools reindex` to recompute embeddings. See [hugr-tools.md](hugr-tools.md).
+Descriptions are curated through the `core.catalog.annotate_*` mutation
+functions; the embedding vector is recomputed on every write, and
+`core.catalog.reindex_embeddings` re-embeds everything after an embedder model
+change. (The `hugr-tools summarize` / `reindex` commands that used to do this
+are [deprecated](hugr-tools.md) and no longer work against CoreDB 0.0.20.)
 
 ## DuckDB
 
@@ -200,8 +203,7 @@ MCP_ENABLED=true
 EMBEDDER_URL=http://localhost:8080/embed?model=text-embedding-3-small&api_key=sk-...
 # EMBEDDER_VECTOR_SIZE=768  # default, change if your model uses different dimensions
 
-# hugr-tools summarization (run separately)
-# hugr-tools summarize --api-key sk-... --provider openai --model gpt-4o-mini
+# Schema summarization runs separately (hugr-tools is deprecated — see docs/hugr-tools.md)
 
 # Authentication
 ALLOWED_ANONYMOUS=false

--- a/docs/hugr-tools.md
+++ b/docs/hugr-tools.md
@@ -1,4 +1,17 @@
-# hugr-tools
+# hugr-tools (deprecated)
+
+> **Deprecated — moving to the hub, not developed here any more.**
+>
+> Every command below still reads the compiled-schema views
+> (`core.catalog.types`, `core.catalog.modules`, `core.catalog.module_intro`)
+> and calls the `_schema_*` mutation functions. CoreDB 0.0.20 removed all of
+> them, so the binary builds but the commands fail at run time against a
+> current engine. It is kept in the tree for reference until the hub picks it
+> up.
+>
+> Engine-side replacements: `core.catalog.annotate_*` for curation,
+> `core.catalog.reindex_embeddings` for embeddings, the `core.entity_*` views
+> and the MCP `catalog-*` tools for reading the catalog.
 
 CLI utilities for managing Hugr schema metadata.
 


### PR DESCRIPTION
`hugr-tools` is moving to the hub and is no longer developed in this repo. It is **marked deprecated, not deleted** — the hub has no copy yet, so the source stays here for the port.

The tool is also, right now, broken: every command still reads the compiled-schema views (`core.catalog.types`, `core.catalog.modules`, `core.catalog.module_intro`) and calls the `_schema_*` mutation functions, all of which CoreDB 0.0.20 removed. It compiles and it ships, so without a runtime notice a user finds out only when a command fails mid-run.

## What this changes

- `cmd/hugr-tools/main.go` — package doc comment, a notice on **stderr before every command**, and `(DEPRECATED)` in the usage banner.
- `docs/hugr-tools.md` — deprecation header naming the engine-side replacements: `core.catalog.annotate_*`, `core.catalog.reindex_embeddings`, the `core.entity_*` views, the MCP `catalog-*` tools.
- `README.md`, `cmd/dev-server/README.md` — the tool is flagged wherever it is mentioned.
- `docs/configuration.md` — the summarization paragraph now points at the functions that exist.

Two unrelated README lines that design-036 invalidated are corrected in passing: `pkg/catalog/` is base / ingest / store, not "compiler, static/db providers", and `docs/compiler/01-overview.md` has been *Schema Architecture* for a while.

## Verification

`CGO_CFLAGS="-O1 -g" go build -tags=duckdb_arrow ./cmd/...` clean, `gofmt` clean. No behaviour change beyond the stderr notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016k9uaQHqunF6isM3XhS5PN