### PR TITLE
Catalog views move into core.catalog and drop the entity_ prefix

### DIFF
--- a/cmd/hugr-tools/main.go
+++ b/cmd/hugr-tools/main.go
@@ -6,7 +6,7 @@
 // core.catalog.modules, core.catalog.module_intro) and calls the _schema_*
 // mutation functions, none of which exist any more. The code compiles, but the
 // commands fail at run time against a current engine. The engine-side
-// replacements are the core.catalog.annotate_* functions, the core.entity_*
+// replacements are the core.catalog.annotate_* functions, the core.catalog.*
 // views and the MCP catalog-* tools.
 package main
 
@@ -23,7 +23,7 @@ const deprecationNotice = `hugr-tools is DEPRECATED and is moving to the hub.
 It has not been ported to the catalog storage of CoreDB 0.0.20 — it reads the
 compiled-schema views and _schema_* functions that version removed, so the
 commands below fail against a current engine. Use core.catalog.annotate_*, the
-core.entity_* views or the MCP catalog-* tools instead.
+core.catalog.* views or the MCP catalog-* tools instead.
 `
 
 // Global flags shared by all subcommands.

--- a/docs/hugr-tools.md
+++ b/docs/hugr-tools.md
@@ -10,7 +10,7 @@
 > up.
 >
 > Engine-side replacements: `core.catalog.annotate_*` for curation,
-> `core.catalog.reindex_embeddings` for embeddings, the `core.entity_*` views
+> `core.catalog.reindex_embeddings` for embeddings, the `core.catalog.*` views
 > and the MCP `catalog-*` tools for reading the catalog.
 
 CLI utilities for managing Hugr schema metadata.

--- a/hugr-ipc.md
+++ b/hugr-ipc.md
@@ -228,11 +228,11 @@ For a multi-path query subscription with 2 paths and 10 ticks, the client receiv
 Client → subscribe s1 (query streaming, 2 paths)
 Client → subscribe s2 (LLM streaming)
 
-Server → binary frame (s1, path=core.entity_types)
+Server → binary frame (s1, path=core.catalog.types)
 Server → binary frame (s2, LLM event)
-Server → binary frame (s1, path=core.entity_fields)
+Server → binary frame (s1, path=core.catalog.fields)
 Server → part_complete s1 (tick 1 done for both paths)
-Server → binary frame (s1, path=core.entity_types)  (tick 2)
+Server → binary frame (s1, path=core.catalog.types)  (tick 2)
 Server → binary frame (s2, LLM event)
 Server → subscription_complete s2
 Server → part_complete s1 (tick 2 done)

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -22,7 +22,7 @@ integration-test/
 
 **Location**: `catalog/entity/`
 
-Boots a real `hugr.Service` on the entity catalog storage (design 034) — the schema of every source lives in the `catalog.*` tables as a logical model and the GraphQL schema is generated from it on the fly. These cover the storage end to end rather than a provider in isolation: runtime sources compile and store, a user source loads and is queryable, the catalog's own state is visible through the `entity_*` views, curation reaches introspection, and the MCP `catalog-*` tools read and rank over it (including under a restricted role).
+Boots a real `hugr.Service` on the entity catalog storage (design 034) — the schema of every source lives in the `catalog.*` tables as a logical model and the GraphQL schema is generated from it on the fly. These cover the storage end to end rather than a provider in isolation: runtime sources compile and store, a user source loads and is queryable, the catalog's own state is visible through the `core.catalog.*` views, curation reaches introspection, and the MCP `catalog-*` tools read and rank over it (including under a restricted role).
 
 ### Running
 

--- a/integration-test/catalog/entity/entity_test.go
+++ b/integration-test/catalog/entity/entity_test.go
@@ -88,8 +88,8 @@ func TestEntityStorageBoots(t *testing.T) {
 	var stored []struct {
 		Name string `json:"name"`
 	}
-	query(t, s, ctx, `query { core { entity_data_sources { name } } }`,
-		"core.entity_data_sources", &stored)
+	query(t, s, ctx, `query { core { catalog { active_sources { name } } } }`,
+		"core.catalog.active_sources", &stored)
 	names := map[string]bool{}
 	for _, r := range stored {
 		names[r.Name] = true
@@ -103,8 +103,8 @@ func TestEntityStorageBoots(t *testing.T) {
 		Name   string `json:"name"`
 		Module string `json:"module"`
 	}
-	query(t, s, ctx, `query { core { entity_data_objects(filter: {data_source: {eq: "core"}}, order_by: [{field: "name"}]) { name module } } }`,
-		"core.entity_data_objects", &objects)
+	query(t, s, ctx, `query { core { catalog { data_objects(filter: {data_source: {eq: "core"}}, order_by: [{field: "name"}]) { name module } } } }`,
+		"core.catalog.data_objects", &objects)
 	assert.NotEmpty(t, objects, "CoreDB's own objects are stored")
 }
 
@@ -144,8 +144,8 @@ func TestEntityStorageDataSource(t *testing.T) {
 		Name     string `json:"name"`
 		Original string `json:"original_name"`
 	}
-	query(t, s, ctx, `query { core { entity_data_objects(filter: {data_source: {eq: "shop"}}) { name original_name } } }`,
-		"core.entity_data_objects", &objects)
+	query(t, s, ctx, `query { core { catalog { data_objects(filter: {data_source: {eq: "shop"}}) { name original_name } } } }`,
+		"core.catalog.data_objects", &objects)
 	require.Len(t, objects, 1)
 	assert.Equal(t, "shop_items", objects[0].Name, "stored under its prefixed name")
 
@@ -197,8 +197,8 @@ func TestEntityStorageCuration(t *testing.T) {
 		Name string `json:"name"`
 		Desc string `json:"description"`
 	}
-	query(t, s, ctx, `query { core { entity_data_objects(filter: {name: {eq: "core_data_sources"}}) { name description } } }`,
-		"core.entity_data_objects", &objects)
+	query(t, s, ctx, `query { core { catalog { data_objects(filter: {name: {eq: "core_data_sources"}}) { name description } } } }`,
+		"core.catalog.data_objects", &objects)
 	require.Len(t, objects, 1)
 	assert.Equal(t, "Registered data sources", objects[0].Desc, "curation overrides the stored description")
 
@@ -221,8 +221,8 @@ func TestEntityStorageCuration(t *testing.T) {
 		Kind string `json:"kind"`
 		Desc string `json:"description"`
 	}
-	query(t, s, ctx, `query { core { entity_functions(filter: {name: {eq: "load_data_source"}}) { kind description } } }`,
-		"core.entity_functions", &fns)
+	query(t, s, ctx, `query { core { catalog { functions(filter: {name: {eq: "load_data_source"}}) { kind description } } } }`,
+		"core.catalog.functions", &fns)
 	require.Len(t, fns, 1)
 	assert.Equal(t, "mutation", fns[0].Kind)
 	assert.Equal(t, "Load a registered data source", fns[0].Desc,
@@ -291,19 +291,21 @@ func TestEntityStorageCurationReachesIntrospection(t *testing.T) {
 // opposite while the compiled-schema storage was the default. There is no
 // storage to select any more, so what it guards is the CoreDB catalog module:
 // it must expose the entity views and not regrow the _schema_* ones.
-func TestCatalogModuleServesEntityViewsOnly(t *testing.T) {
+func TestCatalogModuleServesLogicalViewsOnly(t *testing.T) {
 	s, ctx := setupEngine(t)
 
 	var objects []struct {
 		Name string `json:"name"`
 	}
-	query(t, s, ctx, `query { core { entity_data_objects(filter: {name: {eq: "core_data_sources"}}) { name } } }`,
-		"core.entity_data_objects", &objects)
+	query(t, s, ctx, `query { core { catalog { data_objects(filter: {name: {eq: "core_data_sources"}}) { name } } } }`,
+		"core.catalog.data_objects", &objects)
 	assert.NotEmpty(t, objects, "entity views are served")
 
-	// The compiled-schema views went with the storage that filled them (a
-	// validation error surfaces either from Query itself or on the response).
-	res, err := s.Query(ctx, `query { core { catalog { types { name } } } }`, nil)
+	// The compiled-schema views went with the storage that filled them. The
+	// probe deliberately names one whose name was NOT reused: this module now
+	// serves modules / types / fields / data_objects again, but over the
+	// LOGICAL model, so those names prove nothing about the old storage.
+	res, err := s.Query(ctx, `query { core { catalog { module_intro { name } } } }`, nil)
 	if err == nil {
 		assert.Error(t, res.Err(), "compiled-schema views are no longer part of the schema")
 		res.Close()

--- a/integration-test/catalog/entity/entity_test.go
+++ b/integration-test/catalog/entity/entity_test.go
@@ -287,10 +287,10 @@ func TestEntityStorageCurationReachesIntrospection(t *testing.T) {
 	assert.Equal(t, "Reloads when already loaded.", probe.Function.LongDescription)
 }
 
-// TestCatalogModuleServesEntityViewsOnly replaces the test that asserted the
+// TestCatalogModuleServesLogicalViewsOnly replaces the test that asserted the
 // opposite while the compiled-schema storage was the default. There is no
 // storage to select any more, so what it guards is the CoreDB catalog module:
-// it must expose the entity views and not regrow the _schema_* ones.
+// it must expose the catalog views and not regrow the _schema_* ones.
 func TestCatalogModuleServesLogicalViewsOnly(t *testing.T) {
 	s, ctx := setupEngine(t)
 
@@ -299,7 +299,7 @@ func TestCatalogModuleServesLogicalViewsOnly(t *testing.T) {
 	}
 	query(t, s, ctx, `query { core { catalog { data_objects(filter: {name: {eq: "core_data_sources"}}) { name } } } }`,
 		"core.catalog.data_objects", &objects)
-	assert.NotEmpty(t, objects, "entity views are served")
+	assert.NotEmpty(t, objects, "catalog views are served")
 
 	// The compiled-schema views went with the storage that filled them. The
 	// probe deliberately names one whose name was NOT reused: this module now

--- a/integration-test/catalog/entity/lifecycle_test.go
+++ b/integration-test/catalog/entity/lifecycle_test.go
@@ -43,8 +43,8 @@ type sourceStats struct {
 func statsOf(t *testing.T, s *hugr.Service, ctx context.Context, name string) sourceStats {
 	t.Helper()
 	var out []sourceStats
-	query(t, s, ctx, `query { core { entity_catalogs(filter: {name: {eq: "`+name+`"}})
-		{ loaded_at loaded disabled suspended } } }`, "core.entity_catalogs", &out)
+	query(t, s, ctx, `query { core { catalog { stored_catalogs(filter: {name: {eq: "`+name+`"}})
+		{ loaded_at loaded disabled suspended } } } }`, "core.catalog.stored_catalogs", &out)
 	require.Len(t, out, 1, "source %q has a metadata row", name)
 	return out[0]
 }
@@ -56,13 +56,13 @@ func storedRows(t *testing.T, s *hugr.Service, ctx context.Context, name string)
 	var objs []struct {
 		Name string `json:"name"`
 	}
-	query(t, s, ctx, `query { core { entity_data_objects(filter: {data_source: {eq: "`+name+`"}}) { name } } }`,
-		"core.entity_data_objects", &objs)
+	query(t, s, ctx, `query { core { catalog { data_objects(filter: {data_source: {eq: "`+name+`"}}) { name } } } }`,
+		"core.catalog.data_objects", &objs)
 	var flds []struct {
 		Name string `json:"name"`
 	}
-	query(t, s, ctx, `query { core { entity_fields(filter: {data_source: {eq: "`+name+`"}}) { name } } }`,
-		"core.entity_fields", &flds)
+	query(t, s, ctx, `query { core { catalog { fields(filter: {data_source: {eq: "`+name+`"}}) { name } } } }`,
+		"core.catalog.fields", &flds)
 	return len(objs), len(flds)
 }
 
@@ -100,7 +100,7 @@ func TestUnloadReloadKeepsRows(t *testing.T) {
 	after := statsOf(t, s, ctx, "shop")
 	assert.True(t, after.Suspended, "a soft unload suspends")
 	assert.Equal(t, before.LoadedAt, after.LoadedAt, "no rewrite: loaded_at untouched")
-	// The entity_* views are activity-gated, so a suspended source's entities
+	// The catalog views are activity-gated, so a suspended source's entities
 	// are correctly invisible through them — the rows themselves are still
 	// stored, which the resumed counts below confirm together with loaded_at.
 	gotObjects, gotFields := storedRows(t, s, ctx, "shop")
@@ -175,8 +175,8 @@ func TestHardUnloadRemovesRows(t *testing.T) {
 	require.True(t, ok, msg)
 
 	var meta []sourceStats
-	query(t, s, ctx, `query { core { entity_catalogs(filter: {name: {eq: "shop"}})
-		{ loaded_at loaded disabled suspended } } }`, "core.entity_catalogs", &meta)
+	query(t, s, ctx, `query { core { catalog { stored_catalogs(filter: {name: {eq: "shop"}})
+		{ loaded_at loaded disabled suspended } } } }`, "core.catalog.stored_catalogs", &meta)
 	assert.Empty(t, meta, "a hard unload removes the metadata row")
 	objects, fields := storedRows(t, s, ctx, "shop")
 	assert.Zero(t, objects, "and the entity rows")

--- a/integration-test/catalog/entity/mcp_permissions_test.go
+++ b/integration-test/catalog/entity/mcp_permissions_test.go
@@ -115,12 +115,12 @@ func TestMCPSearchWithoutCatalogViewAccess(t *testing.T) {
 	denied := []perm.Permission{
 		// The other shape a rule takes: a row filter would not deny the read,
 		// it would quietly shrink the index to nothing.
-		{Object: "data-object:query", Field: "core_entity_fields",
+		{Object: "data-object:query", Field: "core_fields",
 			Filter: map[string]any{"name": map[string]any{"eq": "___no_such_field___"}}},
 	}
 	for _, view := range []string{
-		"core_entity_modules", "core_entity_data_objects",
-		"core_entity_functions", "core_entity_data_sources",
+		"core_modules", "core_data_objects",
+		"core_functions", "core_active_sources",
 	} {
 		denied = append(denied, perm.Permission{Object: "data-object:query", Field: view, Disabled: true})
 	}

--- a/integration-test/catalog/entity/mcp_search_test.go
+++ b/integration-test/catalog/entity/mcp_search_test.go
@@ -248,7 +248,7 @@ func TestMCPSearchVectorFieldHits(t *testing.T) {
 	require.Empty(t, payload["lexical_reason"])
 
 	items, _ := payload["items"].([]any)
-	require.NotEmpty(t, items, "no field hits — the entity_fields index is not being ranked")
+	require.NotEmpty(t, items, "no field hits — the fields index is not being ranked")
 
 	for _, raw := range items {
 		hit := raw.(map[string]any)
@@ -284,7 +284,7 @@ func TestMCPSearchVectorFieldHits(t *testing.T) {
 }
 
 // TestMCPSearchFieldHitsHonourModuleScope — a field carries no module of its
-// own (entity_fields has no such column); it belongs to whatever module owns
+// own (fields has no such column); it belongs to whatever module owns
 // its data object. Scoping the search by module used to be applied to the raw
 // ranked hit, where that field is still empty, so ANY module argument erased
 // every field hit — silently, and exactly in the deployments big enough to

--- a/integration-test/catalog/entity/mcp_search_test.go
+++ b/integration-test/catalog/entity/mcp_search_test.go
@@ -248,7 +248,7 @@ func TestMCPSearchVectorFieldHits(t *testing.T) {
 	require.Empty(t, payload["lexical_reason"])
 
 	items, _ := payload["items"].([]any)
-	require.NotEmpty(t, items, "no field hits — the fields index is not being ranked")
+	require.NotEmpty(t, items, "no field hits — the core.catalog.fields index is not being ranked")
 
 	for _, raw := range items {
 		hit := raw.(map[string]any)
@@ -284,8 +284,8 @@ func TestMCPSearchVectorFieldHits(t *testing.T) {
 }
 
 // TestMCPSearchFieldHitsHonourModuleScope — a field carries no module of its
-// own (fields has no such column); it belongs to whatever module owns
-// its data object. Scoping the search by module used to be applied to the raw
+// own (core.catalog.fields has no such column); it belongs to whatever module
+// owns its data object. Scoping the search by module used to be applied to the raw
 // ranked hit, where that field is still empty, so ANY module argument erased
 // every field hit — silently, and exactly in the deployments big enough to
 // need the scope.

--- a/integration-test/catalog/entity/search_test.go
+++ b/integration-test/catalog/entity/search_test.go
@@ -118,22 +118,22 @@ func roleCtx(t testing.TB, p *perm.RolePermissions) context.Context {
 	return perm.CtxWithPerm(ctx, p)
 }
 
-// TestSearchRankingQueryMatchesEntityViews is the guard against a ranking
-// query that silently never runs. With a vector size configured the entity
-// views carry the index columns, so the vector query must at least VALIDATE:
-// if it still falls back, the reason must be the missing embedder and never a
-// schema mismatch.
-func TestSearchRankingQueryMatchesEntityViews(t *testing.T) {
+// TestSearchRankingQueryMatchesCatalogViews is the guard against a ranking
+// query that silently never runs. With a vector size configured the catalog
+// views carry the index columns and the ranking read must reach them: the
+// ONLY acceptable fallback reason is the missing embedder model. Pinning the
+// one good reason instead of a list of bad ones is what lets this catch a
+// break at ANY layer — validation, a view whose SQL lost a column, a missing
+// relation. (The same guard lives in TestCatalogSearchRankingReachesTheViews
+// on the MCP side; keep them in step.)
+func TestSearchRankingQueryMatchesCatalogViews(t *testing.T) {
 	svc, _ := mcpService(t, 8, "")
 	page := runSearch(t, adminCtx(t), svc, `query: "data sources", limit: 20`)
 
-	for _, bad := range []string{"Cannot query field", "Unknown argument", "Unknown type", "couldn't find field resolver"} {
-		assert.NotContains(t, page.LexicalReason, bad,
-			"the ranking query does not match the entity views: %s", page.LexicalReason)
-	}
-	if page.LexicalReason != "" {
-		t.Logf("fell back to lexical, as expected without an embedder: %s", page.LexicalReason)
-	}
+	require.NotEmpty(t, page.LexicalReason, "no embedder is configured here, so the vector path must fall back")
+	assert.Contains(t, page.LexicalReason, "_system_embedder",
+		"the ranking read fails against the catalog views for a reason other than the missing embedder: %s",
+		page.LexicalReason)
 }
 
 // TestSearchLexicalAnswers — without an embedder the lexical path must still
@@ -157,7 +157,8 @@ func TestSearchLexicalAnswers(t *testing.T) {
 
 // TestSearchLexicalReachesFields is the capability MCP's fallback never had:
 // a structural walk has no field enumeration that is not per object, so field
-// hits used to vanish whenever the embedder did. fields is one table.
+// hits used to vanish whenever the embedder did. core.catalog.fields is one
+// table.
 func TestSearchLexicalReachesFields(t *testing.T) {
 	svc, _ := mcpService(t, 0, "")
 	page := runSearch(t, adminCtx(t), svc, `query: "description", kinds: [FIELD], limit: 50`)

--- a/integration-test/catalog/entity/search_test.go
+++ b/integration-test/catalog/entity/search_test.go
@@ -19,7 +19,7 @@ import (
 //
 // Two properties are worth testing here rather than in a unit test, because
 // both only exist end to end: the ranking read really runs against the
-// core.entity_* views (a column that does not exist there produces a silent
+// core.catalog.* views (a column that does not exist there produces a silent
 // lexical fallback, which is indistinguishable from "no embedder configured"
 // unless you read lexicalReason), and the permission filter really is the same
 // predicate _dataObject uses.
@@ -157,7 +157,7 @@ func TestSearchLexicalAnswers(t *testing.T) {
 
 // TestSearchLexicalReachesFields is the capability MCP's fallback never had:
 // a structural walk has no field enumeration that is not per object, so field
-// hits used to vanish whenever the embedder did. entity_fields is one table.
+// hits used to vanish whenever the embedder did. fields is one table.
 func TestSearchLexicalReachesFields(t *testing.T) {
 	svc, _ := mcpService(t, 0, "")
 	page := runSearch(t, adminCtx(t), svc, `query: "description", kinds: [FIELD], limit: 50`)

--- a/integration-test/mcp/catalog_test.go
+++ b/integration-test/mcp/catalog_test.go
@@ -465,6 +465,11 @@ type searchPage struct {
 	HasMore  bool `json:"has_more"`
 	Filtered int  `json:"filtered_out"`
 	Lexical  bool `json:"lexical"`
+	// LexicalReason is why the vector index was unusable. A silent fallback is
+	// indistinguishable from a broken ranking query, which is what makes this
+	// field the only way to tell "no embedder here" from "the ranking query no
+	// longer matches the catalog views".
+	LexicalReason string `json:"lexical_reason"`
 }
 
 func catalogSearch(t *testing.T, h http.Handler, args map[string]any) searchPage {

--- a/integration-test/mcp/catalog_views_test.go
+++ b/integration-test/mcp/catalog_views_test.go
@@ -1,0 +1,87 @@
+//go:build duckdb_arrow
+
+package mcp_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MCP does not read the catalog views directly — it goes through _search, and
+// the engine reads the index for it. That indirection is what keeps the skills
+// and the tool contract free of view names, and it is also what makes a move
+// of those views invisible from here until search quietly stops ranking.
+//
+// These two tests close that gap from the MCP side: one pins WHERE the views
+// live, the other proves the ranking read actually reaches them.
+
+// TestCatalogViewsLiveInTheCatalogModule pins the module and the names. It is
+// the test a rename has to walk past: everything else about MCP keeps working
+// when a view moves, because the failure degrades into a lexical fallback
+// rather than an error.
+func TestCatalogViewsLiveInTheCatalogModule(t *testing.T) {
+	res, err := testService.Query(context.Background(),
+		`{ _module(name: "core.catalog") { name dataObjects { name } } }`, nil)
+	require.NoError(t, err)
+	require.NoError(t, res.Err())
+	defer res.Close()
+
+	var mod struct {
+		Name        string `json:"name"`
+		DataObjects []struct {
+			Name string `json:"name"`
+		} `json:"dataObjects"`
+	}
+	require.NoError(t, res.ScanData("_module", &mod))
+	require.Equal(t, "core.catalog", mod.Name)
+
+	served := make(map[string]bool, len(mod.DataObjects))
+	for _, o := range mod.DataObjects {
+		served[o.Name] = true
+	}
+	// The type name carries the SOURCE prefix and not the module, which is why
+	// active_sources and stored_catalogs are not called data_sources and
+	// catalogs: those type names are already taken by the core-db registry and
+	// its m2m junction.
+	for _, want := range []string{
+		"core_modules", "core_module_data_sources", "core_data_objects",
+		"core_fields", "core_relations", "core_functions", "core_types",
+		"core_active_sources", "core_stored_catalogs",
+		"core_catalog_dependencies", "core_annotations",
+	} {
+		assert.Truef(t, served[want], "core.catalog must serve %s", want)
+	}
+}
+
+// TestCatalogSearchRankingReachesTheViews is the guard against a ranking query
+// that silently never runs.
+//
+// catalog-search swallows any error from the ranking read and answers
+// lexically, so a query naming a view that has moved looks exactly like "this
+// deployment has no embedder" — forever, and everywhere. lexical_reason is what
+// tells the two apart, and this reads it.
+func TestCatalogSearchRankingReachesTheViews(t *testing.T) {
+	// Without a vector size the views carry no @embeddings, so the ranking
+	// query legitimately fails on _distance_to_query and falls back — which is
+	// indistinguishable from the failure this test looks for. The guard only
+	// means something where the index columns exist.
+	if os.Getenv("EMBEDDER_VECTOR_SIZE") == "" {
+		t.Skip("set EMBEDDER_URL and EMBEDDER_VECTOR_SIZE: without them the fallback is expected, not a symptom")
+	}
+	h := handler(t)
+	mcpInit(t, h)
+
+	page := catalogSearch(t, h, map[string]any{"query": "data sources"})
+	for _, broken := range []string{
+		"Cannot query field", "Unknown argument", "Unknown type",
+		"couldn't find field resolver",
+	} {
+		assert.NotContainsf(t, page.LexicalReason, broken,
+			"the ranking query no longer matches the catalog views: %s", page.LexicalReason)
+	}
+	require.NotEmpty(t, page.Items, "search must answer whichever path ranked")
+}

--- a/integration-test/mcp/catalog_views_test.go
+++ b/integration-test/mcp/catalog_views_test.go
@@ -76,12 +76,17 @@ func TestCatalogSearchRankingReachesTheViews(t *testing.T) {
 	mcpInit(t, h)
 
 	page := catalogSearch(t, h, map[string]any{"query": "data sources"})
-	for _, broken := range []string{
-		"Cannot query field", "Unknown argument", "Unknown type",
-		"couldn't find field resolver",
-	} {
-		assert.NotContainsf(t, page.LexicalReason, broken,
-			"the ranking query no longer matches the catalog views: %s", page.LexicalReason)
+	// Allowlist, not denylist: an empty reason means the vector path ranked,
+	// and the ONLY acceptable fallback reason is the missing embedder model.
+	// Anything else — a validation error, a Binder error from a view whose SQL
+	// lost a column, a missing relation — is the ranking read failing against
+	// the catalog views, whatever layer it failed at. (The same guard lives in
+	// TestSearchRankingQueryMatchesCatalogViews on the engine side; keep them
+	// in step.)
+	if page.LexicalReason != "" {
+		assert.Contains(t, page.LexicalReason, "_system_embedder",
+			"the ranking read fails against the catalog views for a reason other than the missing embedder: %s",
+			page.LexicalReason)
 	}
 	require.NotEmpty(t, page.Items, "search must answer whichever path ranked")
 }

--- a/integration-test/subscription/subscription_test.go
+++ b/integration-test/subscription/subscription_test.go
@@ -106,9 +106,9 @@ func TestGraphQLWS_QueryStreaming(t *testing.T) {
 	conn := connectGraphQLWS(t)
 	defer conn.CloseNow()
 
-	// Subscribe to a query — use entity_types, which always has data
+	// Subscribe to a query — use types, which always has data
 	payload, _ := json.Marshal(map[string]any{
-		"query": `subscription { query { core { entity_types(limit: 3) { name kind } } } }`,
+		"query": `subscription { query { core { catalog { types(limit: 3) { name kind } } } } }`,
 	})
 	wdata, _ := json.Marshal(gqlwsMsg{ID: "1", Type: "subscribe", Payload: payload})
 	err := conn.Write(context.Background(), websocket.MessageText, wdata)
@@ -162,9 +162,9 @@ func TestGraphQLWS_PeriodicPolling(t *testing.T) {
 	conn := connectGraphQLWS(t)
 	defer conn.CloseNow()
 
-	// Subscribe with interval=1s, count=2 — use entity_types, which always has data
+	// Subscribe with interval=1s, count=2 — use types, which always has data
 	payload, _ := json.Marshal(map[string]any{
-		"query": `subscription { query(interval: "1s", count: 2) { core { entity_types(limit: 3) { name } } } }`,
+		"query": `subscription { query(interval: "1s", count: 2) { core { catalog { types(limit: 3) { name } } } } }`,
 	})
 	wdata, _ := json.Marshal(gqlwsMsg{ID: "poll", Type: "subscribe", Payload: payload})
 	err := conn.Write(context.Background(), websocket.MessageText, wdata)
@@ -212,7 +212,7 @@ func TestGraphQLWS_MultiPathQuery(t *testing.T) {
 	payload, _ := json.Marshal(map[string]any{
 		"query": `subscription { query {
 			core {
-				entity_types(limit: 2) { name kind }
+				catalog { types(limit: 2) { name kind } }
 				data_sources { name type }
 			}
 		} }`,
@@ -236,8 +236,13 @@ func TestGraphQLWS_MultiPathQuery(t *testing.T) {
 			data, _ := p["data"].(map[string]any)
 			if data != nil {
 				if core, ok := data["core"].(map[string]any); ok {
-					if _, ok := core["entity_types"]; ok {
-						paths["entity_types"]++
+					// The catalog views moved a module deeper; the data-source
+					// registry did not, which is what keeps this a MULTI-path
+					// test rather than two readers on one branch.
+					if cat, ok := core["catalog"].(map[string]any); ok {
+						if _, ok := cat["types"]; ok {
+							paths["types"]++
+						}
 					}
 					if _, ok := core["data_sources"]; ok {
 						paths["data_sources"]++
@@ -250,9 +255,9 @@ func TestGraphQLWS_MultiPathQuery(t *testing.T) {
 		}
 	}
 
-	assert.Greater(t, paths["entity_types"], 0, "should have catalog rows")
+	assert.Greater(t, paths["types"], 0, "should have catalog rows")
 	// data_sources may be empty in test DB but path should still be attempted
-	t.Logf("multi-path: entity_types=%d rows, data_sources=%d rows", paths["entity_types"], paths["data_sources"])
+	t.Logf("multi-path: types=%d rows, data_sources=%d rows", paths["types"], paths["data_sources"])
 }
 
 func TestGraphQLWS_Cancel(t *testing.T) {
@@ -261,7 +266,7 @@ func TestGraphQLWS_Cancel(t *testing.T) {
 
 	// Subscribe to periodic — first tick executes immediately, then waits interval
 	payload, _ := json.Marshal(map[string]any{
-		"query": `subscription { query(interval: "60s") { core { entity_types(limit: 1) { name } } } }`,
+		"query": `subscription { query(interval: "60s") { core { catalog { types(limit: 1) { name } } } } }`,
 	})
 	wdata, _ := json.Marshal(gqlwsMsg{ID: "cancel-test", Type: "subscribe", Payload: payload})
 	err := conn.Write(context.Background(), websocket.MessageText, wdata)
@@ -358,11 +363,11 @@ func TestIPC_Subscribe(t *testing.T) {
 	conn := connectIPC(t)
 	defer conn.CloseNow()
 
-	// Send subscribe — use entity_types, which always has data
+	// Send subscribe — use types, which always has data
 	wdata, _ := json.Marshal(ipcMsg{
 		Type:           "subscribe",
 		SubscriptionID: "s1",
-		Query:          `subscription { query { core { entity_types(limit: 3) { name kind } } } }`,
+		Query:          `subscription { query { core { catalog { types(limit: 3) { name kind } } } } }`,
 	})
 	err := conn.Write(context.Background(), websocket.MessageText, wdata)
 	require.NoError(t, err)
@@ -419,11 +424,11 @@ func TestIPC_Unsubscribe(t *testing.T) {
 	conn := connectIPC(t)
 	defer conn.CloseNow()
 
-	// Subscribe to periodic with data (entity_types always has data)
+	// Subscribe to periodic with data (types always has data)
 	wdata, _ := json.Marshal(ipcMsg{
 		Type:           "subscribe",
 		SubscriptionID: "s-cancel",
-		Query:          `subscription { query(interval: "30s") { core { entity_types(limit: 1) { name } } } }`,
+		Query:          `subscription { query(interval: "30s") { core { catalog { types(limit: 1) { name } } } } }`,
 	})
 	err := conn.Write(context.Background(), websocket.MessageText, wdata)
 	require.NoError(t, err)
@@ -575,7 +580,7 @@ func TestGoClient_Subscribe(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	sub, err := c.Subscribe(ctx, `subscription { query { core { entity_types(limit: 3) { name kind } } } }`, nil)
+	sub, err := c.Subscribe(ctx, `subscription { query { core { catalog { types(limit: 3) { name kind } } } } }`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, sub)
 	defer sub.Cancel()
@@ -603,7 +608,7 @@ func TestGoClient_SubscribePeriodic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	sub, err := c.Subscribe(ctx, `subscription { query(interval: "1s", count: 2) { core { entity_types(limit: 2) { name } } } }`, nil)
+	sub, err := c.Subscribe(ctx, `subscription { query(interval: "1s", count: 2) { core { catalog { types(limit: 2) { name } } } } }`, nil)
 	require.NoError(t, err)
 	defer sub.Cancel()
 
@@ -629,9 +634,9 @@ func TestGoClient_MultipleSubscriptions(t *testing.T) {
 
 	ctx := context.Background()
 
-	sub1, err := c.Subscribe(ctx, `subscription { query { core { entity_types(limit: 2) { name } } } }`, nil)
+	sub1, err := c.Subscribe(ctx, `subscription { query { core { catalog { types(limit: 2) { name } } } } }`, nil)
 	require.NoError(t, err)
-	sub2, err := c.Subscribe(ctx, `subscription { query { core { entity_types(limit: 3) { name } } } }`, nil)
+	sub2, err := c.Subscribe(ctx, `subscription { query { core { catalog { types(limit: 3) { name } } } } }`, nil)
 	require.NoError(t, err)
 
 	// Drain both in parallel
@@ -654,7 +659,7 @@ func TestGoClient_ReuseAfterComplete(t *testing.T) {
 	ctx := context.Background()
 
 	// First subscription — completes
-	sub1, err := c.Subscribe(ctx, `subscription { query { core { entity_types(limit: 1) { name } } } }`, nil)
+	sub1, err := c.Subscribe(ctx, `subscription { query { core { catalog { types(limit: 1) { name } } } } }`, nil)
 	require.NoError(t, err)
 	var rows1 int
 	for event := range sub1.Events {
@@ -666,7 +671,7 @@ func TestGoClient_ReuseAfterComplete(t *testing.T) {
 	assert.Greater(t, rows1, 0)
 
 	// Second subscription — reuses same pool connection
-	sub2, err := c.Subscribe(ctx, `subscription { query { core { entity_types(limit: 2) { name } } } }`, nil)
+	sub2, err := c.Subscribe(ctx, `subscription { query { core { catalog { types(limit: 2) { name } } } } }`, nil)
 	require.NoError(t, err)
 	var rows2 int
 	for event := range sub2.Events {
@@ -687,9 +692,9 @@ func TestGoClient_DedicatedConn(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	sub1, err := conn.Subscribe(ctx, `subscription { query { core { entity_types(limit: 2) { name } } } }`, nil)
+	sub1, err := conn.Subscribe(ctx, `subscription { query { core { catalog { types(limit: 2) { name } } } } }`, nil)
 	require.NoError(t, err)
-	sub2, err := conn.Subscribe(ctx, `subscription { query { core { entity_types(limit: 3) { name } } } }`, nil)
+	sub2, err := conn.Subscribe(ctx, `subscription { query { core { catalog { types(limit: 3) { name } } } } }`, nil)
 	require.NoError(t, err)
 
 	// Drain both in parallel — sequential drain deadlocks on shared connection
@@ -714,11 +719,11 @@ func TestGoClient_Pool(t *testing.T) {
 
 	ctx := context.Background()
 
-	sub1, err := c.Subscribe(ctx, `subscription { query { core { entity_types(limit: 1) { name } } } }`, nil)
+	sub1, err := c.Subscribe(ctx, `subscription { query { core { catalog { types(limit: 1) { name } } } } }`, nil)
 	require.NoError(t, err)
-	sub2, err := c.Subscribe(ctx, `subscription { query { core { entity_types(limit: 2) { name } } } }`, nil)
+	sub2, err := c.Subscribe(ctx, `subscription { query { core { catalog { types(limit: 2) { name } } } } }`, nil)
 	require.NoError(t, err)
-	sub3, err := c.Subscribe(ctx, `subscription { query { core { entity_types(limit: 3) { name } } } }`, nil)
+	sub3, err := c.Subscribe(ctx, `subscription { query { core { catalog { types(limit: 3) { name } } } } }`, nil)
 	require.NoError(t, err)
 
 	var r1, r2, r3 int
@@ -774,8 +779,10 @@ func TestGoClient_TwoSubscriptionsSameData(t *testing.T) {
 
 	query := `subscription { query(interval: "500ms", count: 10) {
 		core {
-			entity_types(limit: 100, order_by: [{field: "name", direction: ASC}]) { name kind }
-			entity_fields(limit: 100, order_by: [{field: "name", direction: ASC}]) { name field_type }
+			catalog {
+				types(limit: 100, order_by: [{field: "name", direction: ASC}]) { name kind }
+				fields(limit: 100, order_by: [{field: "name", direction: ASC}]) { name field_type }
+			}
 		}
 	} }`
 

--- a/pkg/catalog/base/interfaces.go
+++ b/pkg/catalog/base/interfaces.go
@@ -54,7 +54,7 @@ type Provider interface {
 // and lives on in LogicalAnnotator / GraphQLAnnotator below.
 
 // LogicalAnnotator curates human descriptions over the LOGICAL model — the
-// source-level entities the CoreDB entity_* views expose: modules, data
+// source-level entities the CoreDB core.catalog.* views expose: modules, data
 // objects, residual source-defined types, object fields (including relation
 // navigation fields), functions and data sources. The keys mirror exactly how
 // those views select their overlay from catalog.annotations, so a curation

--- a/pkg/catalog/store/annotate.go
+++ b/pkg/catalog/store/annotate.go
@@ -11,7 +11,7 @@ import (
 )
 
 // The store implements both curation surfaces. LogicalAnnotator writes the
-// source-level entity kinds the entity_* views read; GraphQLAnnotator writes
+// source-level entity kinds the core.catalog.* views read; GraphQLAnnotator writes
 // the generated-surface kinds. Every write upserts one catalog.annotations row
 // by (entity_kind, entity_key) — text plus, when an embedder is configured, the
 // text's embedding vector so MCP vector search is current — and then evicts the
@@ -30,7 +30,7 @@ var errReadonly = errors.New("catalog store: read-only, cannot annotate")
 // --- LogicalAnnotator ---
 
 // SetModuleDescription curates a module (no ForName surface — module
-// descriptions reach clients through the logical model / entity_modules view).
+// descriptions reach clients through the logical model / core.catalog.modules view).
 func (s *Store) SetModuleDescription(ctx context.Context, module, desc, longDesc string) error {
 	return s.curate(ctx, kindModule, module, "", desc, longDesc, nil)
 }
@@ -69,7 +69,7 @@ func (s *Store) SetFunctionDescription(ctx context.Context, module, name, kind, 
 }
 
 // SetDataSourceDescription curates a data source (no ForName surface — data
-// source descriptions reach clients through the entity_data_sources view).
+// source descriptions reach clients through the core.catalog.active_sources view).
 func (s *Store) SetDataSourceDescription(ctx context.Context, name, desc, longDesc string) error {
 	return s.curate(ctx, kindDataSource, name, "", desc, longDesc, nil)
 }

--- a/pkg/catalog/store/annotations.go
+++ b/pkg/catalog/store/annotations.go
@@ -14,10 +14,10 @@ import (
 // AFTER the default descriptions: a row in catalog.annotations overrides the
 // generated description of the reconstructed definition. Two layers stack in
 // order (logical first, GraphQL second, each overriding the previous), keyed
-// EXACTLY the way the CoreDB entity_* views select their overlay so a single
+// EXACTLY the way the CoreDB core.catalog.* views select their overlay so a single
 // annotations table drives both the reconstructed schema and MCP vector search.
 //
-//	LOGICAL (the source-level model the entity_* views expose):
+//	LOGICAL (the source-level model the core.catalog.* views expose):
 //	  module        entity_key = module name                        (no ForName surface)
 //	  data_object   entity_key = compiled object type name          → def.Description
 //	  type          entity_key = residual source type name          → def.Description
@@ -38,7 +38,7 @@ import (
 // writers (annotate.go).
 
 const (
-	// Logical kinds (mirror the entity_* view annotation joins).
+	// Logical kinds (mirror the catalog view annotation joins).
 	kindModule     = "module"
 	kindDataObject = "data_object"
 	kindType       = "type"
@@ -53,7 +53,7 @@ const (
 	// it does in the catalog.functions primary key, and it does so with the very
 	// value that table stores: the overlay join needs no mapping
 	// (a.entity_kind = f.kind) and a client curating a function passes back the
-	// kind it read from entity_functions / _catalog.
+	// kind it read from core.catalog.functions / _catalog.
 	kindFunction         = "function"     // query function — also the pre-kind value
 	kindMutationFunction = "mutation"     // mutation function
 	kindSubscription     = "subscription" // subscription
@@ -69,7 +69,7 @@ const (
 // from the data object that uses it, so it is never a search target
 // (design-035 vector index scope — the same decision seedableField and the
 // reindex enumeration implement). Its CURATION is unaffected: the description
-// overlay lives in the text columns and entity_types still coalesces it; only
+// overlay lives in the text columns and core.catalog.types still coalesces it; only
 // the embedder call, and the vector nothing would read, are skipped.
 func indexedKind(kind string) bool {
 	return kind != kindType

--- a/pkg/catalog/store/logical.go
+++ b/pkg/catalog/store/logical.go
@@ -689,7 +689,7 @@ func (g *genContext) dataSourceInfo(ctx context.Context, row *dataSourceRow) (*c
 }
 
 // readDataSources reads the active sources with the data_source curation
-// overlay applied — the same coalesce the entity_data_sources view does, so
+// overlay applied — the same coalesce the core.catalog.active_sources view does, so
 // introspection and the view never disagree. name == "" reads all.
 func (g *genContext) readDataSources(ctx context.Context, name string) ([]*dataSourceRow, error) {
 	where := `WHERE m.loaded AND NOT m.disabled AND NOT m.suspended`

--- a/pkg/catalog/store/logical_test.go
+++ b/pkg/catalog/store/logical_test.go
@@ -158,7 +158,7 @@ type gauges @module(name: "ops") @table(name: "gauges") {
 	assert.Equal(t, []string{"sales", "sales.reports"}, main.Modules)
 
 	// Curation is the point of the logical model: a curated description must
-	// reach introspection, not just the entity_data_sources view.
+	// reach introspection, not just the active_sources view.
 	require.NoError(t, store.SetDataSourceDescription(ctx, "ro", "Operational gauges", "Long form."))
 	curated := store.DataSource(ctx, "ro")
 	require.NotNil(t, curated)
@@ -172,7 +172,7 @@ type gauges @module(name: "ops") @table(name: "gauges") {
 // TestLogicalCurationOverlay pins that the LOGICAL-MODEL surface serves the
 // curated text, not the stored row. The overlay used to be applied only in
 // ForName, so _catalog / _module / _dataObject / _function answered with raw
-// descriptions while the entity_* views answered with curated ones — the same
+// descriptions while the catalog views answered with curated ones — the same
 // deployment describing itself two different ways depending on the door.
 // Long descriptions exist ONLY as curation and had no surface at all.
 func TestLogicalCurationOverlay(t *testing.T) {

--- a/pkg/catalog/store/reindex.go
+++ b/pkg/catalog/store/reindex.go
@@ -158,7 +158,7 @@ func (r reindexRow) text() string {
 
 // reindexQueries builds the per-kind enumeration statements for a scope. Each
 // LEFT JOINs the curation onto the entity rows (the overlay read shape the
-// entity_* views use) and projects the reindexRow columns, with the constant
+// the catalog views use) and projects the reindexRow columns, with the constant
 // parts as literals so a single scanner serves all of them.
 func reindexQueries(dataSource string) []string {
 	// join correlates the curation by the kind's entity_key expression. Both

--- a/pkg/catalog/store/reindex.go
+++ b/pkg/catalog/store/reindex.go
@@ -158,7 +158,7 @@ func (r reindexRow) text() string {
 
 // reindexQueries builds the per-kind enumeration statements for a scope. Each
 // LEFT JOINs the curation onto the entity rows (the overlay read shape the
-// the catalog views use) and projects the reindexRow columns, with the constant
+// catalog views use) and projects the reindexRow columns, with the constant
 // parts as literals so a single scanner serves all of them.
 func reindexQueries(dataSource string) []string {
 	// join correlates the curation by the kind's entity_key expression. Both

--- a/pkg/catalog/store/seed.go
+++ b/pkg/catalog/store/seed.go
@@ -243,7 +243,7 @@ func (s *Store) upsertVectors(ctx context.Context, what string, rows []seedRow, 
 // still present to resolve the keys (ctx carries the transaction). Modules are
 // shared across sources and are not swept here (a truly orphaned module seed is
 // harmless — the module row is gone, so it never surfaces through
-// entity_modules).
+// core.catalog.modules).
 func (s *Store) sweepAnnotationSeeds(ctx context.Context, dataSource string) error {
 	conn, err := s.pool.Conn(ctx)
 	if err != nil {

--- a/pkg/catalog/store/seed_test.go
+++ b/pkg/catalog/store/seed_test.go
@@ -93,7 +93,7 @@ func TestSeedVectorsAndSweep(t *testing.T) {
 
 	// The curated object survives; module seeds stay as tolerated orphans —
 	// modules are shared and not source-attributable, and a vec-only orphan is
-	// invisible through entity_modules (the module row is gone) and is revived
+	// invisible through modules (the module row is gone) and is revived
 	// by the seed upsert if the module is recreated.
 	assert.Equal(t, []string{"data_object|orders", "module|sales", "module|sales.reports"},
 		rows(t, pool, `SELECT entity_kind, entity_key FROM core.catalog.annotations

--- a/pkg/catalog/store/seed_test.go
+++ b/pkg/catalog/store/seed_test.go
@@ -93,8 +93,8 @@ func TestSeedVectorsAndSweep(t *testing.T) {
 
 	// The curated object survives; module seeds stay as tolerated orphans —
 	// modules are shared and not source-attributable, and a vec-only orphan is
-	// invisible through modules (the module row is gone) and is revived
-	// by the seed upsert if the module is recreated.
+	// invisible through core.catalog.modules (the module row is gone) and is
+	// revived by the seed upsert if the module is recreated.
 	assert.Equal(t, []string{"data_object|orders", "module|sales", "module|sales.reports"},
 		rows(t, pool, `SELECT entity_kind, entity_key FROM core.catalog.annotations
 			ORDER BY entity_kind, entity_key`),

--- a/pkg/data-sources/sources/runtime/core-db/hugr_catalog_test.go
+++ b/pkg/data-sources/sources/runtime/core-db/hugr_catalog_test.go
@@ -349,7 +349,7 @@ func probeCatalogStatements(t *testing.T, pool *db.Pool) {
 
 	// E7: the FUNCTION overlay join — the annotation kind is a COLUMN here, not
 	// a literal: a function's kind is part of its annotation identity, so the
-	// curation correlates on functions.kind (the entity_functions view and the
+	// curation correlates on functions.kind (the functions view and the
 	// reindex enumeration share this shape). The uncurated kind falls through.
 	exec(`INSERT INTO core.catalog.annotations (entity_kind, entity_key, description) VALUES
 		('function', 'probe.fn', 'the query fn'),

--- a/pkg/data-sources/sources/runtime/core-db/schema_catalog_tmpl.graphql
+++ b/pkg/data-sources/sources/runtime/core-db/schema_catalog_tmpl.graphql
@@ -174,7 +174,7 @@ type function_binding {
   json_cast: Boolean
 }
 
-# --- Entity views ----------------------------------------------------------
+# --- Catalog views ---------------------------------------------------------
 
 "Logical-model modules with at least one active data source"
 type modules
@@ -342,7 +342,7 @@ type relations
   destination_field_description: String
 }
 
-"Logical-model functions, mutations and subscriptions (entity storage)"
+"Logical-model functions, mutations and subscriptions"
 type functions
   @view(name: "functions", sql: """
     SELECT f.module, f.name, f.kind, f.data_source, f.returns, f.is_table,
@@ -382,7 +382,7 @@ type functions
 # semantic search target (design-035 vector index scope). Curation is
 # unaffected — the description overlay below is the one every entity view
 # applies, and catalog.annotations still stores the curated text.
-"Logical-model residual source-defined types as raw SDL (entity storage)"
+"Logical-model residual source-defined types as raw SDL"
 type types
   @view(name: "types", sql: """
     SELECT t.name, t.kind, t.data_source, t.module, t.definition,
@@ -448,7 +448,7 @@ type stored_catalogs
   long_description: String
 }
 
-"Declared @dependency edges between stored catalogs (entity storage)"
+"Declared @dependency edges between stored catalogs"
 type catalog_dependencies
   @view(name: "catalog_dependencies", sql: """
     SELECT d.data_source AS catalog, d.depends_on
@@ -515,7 +515,7 @@ type active_sources
   vec: Vector {{ if .EmbeddingsEnabled }} @dim(len: {{ .VectorSize }}){{ end }}
 }
 
-"Curation overlay incl. orphans and vec-only seed rows (entity storage)"
+"Curation overlay incl. orphans and vec-only seed rows"
 type annotations
   @view(name: "annotations", sql: """
     SELECT a.entity_kind, a.entity_key, a.parent,

--- a/pkg/data-sources/sources/runtime/core-db/schema_catalog_tmpl.graphql
+++ b/pkg/data-sources/sources/runtime/core-db/schema_catalog_tmpl.graphql
@@ -1,6 +1,6 @@
 # core.catalog Schema Views
-# Mounted as module core.catalog — types accessed as core.catalog.entity_types,
-# core.catalog.entity_data_objects, etc.
+# Mounted as module core.catalog — types accessed as core.catalog.types,
+# core.catalog.data_objects, etc.
 # Conditional: @embeddings directives included only when EmbeddingsEnabled=true
 #
 # These views read the catalog.* tables the catalog storage writes — the
@@ -25,14 +25,14 @@
 # the module-activity gate via [catalog.module_data_sources].
 #
 # Effective descriptions COALESCE the annotations overlay (curation wins over
-# source SDL); properties are TYPED structural fields (entity_*_properties
+# source SDL); properties are TYPED structural fields (*_properties
 # below) cast from the stored bags per the requested selection set — raw SQL
 # is never stored at all (the writer controls the write side).
 
 # --- Typed property structures (the Properties Catalog as GraphQL types) ---
 
 "Typed properties of a data object (Properties Catalog)"
-type entity_data_object_properties {
+type data_object_properties {
   "Physical name in the source"
   name: String
   "View definition SQL (@view)"
@@ -46,27 +46,27 @@ type entity_data_object_properties {
   is_cube: Boolean
   is_m2m: Boolean
   is_hypertable: Boolean
-  embeddings: entity_embeddings_config
+  embeddings: embeddings_config
   "Args input type of a parameterized view"
   args_type_name: String
   required_args: Boolean
-  unique: [entity_unique_constraint]
+  unique: [unique_constraint]
   "Cross-source view dependencies (@dependency)"
   dependencies: [String]
-  cache: entity_cache_settings
-  at: entity_at_pin
+  cache: cache_settings
+  at: at_pin
 }
 
 "Typed properties of a data-object field (Properties Catalog)"
-type entity_field_properties {
+type field_properties {
   "Physical column (@field_source)"
   source: String
   "Computed field marker (@sql)"
   computed: Boolean
   "Computed field SQL expression (@sql)"
   sql: String
-  default: entity_default_value
-  geometry: entity_geometry_info
+  default: default_value
+  geometry: geometry_info
   "Geometry / vector dimension (@dim(len:))"
   dim: Int
   measurement: Boolean
@@ -76,23 +76,23 @@ type entity_field_properties {
   exclude_filter: [String]
   filter_required: Boolean
   exclude_mcp: Boolean
-  cache: entity_cache_settings
+  cache: cache_settings
   "Declared @join field binding"
-  join: entity_join_binding
-  function_call: entity_function_call_binding
-  table_function_call_join: entity_function_call_binding
+  join: join_binding
+  function_call: function_call_binding
+  table_function_call_join: function_call_binding
 }
 
 "Typed properties of a function (Properties Catalog)"
-type entity_function_properties {
-  function: entity_function_binding
-  cache: entity_cache_settings
+type function_properties {
+  function: function_binding
+  cache: cache_settings
   "Geometry return metadata (@geometry_info)"
-  geometry: entity_geometry_info
+  geometry: geometry_info
 }
 
 "One ordered argument of a function"
-type entity_function_argument {
+type function_argument {
   name: String
   type: String
   description: String
@@ -103,31 +103,31 @@ type entity_function_argument {
   deprecation_reason: String
 }
 
-type entity_embeddings_config {
+type embeddings_config {
   model: String
   vector: String
   distance: String
 }
 
-type entity_unique_constraint {
+type unique_constraint {
   fields: [String]
   query_suffix: String
   skip_query: Boolean
 }
 
-type entity_cache_settings {
+type cache_settings {
   ttl: String
   key: String
   tags: [String]
 }
 
-type entity_at_pin {
+type at_pin {
   "Snapshot / version id (@at(version:)) — 64-bit (Iceberg snapshot ids)"
   version: BigInt
   timestamp: String
 }
 
-type entity_default_value {
+type default_value {
   value: JSON
   sequence: String
   "Insert-time SQL expression (@default(insert_exp:))"
@@ -136,12 +136,12 @@ type entity_default_value {
   update_exp: String
 }
 
-type entity_geometry_info {
+type geometry_info {
   type: String
   srid: Int
 }
 
-type entity_join_binding {
+type join_binding {
   references_name: String
   source_fields: [String]
   references_fields: [String]
@@ -149,8 +149,8 @@ type entity_join_binding {
   sql: String
 }
 
-type entity_function_call_binding {
-  function: entity_function_binding_ref
+type function_call_binding {
+  function: function_binding_ref
   "Field-to-argument mapping"
   args: JSON
   source_fields: [String]
@@ -159,13 +159,13 @@ type entity_function_call_binding {
   sql: String
 }
 
-type entity_function_binding_ref {
+type function_binding_ref {
   module: String
   name: String
 }
 
 "Bound source function (@function)"
-type entity_function_binding {
+type function_binding {
   name: String
   "Function body SQL (@function(sql:))"
   sql: String
@@ -177,8 +177,8 @@ type entity_function_binding {
 # --- Entity views ----------------------------------------------------------
 
 "Logical-model modules with at least one active data source"
-type entity_modules
-  @view(name: "entity_modules", sql: """
+type modules
+  @view(name: "modules", sql: """
     SELECT m.name, m.parent,
       COALESCE(a.description, m.description) AS description,
       a.long_description,
@@ -190,11 +190,12 @@ type entity_modules
       JOIN [catalog.data_source_meta] ms ON ms.data_source = md.data_source
       WHERE md.module = m.name AND ms.loaded AND NOT ms.disabled AND NOT ms.suspended)
   """)
+  @module(name: "catalog")
   {{ if .EmbeddingsEnabled }}@embeddings(model: "_system_embedder", vector: "vec", distance: Cosine){{ end }} {
   name: String! @pk
   parent: String @field_references(
-    name: "entity_modules_parent"
-    references_name: "entity_modules"
+    name: "modules_parent"
+    references_name: "modules"
     field: "name"
     query: "parent_module"
     description: "The parent module"
@@ -207,8 +208,8 @@ type entity_modules
 }
 
 "Module → contributing data sources (closure over submodules, active sources only)"
-type entity_module_data_sources
-  @view(name: "entity_module_data_sources", sql: """
+type module_data_sources
+  @view(name: "module_data_sources", sql: """
     SELECT md.module, md.data_source,
       md.has_data_objects, md.has_tables, md.has_functions,
       md.has_mut_functions, md.has_subscriptions
@@ -216,10 +217,11 @@ type entity_module_data_sources
       JOIN [catalog.data_source_meta] ms
         ON ms.data_source = md.data_source AND ms.loaded AND NOT ms.disabled AND NOT ms.suspended
   """)
+  @module(name: "catalog")
   {
   module: String! @pk @field_references(
-    name: "entity_module_data_sources_module"
-    references_name: "entity_modules"
+    name: "module_data_sources_module"
+    references_name: "modules"
     field: "name"
     query: "module_info"
     description: "The module"
@@ -235,8 +237,8 @@ type entity_module_data_sources
 }
 
 "Logical-model data objects (active data sources only)"
-type entity_data_objects
-  @view(name: "entity_data_objects", sql: """
+type data_objects
+  @view(name: "data_objects", sql: """
     SELECT o.name, o.original_name, o.data_source, o.module, o.kind,
       o.properties,
       COALESCE(a.description, o.description) AS description,
@@ -248,6 +250,7 @@ type entity_data_objects
       LEFT JOIN [catalog.annotations] a
         ON a.entity_kind = 'data_object' AND a.entity_key = o.name
   """)
+  @module(name: "catalog")
   {{ if .EmbeddingsEnabled }}@embeddings(model: "_system_embedder", vector: "vec", distance: Cosine){{ end }} {
   "Compiled (prefixed) GraphQL type name"
   name: String! @pk
@@ -256,15 +259,15 @@ type entity_data_objects
   data_source: String!
   module: String!
   kind: String!
-  properties: entity_data_object_properties
+  properties: data_object_properties
   description: String
   long_description: String
   vec: Vector {{ if .EmbeddingsEnabled }} @dim(len: {{ .VectorSize }}){{ end }}
 }
 
 "Logical-model data object fields incl. declared join/function-call fields"
-type entity_fields
-  @view(name: "entity_fields", sql: """
+type fields
+  @view(name: "fields", sql: """
     SELECT f.type_name, f.name, f.field_type,
       f.properties, f.args,
       f.data_source, f.dependency_data_source, f.is_pk, f.ordinal,
@@ -278,10 +281,11 @@ type entity_fields
       LEFT JOIN [catalog.annotations] a
         ON a.entity_kind = 'field' AND a.entity_key = f.type_name || '.' || f.name
   """)
+  @module(name: "catalog")
   {{ if .EmbeddingsEnabled }}@embeddings(model: "_system_embedder", vector: "vec", distance: Cosine){{ end }} {
   type_name: String! @pk @field_references(
-    name: "entity_fields_object"
-    references_name: "entity_data_objects"
+    name: "fields_object"
+    references_name: "data_objects"
     field: "name"
     query: "data_object"
     description: "The owning data object"
@@ -290,7 +294,7 @@ type entity_fields
   )
   name: String! @pk
   field_type: String!
-  properties: entity_field_properties
+  properties: field_properties
   "Declared SDL arguments of the field (@table_function_call_join call parameters)"
   args: JSON
   data_source: String!
@@ -305,8 +309,8 @@ type entity_fields
 }
 
 "Logical-model relations: ONE row per @references edge (fk | m2m)"
-type entity_relations
-  @view(name: "entity_relations", sql: """
+type relations
+  @view(name: "relations", sql: """
     SELECT r.source, r.name, r.kind, r.destination, r.m2m_object,
       r.source_keys, r.destination_keys, r.field_declared, r.data_source,
       r.source_field,
@@ -320,7 +324,8 @@ type entity_relations
         ON asrc.entity_kind = 'field' AND asrc.entity_key = r.source || '.' || r.source_field
       LEFT JOIN [catalog.annotations] adst
         ON adst.entity_kind = 'field' AND adst.entity_key = r.destination || '.' || r.destination_field
-  """) {
+  """)
+  @module(name: "catalog") {
   source: String! @pk
   name: String! @pk
   kind: String!
@@ -338,8 +343,8 @@ type entity_relations
 }
 
 "Logical-model functions, mutations and subscriptions (entity storage)"
-type entity_functions
-  @view(name: "entity_functions", sql: """
+type functions
+  @view(name: "functions", sql: """
     SELECT f.module, f.name, f.kind, f.data_source, f.returns, f.is_table,
       f.args,
       f.properties,
@@ -354,6 +359,7 @@ type entity_functions
         ON a.entity_kind = f.kind
         AND a.entity_key = CASE WHEN f.module = '' THEN f.name ELSE f.module || '.' || f.name END
   """)
+  @module(name: "catalog")
   {{ if .EmbeddingsEnabled }}@embeddings(model: "_system_embedder", vector: "vec", distance: Cosine){{ end }} {
   module: String! @pk
   name: String! @pk
@@ -362,8 +368,8 @@ type entity_functions
   data_source: String!
   returns: String!
   is_table: Boolean!
-  args: [entity_function_argument]
-  properties: entity_function_properties
+  args: [function_argument]
+  properties: function_properties
   "@deprecated(reason:) — null means active"
   deprecation_reason: String
   description: String
@@ -377,8 +383,8 @@ type entity_functions
 # unaffected — the description overlay below is the one every entity view
 # applies, and catalog.annotations still stores the curated text.
 "Logical-model residual source-defined types as raw SDL (entity storage)"
-type entity_types
-  @view(name: "entity_types", sql: """
+type types
+  @view(name: "types", sql: """
     SELECT t.name, t.kind, t.data_source, t.module, t.definition,
       COALESCE(a.description, t.description) AS description,
       a.long_description
@@ -387,7 +393,8 @@ type entity_types
         ON m.data_source = t.data_source AND m.loaded AND NOT m.disabled AND NOT m.suspended
       LEFT JOIN [catalog.annotations] a
         ON a.entity_kind = 'type' AND a.entity_key = t.name
-  """) {
+  """)
+  @module(name: "catalog") {
   name: String! @pk
   kind: String!
   data_source: String!
@@ -399,13 +406,13 @@ type entity_types
 
 """
   Stored catalog state — EVERY source that has a stored schema, including the
-  suspended and disabled ones (entity_data_sources shows only the active half).
+  suspended and disabled ones (active_sources shows only the active half).
   Rows are what a source costs; the three flags are what it shows. loaded_at is
   stamped only by a real write, so an unchanged value across an unload/load
   cycle is the proof that nothing was rewritten.
 """
-type entity_catalogs
-  @view(name: "entity_catalogs", sql: """
+type stored_catalogs
+  @view(name: "stored_catalogs", sql: """
     SELECT m.data_source AS name, m.version, m.engine,
       COALESCE(ds.type, m.engine) AS type,
       COALESCE(NULLIF(m.prefix, ''), ds.prefix) AS prefix,
@@ -417,7 +424,8 @@ type entity_catalogs
       LEFT JOIN [data_sources] ds ON ds.name = m.data_source
       LEFT JOIN [catalog.annotations] a
         ON a.entity_kind = 'data_source' AND a.entity_key = m.data_source
-  """) {
+  """)
+  @module(name: "catalog") {
   "The data source name (@catalog name)"
   name: String! @pk
   "Stored content version — the gate a load compares against"
@@ -441,26 +449,27 @@ type entity_catalogs
 }
 
 "Declared @dependency edges between stored catalogs (entity storage)"
-type entity_catalog_dependencies
-  @view(name: "entity_catalog_dependencies", sql: """
+type catalog_dependencies
+  @view(name: "catalog_dependencies", sql: """
     SELECT d.data_source AS catalog, d.depends_on
     FROM [catalog.data_source_dependencies] d
   """)
+  @module(name: "catalog")
   @references(
-    name: "entity_catalog_dep_catalog"
+    name: "catalog_dep_catalog"
     source_fields: ["catalog"]
     references_fields: ["name"]
-    references_name: "entity_catalogs"
+    references_name: "stored_catalogs"
     query: "catalog_info"
     description: "The dependent catalog"
     references_query: "dependencies"
     references_description: "Catalogs this catalog depends on"
   )
   @references(
-    name: "entity_catalog_dep_depends_on"
+    name: "catalog_dep_depends_on"
     source_fields: ["depends_on"]
     references_fields: ["name"]
-    references_name: "entity_catalogs"
+    references_name: "stored_catalogs"
     query: "depends_on_info"
     description: "The dependency catalog"
     references_query: "dependents"
@@ -471,8 +480,8 @@ type entity_catalog_dependencies
 }
 
 "Logical-model data sources (active runtime state; config joined when present)"
-type entity_data_sources
-  @view(name: "entity_data_sources", sql: """
+type active_sources
+  @view(name: "active_sources", sql: """
     SELECT m.data_source AS name, m.engine,
       COALESCE(ds.type, m.engine) AS type,
       COALESCE(NULLIF(m.prefix, ''), ds.prefix) AS prefix,
@@ -488,6 +497,7 @@ type entity_data_sources
         ON a.entity_kind = 'data_source' AND a.entity_key = m.data_source
     WHERE m.loaded AND NOT m.disabled AND NOT m.suspended
   """)
+  @module(name: "catalog")
   {{ if .EmbeddingsEnabled }}@embeddings(model: "_system_embedder", vector: "vec", distance: Cosine){{ end }} {
   "The data source name (@catalog name)"
   name: String! @pk
@@ -506,12 +516,13 @@ type entity_data_sources
 }
 
 "Curation overlay incl. orphans and vec-only seed rows (entity storage)"
-type entity_annotations
-  @view(name: "entity_annotations", sql: """
+type annotations
+  @view(name: "annotations", sql: """
     SELECT a.entity_kind, a.entity_key, a.parent,
       a.description, a.long_description, a.vec, a.updated_at, a.updated_by
     FROM [catalog.annotations] a
   """)
+  @module(name: "catalog")
   {{ if .EmbeddingsEnabled }}@embeddings(model: "_system_embedder", vector: "vec", distance: Cosine){{ end }} {
   entity_kind: String! @pk
   entity_key: String! @pk

--- a/pkg/data-sources/sources/runtime/data-sources/catalog_schema.graphql
+++ b/pkg/data-sources/sources/runtime/data-sources/catalog_schema.graphql
@@ -71,7 +71,7 @@ extend type MutationFunction {
   """
     Curate a function description (module is the function's module, '' for none).
     kind selects the root namespace the curated operation lives in — "function",
-    "mutation" or "subscription", exactly the value core.catalog.entity_functions
+    "mutation" or "subscription", exactly the value core.catalog.functions
     and _catalog report; the same name in another namespace keeps its own
     description.
   """

--- a/pkg/metadata/search_rank.go
+++ b/pkg/metadata/search_rank.go
@@ -63,7 +63,7 @@ type candidate struct {
 // entityView describes one kind's ranking query against the catalog views
 // (core.catalog.*), which are the SQL half of the logical model.
 type entityView struct {
-	alias     string   // the view's field name under `core`
+	alias     string   // the view's field name under `core.catalog`
 	selection []string // columns to read besides the ranking expression
 	// nameCols are the text columns the lexical prefilter searches.
 	nameCols []string
@@ -264,8 +264,7 @@ func rankByVector(ctx context.Context, q Querier, req searchRequest, limit int) 
 	}
 
 	batch := map[string][]entityRow{}
-	gql := "query(" + sig + ") { core { catalog {\n" + body.String() + "} } }"
-	if err := scanAdmin(ctx, q, gql, vars, "core.catalog", &batch); err != nil {
+	if err := scanCatalogBatch(ctx, q, sig, body.String(), vars, &batch); err != nil {
 		return nil, err
 	}
 	return collectCandidates(ordered, batch, matchMeaning, func(row entityRow) float64 {
@@ -423,8 +422,7 @@ func rankBySubstring(ctx context.Context, q Querier, req searchRequest, limit in
 	}
 
 	batch := map[string][]entityRow{}
-	gql := "query(" + strings.Join(sig, ", ") + ") { core { catalog {\n" + body.String() + "} } }"
-	if err := scanAdmin(ctx, q, gql, vars, "core.catalog", &batch); err != nil {
+	if err := scanCatalogBatch(ctx, q, strings.Join(sig, ", "), body.String(), vars, &batch); err != nil {
 		return nil, err
 	}
 
@@ -573,6 +571,16 @@ func lexicalScore(terms []string, name, description string) float64 {
 // windows of their own.
 func likePattern(term string) string {
 	return "%" + term + "%"
+}
+
+// scanCatalogBatch is the ONE place the views' address lives: the GraphQL
+// wrapper and the scan path move together or not at all. The previous move of
+// these views had to chase the mount through every literal, and a missed one
+// degrades into the lexical fallback that is indistinguishable from a missing
+// embedder.
+func scanCatalogBatch(ctx context.Context, q Querier, sig, body string, vars map[string]any, target any) error {
+	gql := "query(" + sig + ") { core { catalog {\n" + body + "} } }"
+	return scanAdmin(ctx, q, gql, vars, "core.catalog", target)
 }
 
 // scanAdmin runs a catalog query with FULL ACCESS and scans it. This is the

--- a/pkg/metadata/search_rank.go
+++ b/pkg/metadata/search_rank.go
@@ -17,7 +17,7 @@ import (
 // Ranking is the half of _search that reads the INDEX, and it is the only half
 // that reads privileged.
 //
-// The index lives in the core.entity_* views, which carry no row-level
+// The index lives in the core.catalog.* views, which carry no row-level
 // permission filtering by design (they are an administrative surface — see the
 // access note in runtime/core-db/schema_catalog_tmpl.graphql). A role may hold
 // no rights on them at all; operators routinely hide the catalog from end-user
@@ -36,7 +36,7 @@ import (
 
 // candidate is one unverified ranking result: an identity plus a score. It
 // carries only what the INDEX knows — a field's module, for instance, is not
-// in entity_fields (a field belongs to whatever module owns its object) and is
+// in core.catalog.fields (a field belongs to whatever module owns its object) and is
 // filled in later, from the owner.
 type candidate struct {
 	kind        string
@@ -60,7 +60,8 @@ type candidate struct {
 	refObject string
 }
 
-// entityView describes one kind's ranking query against the entity views.
+// entityView describes one kind's ranking query against the catalog views
+// (core.catalog.*), which are the SQL half of the logical model.
 type entityView struct {
 	alias     string   // the view's field name under `core`
 	selection []string // columns to read besides the ranking expression
@@ -69,14 +70,14 @@ type entityView struct {
 }
 
 var entityViews = map[string]entityView{
-	searchKindModule:     {"entity_modules", []string{"name", "description"}, []string{"name", "description"}},
-	searchKindDataSource: {"entity_data_sources", []string{"name", "description"}, []string{"name", "description"}},
-	searchKindDataObject: {"entity_data_objects", []string{"name", "module", "data_source", "description"}, []string{"name", "description"}},
-	searchKindFunction:   {"entity_functions", []string{"name", "module", "data_source", "description"}, []string{"name", "description"}},
+	searchKindModule:     {"modules", []string{"name", "description"}, []string{"name", "description"}},
+	searchKindDataSource: {"active_sources", []string{"name", "description"}, []string{"name", "description"}},
+	searchKindDataObject: {"data_objects", []string{"name", "module", "data_source", "description"}, []string{"name", "description"}},
+	searchKindFunction:   {"functions", []string{"name", "module", "data_source", "description"}, []string{"name", "description"}},
 	// Fields read their stored PROPERTIES too: those say what the field is
 	// (see fieldRole), so a hit needs neither the rebuilt definition nor a
 	// relations query to be classified.
-	searchKindField: {"entity_fields",
+	searchKindField: {"fields",
 		[]string{"type_name", "name", "field_type", "data_source", "description", fieldPropsSelection},
 		[]string{"name", "description"}},
 }
@@ -263,8 +264,8 @@ func rankByVector(ctx context.Context, q Querier, req searchRequest, limit int) 
 	}
 
 	batch := map[string][]entityRow{}
-	gql := "query(" + sig + ") { core {\n" + body.String() + "} }"
-	if err := scanAdmin(ctx, q, gql, vars, "core", &batch); err != nil {
+	gql := "query(" + sig + ") { core { catalog {\n" + body.String() + "} } }"
+	if err := scanAdmin(ctx, q, gql, vars, "core.catalog", &batch); err != nil {
 		return nil, err
 	}
 	return collectCandidates(ordered, batch, matchMeaning, func(row entityRow) float64 {
@@ -284,7 +285,7 @@ func rankByVector(ctx context.Context, q Querier, req searchRequest, limit int) 
 // Doing the narrowing in the view rather than by walking the module tree is
 // what lets this path reach FIELDS. A structural walk has no enumeration of
 // fields that is not per object, which is why MCP's fallback dropped field
-// hits entirely; entity_fields is one table.
+// hits entirely; core.catalog.fields is one table.
 func rankLexically(ctx context.Context, q Querier, req searchRequest, limit int) ([]candidate, error) {
 	return rankBySubstring(ctx, q, req, limit, substringTrack{
 		matchedOn:     matchMeaning,
@@ -422,8 +423,8 @@ func rankBySubstring(ctx context.Context, q Querier, req searchRequest, limit in
 	}
 
 	batch := map[string][]entityRow{}
-	gql := "query(" + strings.Join(sig, ", ") + ") { core {\n" + body.String() + "} }"
-	if err := scanAdmin(ctx, q, gql, vars, "core", &batch); err != nil {
+	gql := "query(" + strings.Join(sig, ", ") + ") { core { catalog {\n" + body.String() + "} } }"
+	if err := scanAdmin(ctx, q, gql, vars, "core.catalog", &batch); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The logical-model views sat in module `core` as `core.entity_modules`, `core.entity_data_objects` and so on. The prefix was a disambiguator against the compiled-schema views that used to occupy those names — and those were removed with the storage that filled them, so it now names nothing.

They move into a `catalog` module (`@module(name: "catalog")` on each view, composing with the source's AsModule name) and lose the prefix:

| before | after |
|---|---|
| `core.entity_modules` | `core.catalog.modules` |
| `core.entity_module_data_sources` | `core.catalog.module_data_sources` |
| `core.entity_data_objects` | `core.catalog.data_objects` |
| `core.entity_fields` | `core.catalog.fields` |
| `core.entity_relations` | `core.catalog.relations` |
| `core.entity_functions` | `core.catalog.functions` |
| `core.entity_types` | `core.catalog.types` |
| `core.entity_catalog_dependencies` | `core.catalog.catalog_dependencies` |
| `core.entity_annotations` | `core.catalog.annotations` |
| `core.entity_data_sources` | `core.catalog.active_sources` |
| `core.entity_catalogs` | `core.catalog.stored_catalogs` |

The last two could not simply lose the prefix: a type name carries the SOURCE prefix and not the module, so `core.catalog.data_sources` and `core.catalog.catalogs` would both have compiled to a type name the core-db source already defines (`core_data_sources`, the registry; `core_catalogs`, the m2m junction). Named for what they are instead — the active sources, and every source with a stored schema including the suspended and disabled ones.

The property structs lose the prefix too (`entity_field_properties` → `field_properties` and so on); they are field types, so they take no module. `entity_kind` and `entity_key` are NOT renamed — they are columns of `catalog.annotations` naming WHICH entity a row annotates, and that is still what they mean.

Two MCP-side tests pin the move: one fixes where the views live and what they are called (the test a rename has to walk past), the other reads `lexical_reason` and fails when it names a schema error rather than a missing embedder — the failure mode that made a silent view move look like "this deployment has no embedder", forever and everywhere.

Rebased onto main with #154: after the review fixes there, both substring tracks assemble their ranking query in one place (`rankBySubstring`), so the `core.catalog` addressing lands on the NAME track and the lexical fallback by construction — the cross-branch breakage the #154 review flagged cannot occur.

Verified: full `go test ./...` (38 packages, live embedder for the vector search tests), e2e 245/0, e2e-hugrapp 39/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)