### PR TITLE
_search: separate matching by NAME from matching by MEANING

### DIFF
--- a/integration-test/catalog/entity/search_test.go
+++ b/integration-test/catalog/entity/search_test.go
@@ -27,7 +27,7 @@ import (
 // searchRoot is the shape every test here selects: enough to identify a hit
 // without pulling the drill-down.
 const searchRoot = `lexical lexicalReason hasMore filteredOut limit offset
-	items { kind name moduleName dataSourceName score objectName type hugrType refObjectName }`
+	items { kind matchedOn name moduleName dataSourceName score objectName type hugrType refObjectName }`
 
 type searchHit struct {
 	Kind          string  `json:"kind"`
@@ -36,6 +36,7 @@ type searchHit struct {
 	DataSource    string  `json:"dataSourceName"`
 	Score         float64 `json:"score"`
 	ObjectName    string  `json:"objectName"`
+	MatchedOn     string  `json:"matchedOn"`
 	GQLType       string  `json:"type"`
 	HugrType      string  `json:"hugrType"`
 	RefObjectName string  `json:"refObjectName"`
@@ -353,4 +354,73 @@ func TestSearchVectorRanking(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "semantic search should reach the data-source catalog, got %v", names)
+}
+
+// TestSearchByName is the track the vector index cannot serve: embeddings are
+// made from DESCRIPTIONS, so an identifier never enters them, and on a
+// deployment WITH an embedder a caller who typed a name used to get whatever
+// was described in similar words instead of the thing they named.
+//
+// The underscore is the point of the fixture, not decoration. hugr names are
+// underscore-separated identifiers, and the ilike prefilter has no ESCAPE
+// clause — escaping "_" as "\_" matched literally and returned nothing, which
+// is invisible to any test whose query happens to be one plain word.
+func TestSearchByName(t *testing.T) {
+	svc, _ := mcpService(t, 0, "")
+	ctx := adminCtx(t)
+
+	exact := runSearch(t, ctx, svc, `query: "core_api_keys", kinds: [DATA_OBJECT], match: NAME, limit: 10`)
+	require.NotEmpty(t, exact.Items, "an exact name must find its object")
+	assert.Equal(t, "core_api_keys", exact.Items[0].Name)
+	assert.Equal(t, "NAME", exact.Items[0].MatchedOn)
+	assert.Equal(t, 1.0, exact.Items[0].Score, "an exact name is the top of the name scale")
+	assert.False(t, exact.Lexical, "substring matching is the POINT of this track, not a fallback")
+
+	partial := runSearch(t, ctx, svc, `query: "api_keys", kinds: [DATA_OBJECT], match: NAME, limit: 10`)
+	assert.Contains(t, hitNamesOf(partial), "core_api_keys", "a fragment of the name must still find it")
+
+	// A name track ranks names. A word that appears only in descriptions is
+	// not a name match, however well it would do semantically.
+	none := runSearch(t, ctx, svc,
+		`query: "who can log in and with what key", kinds: [DATA_OBJECT], match: NAME, limit: 10`)
+	assert.Empty(t, none.Items, "prose is not an identifier")
+}
+
+// TestSearchBothPutsNamesFirst — the two tracks rank on scales that do not
+// compare (an exact identifier against an embedding distance), so BOTH
+// concatenates them rather than merge-sorting. Blending is what buried an
+// object under its own fields.
+func TestSearchBothPutsNamesFirst(t *testing.T) {
+	svc, _ := mcpService(t, 0, "")
+	page := runSearch(t, adminCtx(t), svc, `query: "core_api_keys", match: BOTH, limit: 20`)
+
+	require.NotEmpty(t, page.Items)
+	first := page.Items[0]
+	assert.Equal(t, "NAME", first.MatchedOn, "a name match leads")
+	assert.Equal(t, "core_api_keys", first.Name)
+
+	// Once a name hit covers an entity, the meaning track must not repeat it.
+	seen := map[string]int{}
+	for _, h := range page.Items {
+		seen[h.Kind+"/"+h.ObjectName+"/"+h.Name]++
+	}
+	for key, n := range seen {
+		assert.Equal(t, 1, n, "duplicate across tracks: %s", key)
+	}
+
+	// And every hit says which track found it.
+	for _, h := range page.Items {
+		assert.Contains(t, []string{"NAME", "MEANING"}, h.MatchedOn, "hit %s", h.Name)
+	}
+}
+
+// TestSearchMeaningExcludesTheNameTrack — MCP pins match: MEANING, so the
+// track has to stay pure: no name hits leaking in, whatever the query.
+func TestSearchMeaningExcludesTheNameTrack(t *testing.T) {
+	svc, _ := mcpService(t, 0, "")
+	page := runSearch(t, adminCtx(t), svc, `query: "core_api_keys", match: MEANING, limit: 20`)
+	require.NotEmpty(t, page.Items)
+	for _, h := range page.Items {
+		assert.Equal(t, "MEANING", h.MatchedOn, "hit %s", h.Name)
+	}
 }

--- a/integration-test/catalog/entity/search_test.go
+++ b/integration-test/catalog/entity/search_test.go
@@ -71,6 +71,36 @@ func hitNamesOf(page searchPage) []string {
 	return out
 }
 
+// assertTracksOrdered is the ordering contract of a page. Scores are ordered
+// WITHIN a track and never across: the two scales do not compare, which is
+// why BOTH concatenates the name block before the meaning block instead of
+// merge-sorting. A page from a single-track search degenerates to the plain
+// "ordered by score" assertion.
+func assertTracksOrdered(t testing.TB, page searchPage) {
+	t.Helper()
+	meaningStarted := false
+	last := map[string]float64{"NAME": 2, "MEANING": 2}
+	for _, h := range page.Items {
+		require.Contains(t, last, h.MatchedOn, "hit %s carries an unknown track", h.Name)
+		if h.MatchedOn == "MEANING" {
+			meaningStarted = true
+		} else {
+			assert.False(t, meaningStarted, "a NAME hit after the MEANING block: %s", h.Name)
+		}
+		assert.LessOrEqual(t, h.Score, last[h.MatchedOn],
+			"scores ordered within the %s track (hit %s)", h.MatchedOn, h.Name)
+		last[h.MatchedOn] = h.Score
+	}
+}
+
+// hitIdentity is the cross-track identity of a hit, mirroring candidateKey in
+// the engine: a function is (module, name) — same-named functions in
+// different modules are different functions — and a field's identity is its
+// owning object.
+func hitIdentity(h searchHit) string {
+	return h.Kind + "/" + h.ModuleName + "/" + h.ObjectName + "/" + h.Name
+}
+
 // adminCtx is what the endpoint middleware installs for an admin caller.
 func adminCtx(t testing.TB) context.Context {
 	t.Helper()
@@ -117,10 +147,10 @@ func TestSearchLexicalAnswers(t *testing.T) {
 	require.NotEmpty(t, page.Items, "lexical search answers on the entity storage")
 	assert.Contains(t, hitNamesOf(page), "core_data_sources")
 
-	var last float64 = 2
+	// The default match is BOTH, so the page is two blocks; global score
+	// ordering is deliberately NOT an invariant here.
+	assertTracksOrdered(t, page)
 	for _, h := range page.Items {
-		assert.LessOrEqual(t, h.Score, last, "hits come back ordered by score")
-		last = h.Score
 		assert.NotEmpty(t, h.Kind)
 	}
 }
@@ -333,11 +363,7 @@ func TestSearchVectorRanking(t *testing.T) {
 	require.False(t, page.Lexical)
 	require.NotEmpty(t, page.Items)
 
-	var last float64 = 2
-	for _, h := range page.Items {
-		assert.LessOrEqual(t, h.Score, last, "hits come back ordered by score")
-		last = h.Score
-	}
+	assertTracksOrdered(t, page)
 
 	// The query shares no substring with the answer — that is the point. A
 	// lexical ranker scores 0 for "where are the attached databases described"
@@ -379,11 +405,36 @@ func TestSearchByName(t *testing.T) {
 	partial := runSearch(t, ctx, svc, `query: "api_keys", kinds: [DATA_OBJECT], match: NAME, limit: 10`)
 	assert.Contains(t, hitNamesOf(partial), "core_api_keys", "a fragment of the name must still find it")
 
+	// Multi-word: every term must land in the NAME. The prefilter demands the
+	// same (AND of terms), so a two-word query cannot fill its window with
+	// rows matching one word and then score them all to zero.
+	multi := runSearch(t, ctx, svc, `query: "api keys", kinds: [DATA_OBJECT], match: NAME, limit: 10`)
+	assert.Contains(t, hitNamesOf(multi), "core_api_keys", "every term matches the name, so the name track must find it")
+
 	// A name track ranks names. A word that appears only in descriptions is
 	// not a name match, however well it would do semantically.
 	none := runSearch(t, ctx, svc,
 		`query: "who can log in and with what key", kinds: [DATA_OBJECT], match: NAME, limit: 10`)
 	assert.Empty(t, none.Items, "prose is not an identifier")
+}
+
+// TestSearchBothMinScoreKeepsNames — minScore reads on the MEANING scale and
+// binds only that track. A caller who tuned a semantic similarity bar AND
+// typed an identifier fragment must not have the bar delete the very object
+// they named: 0.9 comfortably kills every lexical meaning hit here, and the
+// name hit must survive it.
+func TestSearchBothMinScoreKeepsNames(t *testing.T) {
+	svc, _ := mcpService(t, 0, "")
+	page := runSearch(t, adminCtx(t), svc,
+		`query: "api_keys", kinds: [DATA_OBJECT], match: BOTH, minScore: 0.9, limit: 10`)
+
+	require.Contains(t, hitNamesOf(page), "core_api_keys",
+		"a meaning-scale bar must not delete a name-track hit")
+	for _, h := range page.Items {
+		if h.MatchedOn == "MEANING" {
+			assert.GreaterOrEqual(t, h.Score, 0.9, "the bar still binds the meaning track: %s", h.Name)
+		}
+	}
 }
 
 // TestSearchBothPutsNamesFirst — the two tracks rank on scales that do not
@@ -402,16 +453,14 @@ func TestSearchBothPutsNamesFirst(t *testing.T) {
 	// Once a name hit covers an entity, the meaning track must not repeat it.
 	seen := map[string]int{}
 	for _, h := range page.Items {
-		seen[h.Kind+"/"+h.ObjectName+"/"+h.Name]++
+		seen[hitIdentity(h)]++
 	}
 	for key, n := range seen {
 		assert.Equal(t, 1, n, "duplicate across tracks: %s", key)
 	}
 
-	// And every hit says which track found it.
-	for _, h := range page.Items {
-		assert.Contains(t, []string{"NAME", "MEANING"}, h.MatchedOn, "hit %s", h.Name)
-	}
+	// And every hit says which track found it, blocks in order.
+	assertTracksOrdered(t, page)
 }
 
 // TestSearchMeaningExcludesTheNameTrack — MCP pins match: MEANING, so the
@@ -419,6 +468,51 @@ func TestSearchBothPutsNamesFirst(t *testing.T) {
 func TestSearchMeaningExcludesTheNameTrack(t *testing.T) {
 	svc, _ := mcpService(t, 0, "")
 	page := runSearch(t, adminCtx(t), svc, `query: "core_api_keys", match: MEANING, limit: 20`)
+	require.NotEmpty(t, page.Items)
+	for _, h := range page.Items {
+		assert.Equal(t, "MEANING", h.MatchedOn, "hit %s", h.Name)
+	}
+}
+
+// TestSearchBothWithEmbedder is TestSearchBothPutsNamesFirst against the REAL
+// meaning track. Without an embedder both tracks are substring-driven over
+// the same rows, so "names lead" and "no duplicates" hold trivially there;
+// only a vector ranking can produce a semantic hit that would outrank or
+// collide with a name hit, which is exactly what these assertions pin.
+func TestSearchBothWithEmbedder(t *testing.T) {
+	url, size := liveEmbedder(t)
+	svc, _ := mcpService(t, size, url)
+	page := runSearch(t, adminCtx(t), svc, `query: "core_api_keys", match: BOTH, limit: 20`)
+
+	require.False(t, page.Lexical, "the meaning track must be the vector index, not the fallback")
+	require.NotEmpty(t, page.Items)
+	first := page.Items[0]
+	assert.Equal(t, "NAME", first.MatchedOn, "a name match leads, however strong the semantic ranking")
+	assert.Equal(t, "core_api_keys", first.Name)
+
+	var meaningHits int
+	seen := map[string]int{}
+	for _, h := range page.Items {
+		seen[hitIdentity(h)]++
+		if h.MatchedOn == "MEANING" {
+			meaningHits++
+		}
+	}
+	assert.Positive(t, meaningHits, "the vector track fills the rest of the page")
+	for key, n := range seen {
+		assert.Equal(t, 1, n, "duplicate across tracks: %s", key)
+	}
+	assertTracksOrdered(t, page)
+}
+
+// TestSearchMeaningWithEmbedderExcludesNames — the purity of the MEANING
+// track, checked against the vector ranking MCP actually runs on.
+func TestSearchMeaningWithEmbedderExcludesNames(t *testing.T) {
+	url, size := liveEmbedder(t)
+	svc, _ := mcpService(t, size, url)
+	page := runSearch(t, adminCtx(t), svc, `query: "core_api_keys", match: MEANING, limit: 20`)
+
+	require.False(t, page.Lexical)
 	require.NotEmpty(t, page.Items)
 	for _, h := range page.Items {
 		assert.Equal(t, "MEANING", h.MatchedOn, "hit %s", h.Name)

--- a/pkg/catalog/base/system_types.graphql
+++ b/pkg/catalog/base/system_types.graphql
@@ -163,7 +163,11 @@ type Query @system {
 		limit: Int = 50
 		"Hits to skip."
 		offset: Int = 0
-		"Drop hits scoring below this (0..1)."
+		"""
+		Drop MEANING hits scoring below this (0..1). Name-track hits rank on a
+		scale of their own and are never thresholded: a bar tuned for semantic
+		similarity must not silently delete the identifier the caller typed.
+		"""
 		minScore: Float
 		"""
 		Include fields marked @exclude_mcp. That directive is a client policy

--- a/pkg/catalog/base/system_types.graphql
+++ b/pkg/catalog/base/system_types.graphql
@@ -143,6 +143,22 @@ type Query @system {
 		module: String
 		"Restrict FIELD hits to one data object; ignored by the other kinds."
 		object: String
+		"""
+		WHAT to match on. Searching by NAME and searching by MEANING are
+		different questions and rank on scales that do not compare, which is
+		why they are selected rather than blended:
+
+		NAME — substring matching over the entity's name. Always available,
+		needs no embedder, and is the only way to find an identifier: a name
+		never enters the vector index, which embeds DESCRIPTIONS.
+
+		MEANING — semantic ranking over descriptions, degrading to substring
+		matching when the deployment has no vector index (see lexical).
+
+		BOTH (the default) — name matches first, then meaning, deduplicated.
+		Each hit says which one found it.
+		"""
+		match: _SearchMatch = BOTH
 		"Page size, 1..200."
 		limit: Int = 50
 		"Hits to skip."
@@ -596,6 +612,19 @@ type _Function @system {
 # --- logical-model search (_search) ---
 
 """
+What a search matches on. See the `match` argument of `_search`.
+
+NAME and MEANING rank on scales that do not compare — an exact identifier
+against an embedding distance — which is why a search selects one or asks for
+BOTH and gets them concatenated, name matches first, rather than blended.
+"""
+enum _SearchMatch @system {
+	NAME
+	MEANING
+	BOTH
+}
+
+"""
 What kind of logical entity a search hit is.
 """
 enum _SearchKind @system {
@@ -623,8 +652,10 @@ type _SearchResult @system {
 	"""Candidates dropped because the caller may not see them."""
 	filteredOut: Int!
 	"""
-	True when ranking fell back to substring matching because the vector index
-	was unusable: results are cruder, so prefer exact terms.
+	True when the MEANING track fell back to substring matching because the
+	vector index was unusable: those results are cruder, so prefer exact terms.
+	Always false for match: NAME, where substring matching is the point rather
+	than a fallback.
 	"""
 	lexical: Boolean!
 	"""Why the vector index was unusable; null when it was used."""
@@ -638,6 +669,11 @@ selecting it.
 """
 type _SearchHit @system {
 	kind: _SearchKind!
+	"""
+	Which track found this hit — NAME or MEANING, never BOTH. Scores are
+	comparable within a track and not across them.
+	"""
+	matchedOn: _SearchMatch!
 	"""
 	Module: dotted path ("" is the root). Data source: source name. Data
 	object: GraphQL type name. Function: field name in its module. Field:

--- a/pkg/catalog/store/testdata/golden/harness.graphql
+++ b/pkg/catalog/store/testdata/golden/harness.graphql
@@ -2856,7 +2856,9 @@ type Query @system {
     match: _SearchMatch = BOTH
 
     """
-    Drop hits scoring below this (0..1).
+    Drop MEANING hits scoring below this (0..1). Name-track hits rank on a
+    scale of their own and are never thresholded: a bar tuned for semantic
+    similarity must not silently delete the identifier the caller typed.
     """
     minScore: Float
 

--- a/pkg/catalog/store/testdata/golden/harness.graphql
+++ b/pkg/catalog/store/testdata/golden/harness.graphql
@@ -2839,6 +2839,23 @@ type Query @system {
     limit: Int = 50
 
     """
+    WHAT to match on. Searching by NAME and searching by MEANING are
+    different questions and rank on scales that do not compare, which is
+    why they are selected rather than blended:
+    
+    NAME — substring matching over the entity's name. Always available,
+    needs no embedder, and is the only way to find an identifier: a name
+    never enters the vector index, which embeds DESCRIPTIONS.
+    
+    MEANING — semantic ranking over descriptions, degrading to substring
+    matching when the deployment has no vector index (see lexical).
+    
+    BOTH (the default) — name matches first, then meaning, deduplicated.
+    Each hit says which one found it.
+    """
+    match: _SearchMatch = BOTH
+
+    """
     Drop hits scoring below this (0..1).
     """
     minScore: Float

--- a/pkg/catalog/store/testdata/golden/multi.graphql
+++ b/pkg/catalog/store/testdata/golden/multi.graphql
@@ -709,6 +709,23 @@ type Query @system {
     limit: Int = 50
 
     """
+    WHAT to match on. Searching by NAME and searching by MEANING are
+    different questions and rank on scales that do not compare, which is
+    why they are selected rather than blended:
+    
+    NAME — substring matching over the entity's name. Always available,
+    needs no embedder, and is the only way to find an identifier: a name
+    never enters the vector index, which embeds DESCRIPTIONS.
+    
+    MEANING — semantic ranking over descriptions, degrading to substring
+    matching when the deployment has no vector index (see lexical).
+    
+    BOTH (the default) — name matches first, then meaning, deduplicated.
+    Each hit says which one found it.
+    """
+    match: _SearchMatch = BOTH
+
+    """
     Drop hits scoring below this (0..1).
     """
     minScore: Float

--- a/pkg/catalog/store/testdata/golden/multi.graphql
+++ b/pkg/catalog/store/testdata/golden/multi.graphql
@@ -726,7 +726,9 @@ type Query @system {
     match: _SearchMatch = BOTH
 
     """
-    Drop hits scoring below this (0..1).
+    Drop MEANING hits scoring below this (0..1). Name-track hits rank on a
+    scale of their own and are never thresholded: a bar tuned for semantic
+    similarity must not silently delete the identifier the caller typed.
     """
     minScore: Float
 

--- a/pkg/catalog/store/testdata/golden/multi_reachable.txt
+++ b/pkg/catalog/store/testdata/golden/multi_reachable.txt
@@ -109,6 +109,7 @@ _RelationDirection
 _RelationKind
 _SearchHit
 _SearchKind
+_SearchMatch
 _SearchResult
 _TypeScope
 __Directive

--- a/pkg/catalog/store/testdata/golden/vector.graphql
+++ b/pkg/catalog/store/testdata/golden/vector.graphql
@@ -915,7 +915,9 @@ type Query @system {
     match: _SearchMatch = BOTH
 
     """
-    Drop hits scoring below this (0..1).
+    Drop MEANING hits scoring below this (0..1). Name-track hits rank on a
+    scale of their own and are never thresholded: a bar tuned for semantic
+    similarity must not silently delete the identifier the caller typed.
     """
     minScore: Float
 

--- a/pkg/catalog/store/testdata/golden/vector.graphql
+++ b/pkg/catalog/store/testdata/golden/vector.graphql
@@ -898,6 +898,23 @@ type Query @system {
     limit: Int = 50
 
     """
+    WHAT to match on. Searching by NAME and searching by MEANING are
+    different questions and rank on scales that do not compare, which is
+    why they are selected rather than blended:
+    
+    NAME — substring matching over the entity's name. Always available,
+    needs no embedder, and is the only way to find an identifier: a name
+    never enters the vector index, which embeds DESCRIPTIONS.
+    
+    MEANING — semantic ranking over descriptions, degrading to substring
+    matching when the deployment has no vector index (see lexical).
+    
+    BOTH (the default) — name matches first, then meaning, deduplicated.
+    Each hit says which one found it.
+    """
+    match: _SearchMatch = BOTH
+
+    """
     Drop hits scoring below this (0..1).
     """
     minScore: Float

--- a/pkg/mcp/catalog_search.go
+++ b/pkg/mcp/catalog_search.go
@@ -89,9 +89,14 @@ type SearchResultPage struct {
 // searchQuery is the whole ranking pipeline, as one call in the CALLER's
 // context. includeMcpExcluded: false is how @exclude_mcp keeps being honoured
 // without the engine adopting an AI-tooling policy as an access rule.
+// match: MEANING is pinned, not defaulted. An agent describes the data it
+// wants in its own words — that is a question for the semantic track — and the
+// engine's default is BOTH, which serves a human who may be typing an
+// identifier. Naming it here keeps this tool's behaviour where it was when the
+// engine's default changes.
 const searchQuery = `query($q: String!, $kinds: [_SearchKind!],
 	$module: String, $limit: Int!, $offset: Int!, $minScore: Float) {
-	_search(query: $q, kinds: $kinds, module: $module,
+	_search(query: $q, kinds: $kinds, module: $module, match: MEANING,
 		limit: $limit, offset: $offset, minScore: $minScore, includeMcpExcluded: false) {
 		limit offset hasMore filteredOut lexical lexicalReason
 		items {

--- a/pkg/mcp/schema_fields.go
+++ b/pkg/mcp/schema_fields.go
@@ -171,8 +171,12 @@ func (s *Server) orderFieldsByRelevance(ctx context.Context, object, query strin
 			Name string `json:"name"`
 		} `json:"items"`
 	}
+	// match: MEANING is pinned for the same reason catalog-search pins it: a
+	// relevance query is the caller's own words about the data, a question for
+	// the semantic track, and the engine's default (BOTH) would silently put
+	// substring name hits ahead of the semantic order this tool promises.
 	err := s.queryScan(ctx, `query($q: String!, $obj: String!) {
-		_search(query: $q, kinds: [FIELD], object: $obj, limit: 200, includeMcpExcluded: false) {
+		_search(query: $q, kinds: [FIELD], object: $obj, match: MEANING, limit: 200, includeMcpExcluded: false) {
 			items { name }
 		}
 	}`, map[string]any{"q": query, "obj": object}, "_search", &page)

--- a/pkg/metadata/search.go
+++ b/pkg/metadata/search.go
@@ -120,16 +120,23 @@ func processSearchQuery(ctx context.Context, provider catalog.Provider, querier 
 	}
 	// minScore narrows the CANDIDATES, before anything is verified.
 	//
-	// The page comes out the same either way — candidates are score-ordered,
-	// so the leading survivors are the qualifying ones — but two things do
-	// not. Verifying a candidate costs a definition reconstruction, and there
-	// is no reason to spend one on a hit the caller has already excluded. And
-	// filteredOut would otherwise count denials among sub-threshold
-	// candidates, reporting "there is data here you may not see" about rows
-	// the caller's own bar removed — the narrowing-is-not-filtering rule the
-	// verdicts exist to keep.
+	// The page comes out the same either way — candidates are score-ordered
+	// within their track, so the leading survivors are the qualifying ones —
+	// but two things do not. Verifying a candidate costs a definition
+	// reconstruction, and there is no reason to spend one on a hit the caller
+	// has already excluded. And filteredOut would otherwise count denials
+	// among sub-threshold candidates, reporting "there is data here you may
+	// not see" about rows the caller's own bar removed — the
+	// narrowing-is-not-filtering rule the verdicts exist to keep.
+	//
+	// The bar reads on the MEANING scale and binds ONLY that track. The two
+	// tracks rank on scales that do not compare — the reason BOTH concatenates
+	// instead of merge-sorting — so a threshold a caller tuned for semantic
+	// similarity must not silently delete the identifier they typed.
 	if req.minScore > 0 {
-		candidates = slices.DeleteFunc(candidates, func(c candidate) bool { return c.score < req.minScore })
+		candidates = slices.DeleteFunc(candidates, func(c candidate) bool {
+			return c.matchedOn == matchMeaning && c.score < req.minScore
+		})
 	}
 
 	kept, filtered, exhausted := filterCandidates(ctx, lm, provider, candidates, req, need)

--- a/pkg/metadata/search.go
+++ b/pkg/metadata/search.go
@@ -27,6 +27,16 @@ import (
 // window; without one, a role that may see little would get an empty page out
 // of a full index.
 
+// The two ways to match, and the reason they are selected rather than
+// blended: a name is an identifier and a description is prose, they rank on
+// scales that do not compare, and mixing them buries an exact name hit under
+// whatever happened to be described in similar words.
+const (
+	matchName    = "NAME"
+	matchMeaning = "MEANING"
+	matchBoth    = "BOTH"
+)
+
 const (
 	searchKindModule     = "module"
 	searchKindDataSource = "data_source"
@@ -70,6 +80,7 @@ type searchRequest struct {
 	kinds              []string
 	module             string
 	object             string
+	match              string
 	limit              int
 	offset             int
 	minScore           float64
@@ -148,6 +159,7 @@ func parseSearchArgs(field *ast.Field, vars map[string]any) (searchRequest, erro
 		kinds:              searchKinds,
 		limit:              searchDefaultLimit,
 		includeMcpExcluded: true,
+		match:              matchBoth,
 	}
 	args := field.ArgumentMap(vars)
 
@@ -171,6 +183,15 @@ func parseSearchArgs(field *ast.Field, vars map[string]any) (searchRequest, erro
 	}
 	if v, ok := args["object"].(string); ok {
 		req.object = v
+	}
+	if v, ok := args["match"].(string); ok && v != "" {
+		switch v {
+		case matchName, matchMeaning, matchBoth:
+			req.match = v
+		default:
+			return req, fmt.Errorf("_search: unknown match %q — valid: %s, %s, %s",
+				v, matchName, matchMeaning, matchBoth)
+		}
 	}
 	if v, ok := intArg(args["limit"]); ok {
 		req.limit = v
@@ -432,6 +453,7 @@ func searchHitResolver(ctx context.Context, lm catalog.LogicalModel, provider ca
 	return processSelectionSet(ctx, ss, map[string]fieldResolverFunc{
 		"__typename":     typeNameResolver,
 		"kind":           value(searchKindGQL[h.kind]),
+		"matchedOn":      value(h.matchedOn),
 		"name":           value(h.name),
 		"moduleName":     value(h.module),
 		"dataSourceName": nullableText(h.dataSource),

--- a/pkg/metadata/search_rank.go
+++ b/pkg/metadata/search_rank.go
@@ -44,6 +44,10 @@ type candidate struct {
 	dataSource  string
 	description string
 	score       float64
+	// matchedOn is the track that produced this candidate — NAME or MEANING.
+	// Scores are comparable within a track and not across them, which is why
+	// the two are concatenated rather than merge-sorted.
+	matchedOn string
 
 	// Field candidates only, read straight off the index row. The writer
 	// stored these properties; the reconstructed field definition is BUILT
@@ -138,16 +142,63 @@ func fieldRole(row entityRow) (hugrType, refObject string) {
 
 var errNoQuerier = errors.New("logical-model search needs an engine to rank with, and none was provided")
 
-// rankCandidates produces the ordered candidate list: semantically when the
-// index has vectors, lexically otherwise. It returns the REASON the vector
-// path was unusable ("" when it was used).
+// rankCandidates produces the ordered candidate list for the requested track.
+// It returns the REASON the vector path was unusable ("" when it was used, and
+// always "" for a name-only search, where substring matching is the point
+// rather than a fallback).
 //
-// Both paths failing is an error, never an empty page: "nothing matched" and
-// "the search is broken" must not look the same to a client.
+// NAME and MEANING are CONCATENATED, never merge-sorted: an exact name match
+// scores 1.0 on a scale that has nothing to do with an embedding distance, and
+// interleaving them by score is what buried aw_Product under whatever happened
+// to be described in similar words. Name hits come first because a caller who
+// typed an identifier meant it.
 func rankCandidates(ctx context.Context, q Querier, req searchRequest, limit int) ([]candidate, string, error) {
 	if q == nil {
 		return nil, "", errNoQuerier
 	}
+
+	var out []candidate
+	if req.match == matchName || req.match == matchBoth {
+		named, err := rankByName(ctx, q, req, limit)
+		if err != nil {
+			return nil, "", err
+		}
+		out = append(out, named...)
+	}
+	if req.match == matchName {
+		return out, "", nil
+	}
+
+	meaning, reason, err := rankByMeaning(ctx, q, req, limit)
+	if err != nil {
+		return nil, "", err
+	}
+	if req.match == matchMeaning {
+		return meaning, reason, nil
+	}
+
+	// BOTH: a name hit already covers its entity, so the meaning track only
+	// contributes what the name track did not find.
+	seen := make(map[string]struct{}, len(out))
+	for _, c := range out {
+		seen[candidateKey(c)] = struct{}{}
+	}
+	for _, c := range meaning {
+		if _, dup := seen[candidateKey(c)]; dup {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out, reason, nil
+}
+
+func candidateKey(c candidate) string {
+	return c.kind + "\x1f" + c.object + "\x1f" + c.name
+}
+
+// rankByMeaning is the semantic track, degrading to substring matching over
+// the SAME text (name and description) when the vector index is unusable.
+func rankByMeaning(ctx context.Context, q Querier, req searchRequest, limit int) ([]candidate, string, error) {
 	hits, err := rankByVector(ctx, q, req, limit)
 	if err == nil {
 		return hits, "", nil
@@ -189,14 +240,18 @@ func rankByVector(ctx context.Context, q Querier, req searchRequest, limit int) 
 	if err := scanAdmin(ctx, q, gql, vars, "core", &batch); err != nil {
 		return nil, err
 	}
-	return collectCandidates(ordered, batch, func(row entityRow) float64 {
+	hits := collectCandidates(ordered, batch, func(row entityRow) float64 {
 		// Distance 0 is identical; a score is the other way round so a client
 		// can reason about "higher is better" without knowing the metric.
 		if row.Distance < 0 {
 			return 0
 		}
 		return 1 - row.Distance
-	}), nil
+	})
+	for i := range hits {
+		hits[i].matchedOn = matchMeaning
+	}
+	return hits, nil
 }
 
 // rankLexically is the no-embedder path. SQL only NARROWS — any term appearing
@@ -216,7 +271,7 @@ func rankLexically(ctx context.Context, q Querier, req searchRequest, limit int)
 	patterns := make([]string, len(terms))
 	for i, term := range terms {
 		name := fmt.Sprintf("t%d", i)
-		vars[name] = "%" + escapeLike(term) + "%"
+		vars[name] = likePattern(term)
 		patterns[i] = "$" + name
 	}
 	sig := make([]string, 0, len(patterns)+2)
@@ -267,6 +322,9 @@ func rankLexically(ctx context.Context, q Querier, req searchRequest, limit int)
 	hits := collectCandidates(ordered, batch, func(row entityRow) float64 {
 		return lexicalScore(terms, row.Name, row.Desc)
 	})
+	for i := range hits {
+		hits[i].matchedOn = matchMeaning
+	}
 	// The prefilter accepts ANY term; the score demands all of them.
 	kept := hits[:0]
 	for _, h := range hits {
@@ -278,6 +336,107 @@ func rankLexically(ctx context.Context, q Querier, req searchRequest, limit int)
 		kept = kept[:limit]
 	}
 	return kept, nil
+}
+
+// rankByName matches the entity's NAME and nothing else.
+//
+// This is the track the vector index cannot serve at all: embeddings are made
+// from DESCRIPTIONS, so an identifier never enters them, and on a deployment
+// with an embedder a caller who typed aw_Product used to get whatever was
+// described in similar words instead of the table they named.
+//
+// SQL narrows with ilike per term; the ordering is decided in Go, where an
+// exact name outranks a prefix and a prefix outranks a substring.
+func rankByName(ctx context.Context, q Querier, req searchRequest, limit int) ([]candidate, error) {
+	terms := strings.Fields(strings.ToLower(req.query))
+	if len(terms) == 0 {
+		return nil, nil
+	}
+	vars := map[string]any{"limit": limit}
+	patterns := make([]string, len(terms))
+	for i, term := range terms {
+		name := fmt.Sprintf("t%d", i)
+		vars[name] = likePattern(term)
+		patterns[i] = "$" + name
+	}
+	sig := make([]string, 0, len(patterns)+2)
+	sig = append(sig, "$limit: Int!")
+	for _, p := range patterns {
+		sig = append(sig, p+": String!")
+	}
+
+	var body strings.Builder
+	ordered := make([]string, 0, len(req.kinds))
+	for _, kind := range req.kinds {
+		view, ok := entityViews[kind]
+		if !ok {
+			continue
+		}
+		ordered = append(ordered, kind)
+		match := make([]string, 0, len(patterns))
+		for _, p := range patterns {
+			match = append(match, fmt.Sprintf("{name: {ilike: %s}}", p))
+		}
+		filter := fmt.Sprintf("{_or: [%s]", strings.Join(match, ", "))
+		if kind == searchKindField && objectFilterApplies(req) {
+			filter += ", type_name: {eq: $obj}"
+		}
+		filter += "}"
+		fmt.Fprintf(&body, "%s: %s(filter: %s, limit: $limit) { %s }\n",
+			kind, view.alias, filter, strings.Join(view.selection, " "))
+	}
+	if len(ordered) == 0 {
+		return nil, nil
+	}
+	if objectFilterApplies(req) {
+		vars["obj"] = req.object
+		sig = append(sig, "$obj: String!")
+	}
+
+	batch := map[string][]entityRow{}
+	gql := "query(" + strings.Join(sig, ", ") + ") { core {\n" + body.String() + "} }"
+	if err := scanAdmin(ctx, q, gql, vars, "core", &batch); err != nil {
+		return nil, err
+	}
+	hits := collectCandidates(ordered, batch, func(row entityRow) float64 {
+		return nameScore(terms, row.Name)
+	})
+	for i := range hits {
+		hits[i].matchedOn = matchName
+	}
+	// The prefilter accepts ANY term; the score demands all of them.
+	kept := hits[:0]
+	for _, h := range hits {
+		if h.score > 0 {
+			kept = append(kept, h)
+		}
+	}
+	if len(kept) > limit {
+		kept = kept[:limit]
+	}
+	return kept, nil
+}
+
+// nameScore ranks a name match by how much of the name the query accounts for.
+// An exact name is 1, a prefix is close behind, a substring further back, and
+// a name missing any term scores 0 — a multi-word query narrows.
+func nameScore(terms []string, name string) float64 {
+	lname := strings.ToLower(name)
+	if len(terms) == 1 && lname == terms[0] {
+		return 1
+	}
+	var score float64
+	for _, term := range terms {
+		switch {
+		case strings.HasPrefix(lname, term):
+			score += 0.9
+		case strings.Contains(lname, term):
+			score += 0.6
+		default:
+			return 0
+		}
+	}
+	return min(0.99, score/float64(len(terms)))
 }
 
 // vectorFilterArg narrows a kind's vector query where the request allows it.
@@ -347,11 +506,21 @@ func lexicalScore(terms []string, name, description string) float64 {
 	return min(1, score/float64(len(terms)))
 }
 
-// escapeLike neutralises the LIKE wildcards a user's words may contain, so a
-// query for "a_b" does not silently match "axb".
-func escapeLike(s string) string {
-	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
-	return r.Replace(s)
+// likePattern wraps a term for the ilike PREFILTER.
+//
+// It deliberately does NOT escape the LIKE wildcards. The engine's ilike has
+// no ESCAPE clause, so a backslash is matched literally: escaping "_" turned
+// "%core\_api\_keys%" into a pattern that matches nothing, and since hugr
+// names are underscore-separated identifiers that silently broke every name
+// search. (It went unnoticed because the lexical path only runs without an
+// embedder, and the tests that exercised it used queries with no underscores.)
+//
+// Leaving the wildcards in is safe because SQL only NARROWS here: "_" matching
+// any single character and "%" matching anything can over-fetch, never
+// under-fetch, and the Go scorer that follows does the real matching with
+// plain substring tests.
+func likePattern(term string) string {
+	return "%" + term + "%"
 }
 
 // scanAdmin runs a catalog query with FULL ACCESS and scans it. This is the

--- a/pkg/metadata/search_rank.go
+++ b/pkg/metadata/search_rank.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/hugr-lab/query-engine/pkg/auth"
 	"github.com/hugr-lab/query-engine/pkg/catalog/base"
 )
@@ -156,29 +158,43 @@ func rankCandidates(ctx context.Context, q Querier, req searchRequest, limit int
 	if q == nil {
 		return nil, "", errNoQuerier
 	}
-
-	var out []candidate
-	if req.match == matchName || req.match == matchBoth {
+	switch req.match {
+	case matchName:
 		named, err := rankByName(ctx, q, req, limit)
-		if err != nil {
-			return nil, "", err
-		}
-		out = append(out, named...)
-	}
-	if req.match == matchName {
-		return out, "", nil
+		return named, "", err
+	case matchMeaning:
+		return rankByMeaning(ctx, q, req, limit)
 	}
 
-	meaning, reason, err := rankByMeaning(ctx, q, req, limit)
-	if err != nil {
+	// BOTH. The tracks are independent reads of the same index, so they run
+	// concurrently: serially, the default search — the human-facing path —
+	// would pay the embedder round trip ON TOP of the name query instead of
+	// alongside it.
+	var (
+		named, meaning []candidate
+		reason         string
+	)
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		var err error
+		named, err = rankByName(gctx, q, req, limit)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		meaning, reason, err = rankByMeaning(gctx, q, req, limit)
+		return err
+	})
+	if err := g.Wait(); err != nil {
 		return nil, "", err
 	}
-	if req.match == matchMeaning {
-		return meaning, reason, nil
-	}
 
-	// BOTH: a name hit already covers its entity, so the meaning track only
-	// contributes what the name track did not find.
+	// A name hit already covers its entity, so the meaning track only
+	// contributes what the name track did not find. Keeping the NAME
+	// representative is safe against the caller's minScore because that bar
+	// binds only the meaning track (see search.go): dropping the meaning
+	// duplicate can never delete the entity from the page.
+	out := named
 	seen := make(map[string]struct{}, len(out))
 	for _, c := range out {
 		seen[candidateKey(c)] = struct{}{}
@@ -189,11 +205,22 @@ func rankCandidates(ctx context.Context, q Querier, req searchRequest, limit int
 		}
 		out = append(out, c)
 	}
+	// limit caps the verification work per REQUEST (searchMaxCandidates), not
+	// per track; two tracks do not get to double it.
+	if len(out) > limit {
+		out = out[:limit]
+	}
 	return out, reason, nil
 }
 
+// candidateKey is the identity a hit answers to across tracks. A function is
+// (module, name) everywhere else in this package — same-named functions in
+// different modules are DIFFERENT functions, and a stock deployment has them
+// (`checkpoint` lives in core and in core.ducklake). Field candidates carry no
+// module at ranking time; both tracks read the same index rows, so both agree
+// on "" and their identity is the owning object.
 func candidateKey(c candidate) string {
-	return c.kind + "\x1f" + c.object + "\x1f" + c.name
+	return c.kind + "\x1f" + c.module + "\x1f" + c.object + "\x1f" + c.name
 }
 
 // rankByMeaning is the semantic track, degrading to substring matching over
@@ -240,102 +267,32 @@ func rankByVector(ctx context.Context, q Querier, req searchRequest, limit int) 
 	if err := scanAdmin(ctx, q, gql, vars, "core", &batch); err != nil {
 		return nil, err
 	}
-	hits := collectCandidates(ordered, batch, func(row entityRow) float64 {
+	return collectCandidates(ordered, batch, matchMeaning, func(row entityRow) float64 {
 		// Distance 0 is identical; a score is the other way round so a client
 		// can reason about "higher is better" without knowing the metric.
 		if row.Distance < 0 {
 			return 0
 		}
 		return 1 - row.Distance
-	})
-	for i := range hits {
-		hits[i].matchedOn = matchMeaning
-	}
-	return hits, nil
+	}), nil
 }
 
-// rankLexically is the no-embedder path. SQL only NARROWS — any term appearing
-// in a name or a description makes a row a candidate — and the actual scoring
-// happens in Go, where a multi-word query narrows instead of widening.
+// rankLexically is the no-embedder path of the MEANING track. SQL only
+// NARROWS — see rankBySubstring — and the actual scoring happens in Go, where
+// a multi-word query narrows instead of widening.
 //
 // Doing the narrowing in the view rather than by walking the module tree is
 // what lets this path reach FIELDS. A structural walk has no enumeration of
 // fields that is not per object, which is why MCP's fallback dropped field
 // hits entirely; entity_fields is one table.
 func rankLexically(ctx context.Context, q Querier, req searchRequest, limit int) ([]candidate, error) {
-	terms := strings.Fields(strings.ToLower(req.query))
-	if len(terms) == 0 {
-		return nil, nil
-	}
-	vars := map[string]any{"limit": limit}
-	patterns := make([]string, len(terms))
-	for i, term := range terms {
-		name := fmt.Sprintf("t%d", i)
-		vars[name] = likePattern(term)
-		patterns[i] = "$" + name
-	}
-	sig := make([]string, 0, len(patterns)+2)
-	sig = append(sig, "$limit: Int!")
-	for _, p := range patterns {
-		sig = append(sig, p+": String!")
-	}
-
-	var body strings.Builder
-	ordered := make([]string, 0, len(req.kinds))
-	for _, kind := range req.kinds {
-		view, ok := entityViews[kind]
-		if !ok {
-			continue
-		}
-		ordered = append(ordered, kind)
-		// Deliberately not named `terms`: the query words of that name are
-		// what lexicalScore is called with below, and shadowing them here
-		// would put SQL fragments into the scorer the first time this loop
-		// grows a closure.
-		var match []string
-		for _, col := range view.nameCols {
-			for _, p := range patterns {
-				match = append(match, fmt.Sprintf("{%s: {ilike: %s}}", col, p))
-			}
-		}
-		filter := fmt.Sprintf("{_or: [%s]", strings.Join(match, ", "))
-		if kind == searchKindField && objectFilterApplies(req) {
-			filter += ", type_name: {eq: $obj}"
-		}
-		filter += "}"
-		fmt.Fprintf(&body, "%s: %s(filter: %s, limit: $limit) { %s }\n",
-			kind, view.alias, filter, strings.Join(view.selection, " "))
-	}
-	if len(ordered) == 0 {
-		return nil, nil
-	}
-	if objectFilterApplies(req) {
-		vars["obj"] = req.object
-		sig = append(sig, "$obj: String!")
-	}
-
-	batch := map[string][]entityRow{}
-	gql := "query(" + strings.Join(sig, ", ") + ") { core {\n" + body.String() + "} }"
-	if err := scanAdmin(ctx, q, gql, vars, "core", &batch); err != nil {
-		return nil, err
-	}
-	hits := collectCandidates(ordered, batch, func(row entityRow) float64 {
-		return lexicalScore(terms, row.Name, row.Desc)
+	return rankBySubstring(ctx, q, req, limit, substringTrack{
+		matchedOn:     matchMeaning,
+		prefilterCols: func(view entityView) []string { return view.nameCols },
+		score: func(terms []string, row entityRow) float64 {
+			return lexicalScore(terms, row.Name, row.Desc)
+		},
 	})
-	for i := range hits {
-		hits[i].matchedOn = matchMeaning
-	}
-	// The prefilter accepts ANY term; the score demands all of them.
-	kept := hits[:0]
-	for _, h := range hits {
-		if h.score > 0 {
-			kept = append(kept, h)
-		}
-	}
-	if len(kept) > limit {
-		kept = kept[:limit]
-	}
-	return kept, nil
 }
 
 // rankByName matches the entity's NAME and nothing else.
@@ -348,6 +305,48 @@ func rankLexically(ctx context.Context, q Querier, req searchRequest, limit int)
 // SQL narrows with ilike per term; the ordering is decided in Go, where an
 // exact name outranks a prefix and a prefix outranks a substring.
 func rankByName(ctx context.Context, q Querier, req searchRequest, limit int) ([]candidate, error) {
+	return rankBySubstring(ctx, q, req, limit, substringTrack{
+		matchedOn:     matchName,
+		prefilterCols: func(view entityView) []string { return []string{"name"} },
+		score: func(terms []string, row entityRow) float64 {
+			return nameScore(terms, row.Name)
+		},
+	})
+}
+
+// substringTrack is what distinguishes the two substring pipelines: which
+// columns the SQL prefilter searches, how a fetched row is scored, and which
+// track the hits answer for. Everything else — term splitting, the tiered
+// prefilter, scanning, zero-pruning, truncation — is shared in
+// rankBySubstring, so a prefilter fix lands on both tracks or neither. (The
+// ESCAPE bug lived as long as it did because the two copies could diverge
+// silently.)
+type substringTrack struct {
+	matchedOn     string
+	prefilterCols func(view entityView) []string
+	score         func(terms []string, row entityRow) float64
+}
+
+// prefilterTier is one aliased sub-query of the substring prefilter, and the
+// tiers are what makes a BOUNDED window safe. The views cannot rank a
+// substring match, so a single wide ilike window on a large catalog fills
+// with whatever arrives first and may not contain the very row the caller
+// named. Narrow matches therefore arrive through windows of their own: an
+// exact name cannot be crowded out of a window only exact names enter,
+// however many weaker substring rows the wide tier over-fetches.
+type prefilterTier struct {
+	suffix string
+	cond   func(view entityView) string
+}
+
+// rankBySubstring is the substring prefilter both tracks share: SQL narrows,
+// Go scores. Every term must match SOME prefilter column — the same demand
+// the scorer makes — so the window is not spent on rows the scorer will throw
+// away. (An any-term prefilter let rows matching one word of a two-word query
+// fill the whole window and then score 0, turning a full catalog into an
+// empty page.) order_by name keeps each window deterministic across
+// identical requests.
+func rankBySubstring(ctx context.Context, q Querier, req searchRequest, limit int, track substringTrack) ([]candidate, error) {
 	terms := strings.Fields(strings.ToLower(req.query))
 	if len(terms) == 0 {
 		return nil, nil
@@ -359,11 +358,43 @@ func rankByName(ctx context.Context, q Querier, req searchRequest, limit int) ([
 		vars[name] = likePattern(term)
 		patterns[i] = "$" + name
 	}
-	sig := make([]string, 0, len(patterns)+2)
+	sig := make([]string, 0, len(patterns)+4)
 	sig = append(sig, "$limit: Int!")
 	for _, p := range patterns {
 		sig = append(sig, p+": String!")
 	}
+
+	var tiers []prefilterTier
+	// A single-term query can be a whole identifier, and those get their own
+	// windows: the term with no wildcards around it is the exact name (modulo
+	// "_" matching any character — see likePattern), term% the prefixes. A
+	// multi-term query cannot have every term as a prefix, so for those the
+	// extra tiers would fetch nothing the wide one does not.
+	if len(terms) == 1 {
+		vars["tx"] = terms[0]
+		vars["tp"] = terms[0] + "%"
+		sig = append(sig, "$tx: String!", "$tp: String!")
+		tiers = append(tiers,
+			prefilterTier{"x", func(entityView) string { return "{name: {ilike: $tx}}" }},
+			prefilterTier{"p", func(entityView) string { return "{name: {ilike: $tp}}" }},
+		)
+	}
+	tiers = append(tiers, prefilterTier{"s", func(view entityView) string {
+		cols := track.prefilterCols(view)
+		perTerm := make([]string, len(patterns))
+		for i, p := range patterns {
+			if len(cols) == 1 {
+				perTerm[i] = fmt.Sprintf("{%s: {ilike: %s}}", cols[0], p)
+				continue
+			}
+			match := make([]string, len(cols))
+			for j, col := range cols {
+				match[j] = fmt.Sprintf("{%s: {ilike: %s}}", col, p)
+			}
+			perTerm[i] = "{_or: [" + strings.Join(match, ", ") + "]}"
+		}
+		return "{_and: [" + strings.Join(perTerm, ", ") + "]}"
+	}})
 
 	var body strings.Builder
 	ordered := make([]string, 0, len(req.kinds))
@@ -373,17 +404,14 @@ func rankByName(ctx context.Context, q Querier, req searchRequest, limit int) ([
 			continue
 		}
 		ordered = append(ordered, kind)
-		match := make([]string, 0, len(patterns))
-		for _, p := range patterns {
-			match = append(match, fmt.Sprintf("{name: {ilike: %s}}", p))
+		for _, tier := range tiers {
+			cond := tier.cond(view)
+			if kind == searchKindField && objectFilterApplies(req) {
+				cond = "{_and: [" + cond + ", {type_name: {eq: $obj}}]}"
+			}
+			fmt.Fprintf(&body, "%s_%s: %s(filter: %s, order_by: [{field: \"name\", direction: ASC}], limit: $limit) { %s }\n",
+				kind, tier.suffix, view.alias, cond, strings.Join(view.selection, " "))
 		}
-		filter := fmt.Sprintf("{_or: [%s]", strings.Join(match, ", "))
-		if kind == searchKindField && objectFilterApplies(req) {
-			filter += ", type_name: {eq: $obj}"
-		}
-		filter += "}"
-		fmt.Fprintf(&body, "%s: %s(filter: %s, limit: $limit) { %s }\n",
-			kind, view.alias, filter, strings.Join(view.selection, " "))
 	}
 	if len(ordered) == 0 {
 		return nil, nil
@@ -398,13 +426,29 @@ func rankByName(ctx context.Context, q Querier, req searchRequest, limit int) ([
 	if err := scanAdmin(ctx, q, gql, vars, "core", &batch); err != nil {
 		return nil, err
 	}
-	hits := collectCandidates(ordered, batch, func(row entityRow) float64 {
-		return nameScore(terms, row.Name)
-	})
-	for i := range hits {
-		hits[i].matchedOn = matchName
+
+	// Merge the tiers back into one window per kind; a row can arrive through
+	// several of them.
+	merged := make(map[string][]entityRow, len(ordered))
+	for _, kind := range ordered {
+		seen := map[string]struct{}{}
+		for _, tier := range tiers {
+			for _, row := range batch[kind+"_"+tier.suffix] {
+				id := row.TypeName + "\x1f" + row.Module + "\x1f" + row.Name
+				if _, dup := seen[id]; dup {
+					continue
+				}
+				seen[id] = struct{}{}
+				merged[kind] = append(merged[kind], row)
+			}
+		}
 	}
-	// The prefilter accepts ANY term; the score demands all of them.
+
+	hits := collectCandidates(ordered, merged, track.matchedOn, func(row entityRow) float64 {
+		return track.score(terms, row)
+	})
+	// The prefilter accepts wildcard over-matches; the score demands the real
+	// thing.
 	kept := hits[:0]
 	for _, h := range hits {
 		if h.score > 0 {
@@ -461,15 +505,19 @@ func objectFilterApplies(req searchRequest) bool {
 	return false
 }
 
-// collectCandidates flattens the per-kind batch into one list ordered by score.
-func collectCandidates(ordered []string, batch map[string][]entityRow, score func(entityRow) float64) []candidate {
+// collectCandidates flattens the per-kind batch into one list ordered by
+// score, every candidate stamped with the track that found it. The stamp is a
+// parameter rather than a caller-side loop so a ranking path CANNOT forget
+// it: matchedOn serves a non-null enum, and a forgotten stamp would put ""
+// into the response.
+func collectCandidates(ordered []string, batch map[string][]entityRow, matchedOn string, score func(entityRow) float64) []candidate {
 	var hits []candidate
 	for _, kind := range ordered {
 		for _, row := range batch[kind] {
 			c := candidate{
 				kind: kind, name: row.Name, module: row.Module,
 				dataSource: row.DataSource, description: row.Desc,
-				score: score(row),
+				score: score(row), matchedOn: matchedOn,
 			}
 			if kind == searchKindField {
 				c.object = row.TypeName
@@ -518,7 +566,10 @@ func lexicalScore(terms []string, name, description string) float64 {
 // Leaving the wildcards in is safe because SQL only NARROWS here: "_" matching
 // any single character and "%" matching anything can over-fetch, never
 // under-fetch, and the Go scorer that follows does the real matching with
-// plain substring tests.
+// plain substring tests. What keeps the over-fetch from CROWDING the window —
+// a1b-style rows arriving for a_b until the true row no longer fits — is the
+// tier structure in rankBySubstring: exact and prefix matches come through
+// windows of their own.
 func likePattern(term string) string {
 	return "%" + term + "%"
 }


### PR DESCRIPTION
Follow-up to #153, from trying it on a real catalog.

## The problem

Searching for a **name** and searching for a **description** are different questions, and `_search` could only answer the second. The vector index is built from descriptions, so an identifier never enters it. On the reference deployment, with an embedder configured:

```
_search(query: "aw_Product", kinds: [DATA_OBJECT])
  aw_SpecialOfferProduct   0.6231
  aw_BillOfMaterials       0.5892
  aw_TransactionHistory    0.5709
  …                                ← aw_Product is not in the top 5 at all
```

`nw_customers` came back **fourth**, behind `aw_Person` and `aw_Store`. The lexical path did match names — `lexicalScore` gives a name prefix 1.0 — but it only runs when there is *no* embedder. The better the deployment, the less able it was to find a name.

The same measurement showed the second half: cross-kind scores are not comparable. For "product" the best FIELD scored 0.819 against the best DATA_OBJECT at 0.665, so the page filled with four identical `ProductID` rows ahead of the products table.

## The change

`_search` takes `match: NAME | MEANING | BOTH` (default `BOTH`), and every hit carries `matchedOn`.

- **NAME** — substring matching over the name. Always available, needs no embedder, exact name scores 1. The track the vector index cannot serve.
- **MEANING** — unchanged: semantic ranking over descriptions, degrading to substring matching with `lexical` / `lexicalReason` when there is no vector index.
- **BOTH** — name matches first, then meaning, deduplicated.

The two are **concatenated, never merge-sorted**. An exact identifier scores 1 on a scale that has nothing to do with an embedding distance; blending them is precisely what buried the object under its own fields.

**MCP pins `match: MEANING`** rather than inheriting the default — an agent describes what it wants in its own words — so `catalog-search` keeps its behaviour if the engine's default ever moves.

## A bug the new track exposed

The `ilike` prefilter escaped LIKE wildcards as `\_` and `\%`, but the engine's `ilike` has no `ESCAPE` clause, so the backslash matched **literally**:

```
'%core_api_keys%'      → ['core_api_keys']
'%core\_api\_keys%'    → []
```

hugr names are underscore-separated identifiers, so this broke every name match. It had been sitting in the lexical fallback since #153, invisible because that path only runs without an embedder and its tests used single plain words.

Escaping is gone. SQL only *narrows* here — the Go scorer that follows does the real matching with plain substring tests — so an over-fetch is corrected and an under-fetch is impossible.

## Verification

Unit suite, integration (`mcp`, `catalog/entity`, `catalog/curation`) with a live embedder and without, e2e 245/0.

Behaviour checked against an engine built from this branch with a live embedder: an exact name scores 1 and leads under `BOTH`; a fragment (`api_keys`) still finds it; prose finds nothing in the `NAME` track; `MEANING` stays free of name hits; and the object no longer sits below its own fields.

Three integration tests pin it, including the underscore — the fixture is the point, since a query of one plain word cannot see that bug.

Docs: hugr-lab.github.io#35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016k9uaQHqunF6isM3XhS5PN